### PR TITLE
optimize lesson page loading

### DIFF
--- a/src/components/pages/lessons/LessonInfo.tsx
+++ b/src/components/pages/lessons/LessonInfo.tsx
@@ -5,46 +5,45 @@ import {isEmpty, get} from 'lodash'
 import Markdown from 'react-markdown'
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard'
 import Eggo from '../../../components/images/eggo.svg'
-import {LessonResource} from 'types'
+import {useNextUpData} from 'hooks/use-next-up-data'
 
 type NextUpProps = {
   currentLessonSlug: string
-  data: {
-    list: {
-      lessons: LessonResource[]
-    }
-  }
+  url: string
 }
 
-const NextUp: FunctionComponent<NextUpProps> = ({data, currentLessonSlug}) => {
-  return data ? (
+const NextUp: FunctionComponent<NextUpProps> = ({url, currentLessonSlug}) => {
+  const {nextUpData} = useNextUpData(url)
+  return nextUpData ? (
     <ol>
       <span className="font-semibold">Lessons</span>
-      {data.list.lessons.map((lesson, index = 0) => {
-        return (
-          <li key={lesson.slug} className="py-2 pr-3">
-            <div className="flex">
-              <div className="flex items-center mr-2">
-                <div className="mr-1 text-xs text-cool-gray-400">
-                  {index + 1}
+      {nextUpData.list.lessons.map(
+        (lesson: {slug: any; title: any; path: any}, index = 0) => {
+          return (
+            <li key={lesson.slug} className="py-2 pr-3">
+              <div className="flex">
+                <div className="flex items-center mr-2">
+                  <div className="mr-1 text-xs text-cool-gray-400">
+                    {index + 1}
+                  </div>
+                  {/* <input type="checkbox" checked={lesson.completed} readOnly /> */}
                 </div>
-                {/* <input type="checkbox" checked={lesson.completed} readOnly /> */}
+                <div className="w-full leading-tight">
+                  {lesson.slug !== currentLessonSlug ? (
+                    <Link href={lesson.path}>
+                      <a className="font-semibold no-underline hover:underline text-blue-600">
+                        {lesson.title}
+                      </a>
+                    </Link>
+                  ) : (
+                    <div className="font-semibold">► {lesson.title}</div>
+                  )}
+                </div>
               </div>
-              <div className="w-full leading-tight">
-                {lesson.slug !== currentLessonSlug ? (
-                  <Link href={lesson.path}>
-                    <a className="font-semibold no-underline hover:underline text-blue-600">
-                      {lesson.title}
-                    </a>
-                  </Link>
-                ) : (
-                  <div className="font-semibold">► {lesson.title}</div>
-                )}
-              </div>
-            </div>
-          </li>
-        )
-      })}
+            </li>
+          )
+        },
+      )}
     </ol>
   ) : null
 }
@@ -161,6 +160,8 @@ type LessonInfoProps = {
     slug: string
   }
   [cssRelated: string]: any
+  nextUpUrl: string
+  playerState: any
 }
 
 const LessonInfo: FunctionComponent<LessonInfoProps> = ({
@@ -169,8 +170,9 @@ const LessonInfo: FunctionComponent<LessonInfoProps> = ({
   tags,
   summary,
   course,
-  nextUpData,
+  nextUpUrl,
   lesson,
+  playerState,
   ...restProps
 }) => {
   return (
@@ -318,9 +320,9 @@ const LessonInfo: FunctionComponent<LessonInfoProps> = ({
           </div>
         </div>
       </div>
-      {nextUpData && (
+      {!playerState.matches('loading') && nextUpUrl && (
         <div className="pt-6">
-          <NextUp data={nextUpData} currentLessonSlug={lesson.slug} />
+          <NextUp url={nextUpUrl} currentLessonSlug={lesson.slug} />
         </div>
       )}
     </div>

--- a/src/components/pages/lessons/overlay/next-up-overlay.tsx
+++ b/src/components/pages/lessons/overlay/next-up-overlay.tsx
@@ -1,0 +1,87 @@
+import {useNextUpData} from 'hooks/use-next-up-data'
+import Link from 'next/link'
+import * as React from 'react'
+
+const NextUpOverlay: React.FunctionComponent<{
+  lesson: any
+  send: any
+  url: string
+}> = ({lesson, send, url}) => {
+  const {nextLessonTitle, nextUpPath} = useNextUpData(url)
+  return (
+    <>
+      <img src={lesson.course.square_cover_480_url} alt="" className="w-32" />
+      <div className="mt-8">Up Next</div>
+      <h3 className="text-xl font-semibold mt-4">{nextLessonTitle}</h3>
+      <div className="flex mt-16">
+        <button
+          className="bg-gray-300 rounded p-2 flex items-center"
+          onClick={() => send('LOAD')}
+        >
+          <IconRefresh className="w-6 mr-3" /> Watch Again
+        </button>
+        <NextResourceButton
+          path={nextUpPath}
+          className="bg-gray-300 rounded p-2 flex items-center ml-4"
+        >
+          <IconPlay className="w-6 mr-3" /> Load the Next Video
+        </NextResourceButton>
+      </div>
+      <div className="mt-20">
+        Feeling stuck?{' '}
+        <a href="#" className="font-semibold">
+          Get help from egghead community
+        </a>
+      </div>
+    </>
+  )
+}
+
+export default NextUpOverlay
+
+const NextResourceButton: React.FunctionComponent<{
+  path: string
+  className: string
+}> = ({children, path, className = ''}) => {
+  return (
+    <Link href={path || '#'}>
+      <a className={className}>{children || 'Next Lesson'}</a>
+    </Link>
+  )
+}
+
+const IconPlay: React.FunctionComponent<{className: string}> = ({
+  className = '',
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    className={className}
+  >
+    <path
+      fillRule="evenodd"
+      d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
+      clipRule="evenodd"
+    />
+  </svg>
+)
+
+const IconRefresh: React.FunctionComponent<{className: string}> = ({
+  className = '',
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    className={className}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+    />
+  </svg>
+)

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -56,6 +56,15 @@ function useAuthedViewer() {
     const loadViewerFromStorage = async () => {
       console.log(`loading viewer from storage`)
 
+      const localViewer = auth.getLocalUser()
+
+      if (localViewer) {
+        if (!isEqual(localViewer.id, viewerId)) {
+          setViewer(localViewer)
+        }
+        setLoading(() => false)
+      }
+
       auth.refreshUser().then((newViewer: any) => {
         if (!isEqual(newViewer.id, viewerId)) {
           setViewer(newViewer)
@@ -85,6 +94,14 @@ function useAuthedViewer() {
     }
 
     const loadViewerFromToken = async () => {
+      const localViewer = auth.getLocalUser()
+
+      if (localViewer) {
+        if (!isEqual(localViewer.id, viewerId)) {
+          setViewer(localViewer)
+        }
+        setLoading(() => false)
+      }
       auth
         .handleCookieBasedAccessTokenAuthentication(authToken)
         .then((viewer: any) => {

--- a/src/hooks/use-next-up-data.tsx
+++ b/src/hooks/use-next-up-data.tsx
@@ -1,0 +1,10 @@
+import fetcher from 'utils/fetcher'
+import {get} from 'lodash'
+import useSWR from 'swr'
+
+export const useNextUpData = (url: string) => {
+  const {data: nextUpData} = useSWR(url, fetcher)
+  const nextUpPath = get(nextUpData, 'next_lesson')
+  const nextLessonTitle = get(nextUpData, 'next_lesson_title')
+  return {nextUpData, nextUpPath, nextLessonTitle, nextUpLoading: !nextUpData}
+}

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -203,7 +203,10 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
         }}
       />
       <Head>
-        <script src="//cdn.bitmovin.com/player/web/8/bitmovinplayer.js" />
+        <script
+          async
+          src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"
+        />
       </Head>
       <div key={lesson.slug} className="space-y-8 w-full">
         <div className="bg-black -mt-3 sm:-mt-5 -mx-5">

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -194,13 +194,13 @@ export default class Auth {
     return !expired
   }
 
-  refreshUser(loadFullUser = false) {
+  refreshUser(minimalUser = true) {
     return new Promise((resolve, reject) => {
       if (typeof localStorage === 'undefined') {
         reject('no local storage')
       }
       http
-        .get(`/api/users/current?minimal=${loadFullUser}`, {})
+        .get(`/api/users/current?minimal=${minimalUser}`, {})
         .then(({data}) => {
           localStorage.setItem(USER_KEY, JSON.stringify(data))
           resolve(data)

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,0 +1,2 @@
+const fetcher = (url: RequestInfo) => fetch(url).then((r) => r.json())
+export default fetcher


### PR DESCRIPTION
There is a noticeable "lag" when you load a video resource:

https://next.egghead.io/lessons/react-implement-a-custom-material-ui-theme-on-the-server-using-a-higher-order-component

![image](https://user-images.githubusercontent.com/86834/101288358-005d9380-37ab-11eb-8604-4c5b957bf63a.png)

There's a clear gap in the waterfall chart (chrome dev tools, network tab) and a kind of dead zone before everything kicks in.

The initial lesson data is loaded during SSR, and then we load the media urls async with auth. It also refreshes the "current viewer" in the background.

![dj at the records](https://media.giphy.com/media/SXlmEUowKDP8LX5f3l/giphy.gif)