### PR TITLE
Small design updates on the eCommerce with Stripe landing page

### DIFF
--- a/src/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/index.tsx
+++ b/src/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/index.tsx
@@ -63,7 +63,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
       {
         title: 'Bootstrap a Next.js Ecommerce App',
         image:
-          'https://dcv19h61vib2d.cloudfront.net/thumbs/next-js-create-a-new-react-application-with-the-next-js-create-next-app-cli-qtgBZ7pkE/next-js-create-a-new-react-application-with-the-next-js-create-next-app-cli-qtgBZ7pkE.jpg',
+          'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1608205688/next.egghead.io/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/ecommerce-stripe-icon-2.png',
         // body: `* Create a New React Application with Next.js\n* Add a Grid of Products with Images to a Next.js React App\n* Add and Configure Products in the Stripe Dashboard for an Online Store\n* Dynamically Manage a Grid of Products in an Online Store with a JSON Document\n* Host & Deploy a Next.js React app on Vercel`,
         lessons: [
           {
@@ -111,7 +111,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
       {
         title: 'Integrate Stripe Checkout into Next.js',
         image:
-          'https://dcv19h61vib2d.cloudfront.net/thumbs/egghead-add-and-configure-products-in-the-stripe-dashboard-for-an-online-store-ayqt2WDSr/egghead-add-and-configure-products-in-the-stripe-dashboard-for-an-online-store-ayqt2WDSr.jpg',
+          'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1608205688/next.egghead.io/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/ecommerce-stripe-icon-3.png',
         lessons: [
           {
             title:
@@ -142,7 +142,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
       {
         title: 'Manage Shopping Cart State',
         image:
-          'https://dcv19h61vib2d.cloudfront.net/thumbs/javascript-store-and-load-cart-state-from-local-storage-to-persist-cart-data-when-reloading-the-page-hToRGvLze/javascript-store-and-load-cart-state-from-local-storage-to-persist-cart-data-when-reloading-the-page-hToRGvLze.jpg',
+          'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1608205688/next.egghead.io/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/ecommerce-stripe-icon-1.png',
         lessons: [
           {
             title:
@@ -230,7 +230,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
       <div>
         <article className="">
           <header className="relative -mx-5 px-5">
-            <div className="absolute left-0 top-0 sm:-mt-5 -mt-3 h-3 w-full bg-gradient-to-r from-pink-500 via-purple-500 to-cyan-500" />
+            <div className="absolute left-0 top-0 sm:-mt-5 -mt-3 h-3 w-full bg-gradient-to-r from-pink-400 via-purple-500 to-cyan-500" />
             <div className="flex md:flex-row flex-col md:space-x-10 md:space-y-0 space-y-6 items-center md:pb-16 pb-8 md:pt-8 pt-4 max-w-screen-lg mx-auto">
               <div className="flex-shrink-0 mt-8">
                 <Image
@@ -259,10 +259,10 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
             />
             <div className="mt-20 bg-gray-50 -mx-5 pt-24 xl:px-0 px-5">
               <div className="max-w-screen-lg mx-auto">
-                <div className="mb-2 uppercase font-medium tracking-wide text-sm md:text-left text-center text-blue-600">
+                <div className="mb-4 uppercase font-medium tracking-wide text-sm md:text-left text-center text-blue-600">
                   What You’ll Build for Your Portfolio
                 </div>
-                <h2 className="sm:text-2xl text-2xl sm:text-left font-semibold text-center leading-tighter pb-16">
+                <h2 className="sm:text-2xl text-3xl sm:text-left font-semibold text-center leading-tighter pb-12">
                   How to build a start-to-finish dynamic Next.js app
                 </h2>
                 {course.resources.map((part, idx) => {
@@ -435,20 +435,20 @@ const Part: FunctionComponent<{
   }
   const Thumbnail = () => {
     return image ? (
-      <div className="rounded-sm overflow-hidden shadow-md flex">
+      <div className="overflow-hidden flex">
         <Image
           className="block"
           src={image}
           alt={title}
-          width={1280 / 4}
-          height={720 / 4}
+          width={202}
+          height={171}
         />
       </div>
     ) : null
   }
 
   return (
-    <div className="flex md:flex-row flex-col md:space-x-6">
+    <div className="flex md:flex-row flex-col md:space-x-6 mt-4">
       <div
         className={`space-y-2 flex flex-col md:items-end items-center py-1 ${gap}`}
       >
@@ -475,7 +475,7 @@ const Part: FunctionComponent<{
         )} */}
       </div>
       <div className={`md:w-full ${gap}`}>
-        <h3 className="text-lg font-bold relative transform -translate-y-1">
+        <h3 className="text-lg font-bold relative transform -translate-y-1 pb-1">
           {title}
         </h3>
         {body && <Markdown className="prose" source={body} />}

--- a/src/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/index.tsx
+++ b/src/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/index.tsx
@@ -230,14 +230,14 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
       <div>
         <article className="">
           <header className="relative -mx-5 px-5">
-            <div className="absolute left-0 top-0 sm:-mt-5 -mt-3 h-1 w-full bg-gradient-to-r from-pink-500 via-purple-500 to-teal-500" />
+            <div className="absolute left-0 top-0 sm:-mt-5 -mt-3 h-3 w-full bg-gradient-to-r from-pink-500 via-purple-500 to-cyan-500" />
             <div className="flex md:flex-row flex-col md:space-x-10 md:space-y-0 space-y-6 items-center md:pb-16 pb-8 md:pt-8 pt-4 max-w-screen-lg mx-auto">
-              <div className="flex-shrink-0">
+              <div className="flex-shrink-0 mt-8">
                 <Image
                   src={course.image}
                   alt={course.title}
-                  width={256}
-                  height={256}
+                  width={288}
+                  height={288}
                   quality={100}
                 />
               </div>
@@ -245,7 +245,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
                 <div className="uppercase font-medium tracking-wide text-xs md:text-left text-center text-pink-600">
                   Portfolio Project
                 </div>
-                <h1 className="md:text-3xl text-3xl md:text-left text-center font-bold tracking-tight leading-tighter pb-6">
+                <h1 className="md:text-3xl text-3xl md:text-left text-center font-bold tracking-tight leading-snug pb-6 max-w-screen-sm">
                   {course.title}
                 </h1>
                 <Tags tags={course.tags} />
@@ -254,7 +254,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
           </header>
           <main>
             <Markdown
-              className="prose prose-lg md:prose-xl max-w-screen-lg mx-auto"
+              className="prose prose-lg md:prose-xl max-w-screen-md mx-auto"
               source={course.summary}
             />
             <div className="mt-20 bg-gray-50 -mx-5 pt-24 xl:px-0 px-5">

--- a/src/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/index.tsx
+++ b/src/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/index.tsx
@@ -271,8 +271,8 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
                 })}
               </div>
             </div>
-            <div className="bg-gray-900 -mx-5 md:pt-24 pt-10 pb-40 xl:px-0 px-5 text-white ">
-              <div className="max-w-screen-xl mx-auto grid md:grid-cols-2 grid-cols-1 gap-10 md:text-left text-center">
+            <div className="bg-gradient-to-b from-gray-700 to-gray-900 -mx-5 md:pt-24 pt-10 pb-40 xl:px-0 px-5 text-white ">
+              <div className="max-w-screen-lg mx-auto grid md:grid-cols-2 grid-cols-1 gap-10 md:text-left text-center">
                 <div>
                   {/* <div className="mb-2 uppercase font-medium tracking-wide text-sm md:text-left text-center text-purple-300">
                     What You’ll Build for Your Portfolio
@@ -281,13 +281,13 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
                     By the end of this project, you’ll have your own dynamic
                     eCommerce store with a working checkout flow.
                   </p>
-                  <ul className="mt-6 leading-10 list-none list-inside text-lg">
+                  <ul className="text-blueGray-200 mt-6 leading-10 list-none list-inside text-lg font-light">
                     {[
                       'Manage local state with React Hooks',
                       'Manage global state with React Context',
                       'Purchasing flow with Stripe Checkout',
                     ].map((i) => (
-                      <li className="space-x-2" key={i}>
+                      <li className="space-x-4" key={i}>
                         <span className="text-purple-300">✓</span>
                         <span>{i}</span>
                       </li>
@@ -296,7 +296,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
                 </div>
                 <div className="md:row-start-auto row-start-1">
                   <Image
-                    className="rounded-md"
+                    className="rounded-md shadow-lg"
                     src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1608034859/next.egghead.io/pages/projects/create-an-ecommerce-store-with-next-js-and-stripe-checkout/screenshot-of-space-jelly-shop-interface.png"
                     width={1128 / 2}
                     height={698 / 2}
@@ -304,7 +304,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
                   />
                 </div>
               </div>
-              <div className="mt-16 font-light text-gray-200 grid md:grid-cols-5 grid-cols-2 lg:grid-rows-2 text-center max-w-screen-xl mx-auto md:gap-x-12 gap-x-3 md:gap-y-6 gap-y-5">
+              <div className="mt-16 font-light text-purple-300 grid md:grid-cols-5 grid-cols-2 lg:grid-rows-2 text-center max-w-screen-lg mx-auto md:gap-x-12 gap-x-3 md:gap-y-6 gap-y-5 tracking-wide">
                 {[
                   'React Context API',
                   'Data Fetching',
@@ -325,7 +325,7 @@ how to make your Next.js e-commerce store portable to deploy to other platforms.
             </div>
           </main>
         </article>
-        <div className="w-full mx-auto max-w-screen-xl items-center grid md:grid-cols-2 lg:gap-40 md:gap-24 gap-5">
+        <div className="w-full mx-auto max-w-screen-lg items-center grid md:grid-cols-2 lg:gap-40 md:gap-24 gap-5">
           <Instructor instructor={course.instructor} />
           {course.podcast.id && (
             <div>


### PR DESCRIPTION
Made slight adjustments to the spacing and colours on the landing page to align with the mockup.
- Narrowed the text blocks to make them easier to read
- Added more margin on elements to give sections more breathing room
- Added more subtle differences between colours for reading heirarchy

Also added in the three new icons (still working on a fourth icon - have to touch base with Zac and Lauro first to double-check wording/copywriting all looks good). Added them as transparent PNGs for now. We could do them as SVG, but I didn't want to mess with the TS types and it was throwing errors when I tried the SVG version.

Side by side comparison of before -> after:

![Group_shrink](https://user-images.githubusercontent.com/5599295/102487583-b5713500-4062-11eb-80dd-ad8e24e0b09d.png)
