### PR TITLE
Adding a "CommandBar" to issue dev commands

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ const readingTime = require('reading-time')
 
 checkEnv({
   required: ['NEXT_PUBLIC_DEPLOYMENT_URL'],
+  unsafe: ['NEXT_PUBLIC_DEVTOOLS'],
 })
 
 const useURL = (path) =>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:tools": "NEXT_PUBLIC_DEVTOOLS=true next dev",
     "build": "next build",
     "build:style": "tailwind build src/styles/index.css -o src/styles/output.css",
     "start": "next start",

--- a/src/components/app/CommandBar.tsx
+++ b/src/components/app/CommandBar.tsx
@@ -1,0 +1,12 @@
+import {FunctionComponent} from 'react'
+
+const CommandBar: FunctionComponent = () => {
+  return (
+    <div className="mt-8 w-full flex items-center justify-between">
+      {/* TODO: Map commands */}
+      <input type="text" placeholder="Enter a dev command" />
+    </div>
+  )
+}
+
+export default CommandBar

--- a/src/components/app/Layout.tsx
+++ b/src/components/app/Layout.tsx
@@ -1,12 +1,19 @@
 import {FunctionComponent} from 'react'
+import dynamic from 'next/dynamic'
 import Header from './Header'
 import Footer from './Footer'
 import Main from './Main'
 
+let CommandBar: FunctionComponent = () => <></>
+
+if (process.env.NODE_ENV == 'development' && process.env.NEXT_PUBLIC_DEVTOOLS) {
+  CommandBar = dynamic(() => import('./CommandBar')) as FunctionComponent
+}
 const Layout: FunctionComponent = ({children}) => {
   return (
     <>
       <Header></Header>
+      <CommandBar></CommandBar>
       <Main>{children}</Main>
       <Footer></Footer>
     </>


### PR DESCRIPTION
![](https://media1.giphy.com/media/3o6MbcWWytRrtLwzbW/giphy.gif)

Running `yarn dev:tools` dynamically places an app-wide input box. 

TODO: Map commands that the input box can invoke to control the app.


<img width="150" alt="Screen Shot 2020-09-09 at 9 10 55 AM" src="https://user-images.githubusercontent.com/36073/92617317-65711e00-f27c-11ea-8ff2-bcef67a83287.png">
