### PR TITLE
Using "absolute imports" instead of "aliases"

### DIFF
--- a/src/components/EggheadPlayer/use-egghead-player.ts
+++ b/src/components/EggheadPlayer/use-egghead-player.ts
@@ -1,9 +1,9 @@
-import cookies from '@utils/cookies'
-import {track} from '@utils/analytics'
-import getAccessTokenFromCookie from '@utils/getAccessTokenFromCookie'
+import cookies from 'utils/cookies'
+import {track} from 'utils/analytics'
+import getAccessTokenFromCookie from 'utils/getAccessTokenFromCookie'
 import axios from 'axios'
 import {isEmpty, pickBy, identity, get} from 'lodash'
-import {LessonResource} from '@types'
+import {LessonResource} from 'types'
 
 const getOptions = () =>
   getAccessTokenFromCookie()

--- a/src/components/mdx/course.tsx
+++ b/src/components/mdx/course.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr'
-import {loadCourse} from '@lib/courses'
+import {loadCourse} from 'lib/courses'
 import Link from 'next/link'
 import {FunctionComponent} from 'react'
 

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -7,7 +7,7 @@ import {Configure, Pagination, InstantSearch} from 'react-instantsearch-dom'
 import {get, isEqual} from 'lodash'
 import {useToggle} from 'react-use'
 
-import config from '@lib/config'
+import config from 'lib/config'
 
 import SearchReact from './react.mdx'
 

--- a/src/components/search/refinement-list.tsx
+++ b/src/components/search/refinement-list.tsx
@@ -1,6 +1,6 @@
 import React, {FunctionComponent} from 'react'
 import {Highlight, connectRefinementList} from 'react-instantsearch-dom'
-import nameToSlug from '@lib/name-to-slug'
+import nameToSlug from 'lib/name-to-slug'
 
 import useSwr from 'swr'
 

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -1,4 +1,4 @@
-import {LessonResource} from '@types'
+import {LessonResource} from 'types'
 import {request} from 'graphql-request'
 import config from './config'
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,13 @@
 import NextApp from 'next/app'
 import {CacheProvider} from '@emotion/core'
 import {MDXProvider} from '@mdx-js/react'
-import {ViewerProvider} from '@context/viewer-context'
+import {ViewerProvider} from 'context/viewer-context'
 import {DefaultSeo, SocialProfileJsonLd} from 'next-seo'
 import {cache} from 'emotion' // Use only { cache } from 'emotion'. Don't use { css }.
-import AppLayout from '@components/app/Layout'
-import mdxComponents from '@components/mdx'
-import defaultSeoConfig from 'src/next-seo.json'
-import {useURL} from '@hooks/useUrl'
+import AppLayout from 'components/app/Layout'
+import mdxComponents from 'components/mdx'
+import defaultSeoConfig from 'next-seo.json'
+import {useURL} from 'hooks/useUrl'
 import '../styles/index.css'
 import Router from 'next/router'
 

--- a/src/pages/collections/[slug].tsx
+++ b/src/pages/collections/[slug].tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import Markdown from 'react-markdown'
 import useSWR from 'swr'
-import {loadCollection} from '@lib/collections'
+import {loadCollection} from 'lib/collections'
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'
 

--- a/src/pages/courses/[slug].tsx
+++ b/src/pages/courses/[slug].tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import Markdown from 'react-markdown'
 import useSWR from 'swr'
-import {loadCourse} from '@lib/courses'
+import {loadCourse} from 'lib/courses'
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'
 

--- a/src/pages/instructors/[slug].tsx
+++ b/src/pages/instructors/[slug].tsx
@@ -1,4 +1,4 @@
-import {loadInstructor} from '@lib/instructors'
+import {loadInstructor} from 'lib/instructors'
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'
 

--- a/src/pages/instructors/index.tsx
+++ b/src/pages/instructors/index.tsx
@@ -1,4 +1,4 @@
-import {loadInstructors} from '@lib/instructors'
+import {loadInstructors} from 'lib/instructors'
 import Link from 'next/link'
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'

