### PR TITLE
Redirect all gifts path traffic to app-dot

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/gifts/:all*',
+        destination: 'https://app.egghead.io/gifts/:all*',
+        permanent: true,
+      },
+      {
         source: '/feed',
         destination: 'https://app.egghead.io/feed',
         permanent: true,


### PR DESCRIPTION
The gifts feature will continue to be solely serviced by the Rails app.