### PR TITLE
Handle access token cookie for shared auth

### DIFF
--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -83,17 +83,11 @@ function useAuthedViewer() {
     }
 
     const loadViewerFromToken = async () => {
-      await auth
-        .handleCookieBasedAccessTokenAuthentication(authToken)
-        .then((refreshedViewer: any) => {
-          setViewer(refreshedViewer)
-          setLoading(() => false)
-        })
-        .catch((error) => {
-          // if it is a 403, clear out the token and then call auth.monitor?
-          // auth does a logout on any error currently -jh
-          console.log('Catching this error: ', error.message)
-        })
+      const viewer: any = await auth.handleCookieBasedAccessTokenAuthentication(
+        authToken,
+      )
+      setViewer(viewer)
+      setLoading(() => false)
     }
 
     if (authToken) {

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -126,7 +126,7 @@ function useAuthedViewer() {
         auth.logout()
         logoutCallback()
       },
-      setSession: (session: any) => auth.setSession(session),
+      setSession: auth.setSession,
       isAuthenticated: () => auth.isAuthenticated(),
       authToken: auth.getAuthToken(),
       requestSignInEmail: (email: any) => auth.requestSignInEmail(email),

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -83,8 +83,12 @@ function useAuthedViewer() {
     }
 
     if (authToken) {
+      const sixtyDaysInSeconds = JSON.stringify(60 * 24 * 60 * 60)
       auth
-        .refreshUser()
+        .handleCookieBasedAccessTokenAuthentication(
+          authToken,
+          sixtyDaysInSeconds,
+        )
         .then((refreshedViewer: any) => {
           setViewer(refreshedViewer)
           console.log(`refresh user from cookie auth token`)

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -23,6 +23,8 @@ export function getTokenFromCookieHeaders(serverCookies = '') {
   return {eggheadToken, loginRequired: eggheadToken.length <= 0}
 }
 
+const SIXTY_DAYS_IN_SECONDS = JSON.stringify(60 * 24 * 60 * 60)
+
 export default class Auth {
   eggheadAuth: OAuthClient
 
@@ -109,7 +111,7 @@ export default class Auth {
 
   handleCookieBasedAccessTokenAuthentication(
     accessToken: string,
-    expiresInSeconds: string,
+    expiresInSeconds: string = SIXTY_DAYS_IN_SECONDS,
   ) {
     // handle any previous location redirects here
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -235,11 +235,11 @@ export default class Auth {
     })
   }
 
-  getAuthToken(force = false) {
+  getAuthToken() {
     if (typeof localStorage === 'undefined') {
       return
     }
-    if (force || this.isAuthenticated()) {
+    if (this.isAuthenticated()) {
       return cookie.get(ACCESS_TOKEN_KEY)
     }
   }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -215,11 +215,11 @@ export default class Auth {
     })
   }
 
-  getAuthToken() {
+  getAuthToken(force = false) {
     if (typeof localStorage === 'undefined') {
       return
     }
-    if (this.isAuthenticated()) {
+    if (force || this.isAuthenticated()) {
       return cookie.get(ACCESS_TOKEN_KEY)
     }
   }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -193,20 +193,19 @@ export default class Auth {
       if (typeof localStorage === 'undefined') {
         reject('localStorage is not defined')
       }
-      const expires: unknown = authResult.data.expires_in
-      const expiresAt = JSON.stringify(
-        (expires as number) * 1000 + new Date().getTime(),
-      )
+      const expiresInSeconds: number = Number(authResult.data.expires_in)
       const now: number = new Date().getTime()
 
-      const expiresInDays = Math.floor(
-        (Number(expiresAt) - now) / (60 * 60 * 24 * 1000),
-      )
+      const millisecondsInASecond = 1000
+      const expiresAt = expiresInSeconds * millisecondsInASecond + now
+
+      const millisecondsInADay = 60 * 60 * 24 * 1000
+      const expiresInDays = Math.floor((expiresAt - now) / millisecondsInADay)
 
       console.log(expiresInDays)
 
       localStorage.setItem(ACCESS_TOKEN_KEY, authResult.accessToken)
-      localStorage.setItem(EXPIRES_AT_KEY, expiresAt)
+      localStorage.setItem(EXPIRES_AT_KEY, JSON.stringify(expiresAt))
       cookie.set(ACCESS_TOKEN_KEY, authResult.accessToken, {
         expires: expiresInDays,
         domain: process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN,


### PR DESCRIPTION
This PR is the companion of the authentication changes introduced server-side in the Rails app. It allows a user who has already authenticated through egghead-rails to be automatically signed in to egghead-next.

The way this works is:

1. egghead-rails adds a cookie with a fresh oauth access token when a user authenticates
2. egghead-next detects if there is an oauth access token available in a `.egghead.io` cookie
3. it calls `handleCookieBasedAccessTokenAuthentication` with the access token which in turn sets up the session and fetches fresh user data (in the same way as the standard auth flow)


![](https://media4.giphy.com/media/3ohzdYt5HYinIx13ji/200.gif?cid=5a38a5a25hkd8qd0yijx1zuj6u61x74jnzg6z7y0iw6r1nyb&rid=200.gif)
