### PR TITLE
Improve Code and Syntax Highlighting

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,22 +1,10 @@
 const withSvgr = require('next-svgr')
 const withBundleAnalyzer = require('@next/bundle-analyzer')
 const withPlugins = require('next-compose-plugins')
-const rehypeShiki = require('rehype-shiki')
 const checkEnv = require('@47ng/check-env').default
 const withImages = require('next-images')
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
-  options: {
-    rehypePlugins: [
-      [
-        rehypeShiki,
-        {
-          theme: './src/styles/material-theme-dark.json',
-          useBackground: true,
-        },
-      ],
-    ],
-  },
 })
 
 const searchUrlRoot = `/q`
@@ -164,7 +152,6 @@ module.exports = withPlugins(
         require('remark-footnotes'),
         require('remark-code-titles'),
       ],
-      rehypePlugins: [],
     }),
   ],
   nextConfig,

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "next-svgr": "^0.0.2",
     "nextjs-sitemap-generator": "^1.1.3",
     "pluralize": "^8.0.0",
+    "prism-react-renderer": "^1.1.1",
     "qs": "^6.9.4",
     "query-string": "^6.13.7",
     "react": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-textfit": "^1.1.1",
     "react-use": "^15.3.4",
     "reading-time": "^1.2.1",
-    "rehype-shiki": "^0.0.9",
     "remark-code-titles": "^0.1.1",
     "remark-footnotes": "^2.0.0",
     "remark-slug": "^6.0.0",

