### PR TITLE
Store cookie for referral when present in URL

### DIFF
--- a/src/hooks/use-affiliate-assigner.tsx
+++ b/src/hooks/use-affiliate-assigner.tsx
@@ -11,7 +11,7 @@ const http = axios.create()
 function useAffiliateAssigner(
   viewerId: string | null,
   authToken: string | null,
-): void {
+) {
   const {token, signed} = getAffiliateTokenFromCookie()
 
   React.useEffect(() => {

--- a/src/hooks/use-token-signer.tsx
+++ b/src/hooks/use-token-signer.tsx
@@ -41,6 +41,13 @@ function useTokenSigner(): void {
     router.query.af,
   )
 
+  const removeQueryFromUrl = (paramName: string) => {
+    const {[paramName]: _paramToRemove, ...updatedQuery} = router.query
+    router.push({pathname: router.pathname, query: updatedQuery}, undefined, {
+      shallow: true,
+    })
+  }
+
   React.useEffect(() => {
     const requestSignedReferralToken = async (referralToken: string) => {
       const existingReferralToken = cookie.get('rc')
@@ -59,7 +66,7 @@ function useTokenSigner(): void {
 
             createPermanentCookie('rc', newReferralToken)
 
-            // TODO: Remove `rc` from URL query params, similar to `af`.
+            removeQueryFromUrl('rc')
 
             return newReferralToken
           })
@@ -74,7 +81,7 @@ function useTokenSigner(): void {
     }
 
     return () => {}
-  }, [referralQueryParam])
+  }, [referralQueryParam, removeQueryFromUrl])
 
   React.useEffect(() => {
     const requestSignedAffiliateToken = async (affiliateToken: string) => {
@@ -98,15 +105,7 @@ function useTokenSigner(): void {
             // af cookies.
             createPermanentCookie(SIGNED_AFFILIATE_TOKEN_KEY, newAffiliateToken)
 
-            // remove `af` from the URL params
-            const {af, ...updatedQuery} = router.query
-            router.push(
-              {pathname: router.pathname, query: updatedQuery},
-              undefined,
-              {
-                shallow: true,
-              },
-            )
+            removeQueryFromUrl('af')
 
             return newAffiliateToken
           })
@@ -121,7 +120,7 @@ function useTokenSigner(): void {
     }
 
     return () => {}
-  }, [affiliateQueryParam, router])
+  }, [affiliateQueryParam, removeQueryFromUrl])
 }
 
 export default useTokenSigner

--- a/src/hooks/use-token-signer.tsx
+++ b/src/hooks/use-token-signer.tsx
@@ -79,8 +79,6 @@ function useTokenSigner(): void {
     if (!!referralQueryParam) {
       requestSignedReferralToken(referralQueryParam)
     }
-
-    return () => {}
   }, [referralQueryParam, removeQueryFromUrl])
 
   React.useEffect(() => {
@@ -118,8 +116,6 @@ function useTokenSigner(): void {
     if (!!affiliateQueryParam) {
       requestSignedAffiliateToken(affiliateQueryParam)
     }
-
-    return () => {}
   }, [affiliateQueryParam, removeQueryFromUrl])
 }
 


### PR DESCRIPTION
Grab the rc value out of the URL, request that egghead-rails sign the
value, and then add that value to a permanent cookie for a later
checkout session.


![](https://media4.giphy.com/media/mLzbcLQkufnRMFtDkf/giphy.gif?cid=5a38a5a2fjhi5t3r1tnax0g8bieed3u4y49ijv4u0c3yu1cn&rid=giphy.gif)
