### PR TITLE
WIP - attempted fix of the double-logout bug

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -113,7 +113,7 @@ export default class Auth {
 
   logout() {
     track('logged out')
-    return this.clearLocalStorage()
+    return this.clearSessionStorage()
   }
 
   monitor(onInterval: {(): void; (...args: any[]): void}, delay = 2000) {
@@ -184,7 +184,15 @@ export default class Auth {
     })
   }
 
-  clearLocalStorage() {
+  async clearSessionStorage() {
+    let deleteSessionResponse = null
+
+    if (getAccessTokenFromCookie()) {
+      deleteSessionResponse = await axios
+        .delete(`/api/users/session`)
+        .catch((error) => console.error(error))
+    }
+
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem(ACCESS_TOKEN_KEY)
       localStorage.removeItem(EXPIRES_AT_KEY)
@@ -192,11 +200,7 @@ export default class Auth {
       localStorage.removeItem(VIEWING_AS_USER_KEY)
     }
 
-    if (getAccessTokenFromCookie()) {
-      return axios
-        .delete(`/api/users/session`)
-        .catch((error) => console.error(error))
-    }
+    return deleteSessionResponse || Promise.resolve()
   }
 
   isAuthenticated() {


### PR DESCRIPTION
This commit doesn't fix the issue. I'm stuck on where to go from here.

The viewer-context involves a mechanism that tries to resolve a missing
user session. If the authToken is present when it mounts or during any
rerender of the viewer-context, it will request fresh user data.

What I'm noticing when hitting the logout endpoint, is that while a
request to `DELETE /api/users/session` goes out to clear the authToken
cookie, the viewer-context useEffect gets triggered with that authToken,
so by the time the cookie gets deleted and the local storage gets
cleared out, the refreshUser call returns with data to repopulate local
storage.

I tried introducing some state to represent when a logout is being
performed to avoid this timing issue, but the useEffect is still
triggering the refreshUser.


![](https://media0.giphy.com/media/ZeNmLY6FISq4M/200.gif?cid=5a38a5a2thw4vsew3nco7u7yb6blu9wxkpbdbzm5k076kcg2&rid=200.gif)