--- a/src/components/mdx/Code.tsx
+++ b/src/components/mdx/Code.tsx
@@ -1,0 +1,175 @@
+import React, {FunctionComponent, useEffect, useState} from 'react'
+import styled from '@emotion/styled'
+import Highlight, {defaultProps} from 'prism-react-renderer'
+import theme from 'prism-react-renderer/themes/nightOwl'
+
+const RE = /{([\d,-]+)}/
+
+function calculateLinesToHighlight(meta: string) {
+  if (RE.test(meta)) {
+    const lineNumbers = RE.exec(meta)![1]
+      .split(',')
+      .map((v) => v.split('-').map((y) => parseInt(y, 10)))
+    return (index: number) => {
+      const lineNumber = index + 1
+      const inRange = lineNumbers.some(([start, end]) =>
+        end ? lineNumber >= start && lineNumber <= end : lineNumber === start,
+      )
+      return inRange
+    }
+  }
+  return () => false
+}
+
+type CodeProps = {
+  className: string
+  metastring: string
+  children: string
+}
+
+const Code: FunctionComponent<CodeProps> = ({
+  children,
+  className,
+  metastring,
+}) => {
+  const language = className ? className.replace(/language-/, '') : ''
+  const shouldHighlightLine = calculateLinesToHighlight(metastring)
+
+  const defaultCopyText = 'Copy'
+  const [copyText, setCopyText] = useState(defaultCopyText)
+
+  useEffect(() => {
+    let current = true
+    if (copyText !== defaultCopyText) {
+      setTimeout(() => {
+        if (current) {
+          setCopyText(defaultCopyText)
+        }
+      }, 2000)
+    }
+    return () => {
+      current = false
+    }
+  }, [copyText])
+
+  function copy(event: {preventDefault: () => void}) {
+    event.preventDefault()
+    navigator.clipboard.writeText(children).then(
+      () => {
+        setCopyText('Copied')
+      },
+      () => {
+        setCopyText('Error copying text')
+      },
+    )
+  }
+
+  const SyntaxStyles = styled.div`
+    overflow: auto;
+    border-radius: 5px;
+    padding: 10px;
+  `
+
+  const PreStyles = styled.div`
+    float: left;
+    min-width: 100%;
+    overflow: initial;
+    padding: 0;
+    line-height: 150%;
+    margin-top: -5px;
+    .highlight-line {
+      background-color: rgba(164, 107, 255, 0.2);
+    }
+  `
+
+  const SpanStyles = styled.span`
+    display: inline-block;
+    width: 2em;
+    user-select: none;
+    opacity: 0.3;
+    padding-left: 0px;
+  `
+
+  const TitleSection = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 100px;
+    width: 100%;
+    padding: 5px 10px;
+    border-bottom: 1px solid #162633;
+    background: #05223a;
+    small {
+      color: #cad4e3;
+      font-size: 0.8rem;
+    }
+  `
+
+  const Button = styled.button`
+    display: grid;
+    grid-template-columns: 30px 1fr;
+    justify-items: center;
+    align-items: center;
+    outline: none;
+    svg {
+      height: 23px;
+      width: 21px;
+      transform: scale(0.8);
+    }
+
+    svg path {
+      stroke: #cad4e3;
+      fill: none;
+      transition: 1s cubic-bezier(0.075, 0.82, 0.165, 1);
+    }
+
+    :hover {
+      :hover svg path {
+        stroke: #ffffff;
+      }
+    }
+  `
+
+  return (
+    <Highlight
+      {...defaultProps}
+      theme={theme}
+      code={children.trim()}
+      // @ts-ignore
+      language={language}
+    >
+      {({tokens, getLineProps, getTokenProps}) => (
+        <div>
+          <TitleSection>
+            <small className={language}>{language}</small>
+            <Button onClick={copy}>
+              <svg>
+                <path d="M8 17.929H6c-1.105 0-2-.912-2-2.036V5.036C4 3.91 4.895 3 6 3h8c1.105 0 2 .911 2 2.036v1.866m-6 .17h8c1.105 0 2 .91 2 2.035v10.857C20 21.09 19.105 22 18 22h-8c-1.105 0-2-.911-2-2.036V9.107c0-1.124.895-2.036 2-2.036z"></path>
+              </svg>
+              <small>{copyText}</small>
+            </Button>
+          </TitleSection>
+
+          <SyntaxStyles>
+            <PreStyles>
+              {tokens.map((line, i) => (
+                <div
+                  {...getLineProps({
+                    line,
+                    key: i,
+                    className: shouldHighlightLine(i) ? 'highlight-line' : '',
+                  })}
+                >
+                  <SpanStyles>{i + 1}</SpanStyles>
+                  {line.map((token, key) => (
+                    <span {...getTokenProps({token, key})} />
+                  ))}
+                </div>
+              ))}
+            </PreStyles>
+          </SyntaxStyles>
+        </div>
+      )}
+    </Highlight>
+  )
+}
+
+export default Code

--- a/src/components/mdx/Code.tsx
+++ b/src/components/mdx/Code.tsx
@@ -133,8 +133,7 @@ const Code: FunctionComponent<CodeProps> = ({
       {...defaultProps}
       theme={theme}
       code={children.trim()}
-      // @ts-ignore
-      language={language}
+      language={language as any}
     >
       {({tokens, getLineProps, getTokenProps}) => (
         <div>

--- a/src/layouts/ultimate-guide.tsx
+++ b/src/layouts/ultimate-guide.tsx
@@ -4,6 +4,10 @@ import Contributors from 'components/Contributors'
 import Image from 'next/image'
 import Link from 'next/link'
 import {useRouter} from 'next/router'
+import {MDXProvider} from '@mdx-js/react'
+import Code from 'components/mdx/Code'
+
+const components = {code: Code}
 
 type LayoutProps = {
   meta?: {
@@ -101,7 +105,7 @@ const UltimateGuideLayout: FunctionComponent<LayoutProps> = ({
           </header>
 
           <main className="prose md:prose-lg max-w-none">
-            <div>{children}</div>
+            <MDXProvider components={components}>{children}</MDXProvider>
           </main>
           <footer className="mt-8 border-t border-gray-200 py-10 flex sm:flex-row flex-col-reverse justify-between sm:items-start items-center sm:text-left text-center">
             {contributors && <Contributors contributors={contributors} />}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -41,11 +41,14 @@ pre {
 /* Code block styles */
 
 .prose pre {
-  @apply sm:mx-0 -mx-5 sm:rounded-md rounded-none;
+  padding: 0 !important;
+  background: #011627 !important;
+  font-size: 80% !important;
+  @apply sm:mx-0 -mx-5 sm:rounded-md rounded-sm;
 }
 
 pre {
-  @apply sm:mx-0 -mx-5 sm:rounded-md rounded-none;
+  @apply sm:mx-0 -mx-5 sm:rounded-md rounded-sm;
 }
 
 #__next .prose-reset * {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15549,6 +15549,11 @@ prism-media@^1.2.2:
   resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.2.2.tgz#4f1c841f248b67d325a24b4e6b1a491b8f50a24f"
   integrity sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw==
 
+prism-react-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
+  integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
+
 prismjs@^1.21.0, prismjs@~1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11000,11 +11000,6 @@ hast-util-to-parse5@^6.0.0:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
-hast-util-to-string@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz#9b24c114866bdb9478927d7e9c36a485ac728378"
-  integrity sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w==
-
 hast-util-whitespace@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
@@ -14381,13 +14376,6 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-onigasm@^2.2.1:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
-  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
-  dependencies:
-    lru-cache "^5.1.1"
-
 open@^7.0.2, open@^7.0.3:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/open/-/open-7.3.0.tgz#45461fdee46444f3645b6e14eb3ca94b82e1be69"
@@ -16507,17 +16495,6 @@ rehype-parse@^7.0.0:
     hast-util-from-parse5 "^6.0.0"
     parse5 "^6.0.0"
 
-rehype-shiki@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/rehype-shiki/-/rehype-shiki-0.0.9.tgz#539b0113064509a921897c3fd28409ae393908f5"
-  integrity sha512-jyatOsBu0A8ZUnQig0QK0xq7CFZpeEukr0DZazg/zFLZATbdcbnIlO779pIW2El/C2S5An33sN2d4w2kmdS+Bw==
-  dependencies:
-    hast-util-to-string "^1.0.4"
-    shiki "^0.1.7"
-    shiki-languages "^0.1.6"
-    unist-builder "^2.0.3"
-    unist-util-visit "^2.0.3"
-
 rehype-stringify@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-8.0.0.tgz#9b6afb599bcf3165f10f93fc8548f9a03d2ec2ba"
@@ -17287,31 +17264,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-shiki-languages@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/shiki-languages/-/shiki-languages-0.1.6.tgz#4a71eba9d345de4780fc46994e4d073356573e3e"
-  integrity sha512-rMu+z97UCPKMtPBkzLBItReawXnlOgXZmELFwI/s3ATxd9VzJgSQTtQW/hmW5EYCrzF2kAUjoOnn+50/MPWjgQ==
-  dependencies:
-    vscode-textmate "https://github.com/octref/vscode-textmate"
-
-shiki-themes@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/shiki-themes/-/shiki-themes-0.1.7.tgz#edaf2027b31bb3645dd044f66a76d4cdb2599b77"
-  integrity sha512-mpF/VynGun/uNdjOIPnyPv4boN/QYDh+zE94SavgvmatMHkXXjZhls19Xv9rcRwuxUrWfXjaPkEZj7VAk94GGg==
-  dependencies:
-    json5 "^2.1.0"
-    vscode-textmate "https://github.com/octref/vscode-textmate"
-
-shiki@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.1.7.tgz#138eed000063a80e44eedc800381977c690271e5"
-  integrity sha512-9J0PhAdXv6tt3FZf82oKZkcV8c8NRZYJEOH0eIrrxfcyNzMuB79tJFGFSI3OhhiYFL5namob/Ii0Ri4iDoF15A==
-  dependencies:
-    onigasm "^2.2.1"
-    shiki-languages "^0.1.6"
-    shiki-themes "^0.1.7"
-    vscode-textmate "https://github.com/octref/vscode-textmate"
 
 shimmer@^1.2.1:
   version "1.2.1"
@@ -18921,7 +18873,7 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unist-builder@2.0.3, unist-builder@^2.0.0, unist-builder@^2.0.3:
+unist-builder@2.0.3, unist-builder@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
@@ -18987,7 +18939,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
@@ -19266,10 +19218,6 @@ vm-browserify@1.1.2, vm-browserify@^1.0.0, vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
-"vscode-textmate@https://github.com/octref/vscode-textmate":
-  version "4.0.1"
-  resolved "https://github.com/octref/vscode-textmate#e65aabe2227febda7beaad31dd0fca1228c5ddf3"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR improves the code and syntax highlighting for egghead articles. It provides:

- Night Owl theme 
- Line numbering 
- Line highlighting
- Display language name
- The functionality to copy and paste code blocks

**[Codemods with Babel Plugins](https://egghead-io-nextjs-git-ls-syntax-highlighting.eggheadio1.vercel.app/learn/javascript/codemods-with-babel-plugins)**

### Before and After

![Artboard](https://user-images.githubusercontent.com/57044804/103178679-c0ce1880-4839-11eb-9462-284b931845e4.png)