### PR TITLE
Handling search url with instructor, but no tags

### DIFF
--- a/src/lib/__tests__/search-url-builder.test.ts
+++ b/src/lib/__tests__/search-url-builder.test.ts
@@ -123,6 +123,16 @@ test('parses a url tag and instructor', () => {
   })
 })
 
+test('parses a url with only instructor', () => {
+  const searchParams = parseUrl({
+    all: ['lessons-by-kent-c-dodds'],
+  })
+
+  expect(searchParams).toEqual({
+    refinementList: {_tags: [], instructor_name: ['Kent C. Dodds']},
+  })
+})
+
 test('parses a url from tag', () => {
   const searchParams = parseUrl({
     all: ['react'],
@@ -192,6 +202,7 @@ test('parse a url with just the query string', () => {
 
   expect(searchParams).toEqual({
     refinementList: {
+      _tags: [],
       type: ['playlist', 'course'],
     },
   })

--- a/src/lib/search-url-builder.ts
+++ b/src/lib/search-url-builder.ts
@@ -4,7 +4,7 @@ import get from 'lodash/get'
 import qs from 'query-string'
 import nameToSlug from './name-to-slug'
 import humanize from 'humanize-list'
-import {first, pickBy, isEmpty} from 'lodash'
+import {first, pickBy, isEmpty, isUndefined} from 'lodash'
 
 const resourceTypes = {
   resource: 'resources',
@@ -31,11 +31,12 @@ const toTitleCase = (name: string) => {
 }
 
 const tagsForPath = (path: string) => {
-  const tagsSplit = path?.split('-lessons-by-') || []
+  const [tagsString] = path?.split('-lessons-by-') ?? []
 
-  const tags = tagsSplit.length >= 1 ? tagsSplit[0].split('-and-').sort() : []
+  if (isUndefined(tagsString)) return []
+  if (tagsString.startsWith('lessons-by')) return []
 
-  return isEmpty(tags) ? undefined : tags
+  return tagsString.split('-and-').sort()
 }
 
 export const titleFromPath = (all: string[] = []) => {


### PR DESCRIPTION
![](https://media2.giphy.com/media/xGdvlOVSWaDvi/giphy.gif)

`tagsForPath` was incorrectly parsing "lessons-by" as a tag.

Added a test for "only instructor, no tag" and implemented.