### PR TITLE
Add redirects for /api and /graphql

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -96,6 +96,16 @@ const nextConfig = {
         destination: 'https://app.egghead.io/playlists/:id/playlist_feed',
         permanent: true,
       },
+      {
+        source: '/api/:all*',
+        destination: 'https://app.egghead.io/api/:all*',
+        permanent: true,
+      },
+      {
+        source: '/graphql',
+        destination: 'https://app.egghead.io/graphql',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
Ideally we will update any code referencing the API to look at
`app.egghead.io` instead of `egghead.io`. These two redirects will serve
as a useful backup for anything that gets missed.