### PR TITLE
Prevent redirect from wiping out courses pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -49,8 +49,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/courses/:title/:all*',
-        destination: 'https://app.egghead.io/courses/:title/:all*',
+        source: '/courses/:title/:rest(.+)',
+        destination: 'https://app.egghead.io/courses/:title/:rest',
         permanent: true,
       },
       {


### PR DESCRIPTION
The wildcard redirect for `/courses/:title/:all*` was globbing in URLs
like /courses/some-course-title when that should be served directly from
the Next.js pages directory. Using `.+` regex syntax ensures that the
redirect rule only matches for courses routes that have additional URL
structure after the title.

Addresses #171

With this PR:

- `/courses/some-course-title` should resolve as a 200 request to next.egghead.io
- `/courses/some-course-title/edit` should resolve as a 308 redirect to app.egghead.io