--- a/src/pages/learn/[slug].tsx
+++ b/src/pages/learn/[slug].tsx
@@ -1,6 +1,6 @@
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'
-import {getTag} from '@lib/tags'
+import {getTag} from 'lib/tags'
 import Markdown from 'react-markdown'
 
 type TagProps = {

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -1,4 +1,4 @@
-import {getTags} from '@lib/tags'
+import {getTags} from 'lib/tags'
 import Link from 'next/link'
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -1,15 +1,15 @@
 import React, {FunctionComponent} from 'react'
 import Link from 'next/link'
 import {useRouter} from 'next/router'
-import EggheadPlayer from '@components/EggheadPlayer'
+import EggheadPlayer from 'components/EggheadPlayer'
 import get from 'lodash/get'
 import Markdown from 'react-markdown'
 import useSWR from 'swr'
-import {loadLesson} from '@lib/lessons'
+import {loadLesson} from 'lib/lessons'
 import {GraphQLClient} from 'graphql-request'
-import {useViewer} from '@context/viewer-context'
+import {useViewer} from 'context/viewer-context'
 import {GetServerSideProps} from 'next'
-import {LessonResource} from '@types'
+import {LessonResource} from 'types'
 
 const API_ENDPOINT = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/graphql`
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import * as yup from 'yup'
 import {Formik} from 'formik'
-import {useViewer} from '@context/viewer-context'
+import {useViewer} from 'context/viewer-context'
 
 const loginSchema = yup.object().shape({
   email: yup.string().email().required('enter your email'),

--- a/src/pages/podcasts/[slug].tsx
+++ b/src/pages/podcasts/[slug].tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent} from 'react'
-import {loadPodcast} from '@lib/podcasts'
+import {loadPodcast} from 'lib/podcasts'
 import {GetServerSideProps} from 'next'
 
 type PodcastProps = {

--- a/src/pages/podcasts/index.tsx
+++ b/src/pages/podcasts/index.tsx
@@ -1,6 +1,6 @@
 import {FunctionComponent} from 'react'
 import {GetServerSideProps} from 'next'
-import {loadPodcasts} from '@lib/podcasts'
+import {loadPodcasts} from 'lib/podcasts'
 import Link from 'next/link'
 
 type PodcastProps = {

--- a/src/pages/s/[[...all]].tsx
+++ b/src/pages/s/[[...all]].tsx
@@ -2,12 +2,12 @@ import React, {FunctionComponent} from 'react'
 import {useRouter} from 'next/router'
 import {findResultsState} from 'react-instantsearch-dom/server'
 import algoliasearchLite from 'algoliasearch/lite'
-import Search from '@components/search'
+import Search from 'components/search'
 import {NextSeo} from 'next-seo'
 import {GetServerSideProps} from 'next'
 
 import qs from 'qs'
-import {createUrl, parseUrl, titleFromPath} from '@lib/search-url-builder'
+import {createUrl, parseUrl, titleFromPath} from 'lib/search-url-builder'
 import {isEmpty, get} from 'lodash'
 
 const createURL = (state: any) => `?${qs.stringify(state)}`

--- a/src/pages/talks/[slug].tsx
+++ b/src/pages/talks/[slug].tsx
@@ -1,13 +1,13 @@
 import React, {FunctionComponent} from 'react'
 import Link from 'next/link'
 import {useRouter} from 'next/router'
-import EggheadPlayer from '@components/EggheadPlayer'
+import EggheadPlayer from 'components/EggheadPlayer'
 import get from 'lodash/get'
 import Markdown from 'react-markdown'
 import useSWR from 'swr'
-import {loadLesson} from '@lib/lessons'
+import {loadLesson} from 'lib/lessons'
 import {GraphQLClient} from 'graphql-request'
-import {useViewer} from '@context/viewer-context'
+import {useViewer} from 'context/viewer-context'
 import {GetServerSideProps} from 'next'
 
 const API_ENDPOINT = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/graphql`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,16 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "baseUrl": "./",
-    "paths": {
-      "@components/*": ["src/components/*"],
-      "@utils/*": ["src/utils/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@context/*": ["src/context/*"],
-      "@lib/*": ["src/lib/*"],
-      "@content/*": ["content/*"],
-      "@types": ["src/types.ts"]
-    }
+    "baseUrl": "./src/"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Next.js 9.4 added support for absolute imports based on the `baseUrl`:

https://nextjs.org/blog/next-9-4#absolute-imports-and-aliases
https://nextjs.org/docs/advanced-features/module-path-aliases

This removes the need for `@` paths on every directory.