### PR TITLE
egghead-next home page gardening 

### DIFF
--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -26,16 +26,6 @@ const homepageData = [
     title: 'Featured',
     resources: [
       {
-        name: 'Hot',
-        title:
-          'Build a site from scratch with Next.js, TypeScript, Emotion and Netlify',
-        byline: 'Tomasz Łakomy',
-        image:
-          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/387/163/square_480/netlify-ts.png',
-        path:
-          'playlists/build-a-blog-with-next-js-typescript-emotion-and-netlify-adcc',
-      },
-      {
         name: 'In-Depth Article',
         title: 'Codemods with Babel Plugins',
         byline: 'Laurie Barth',
@@ -58,6 +48,14 @@ const homepageData = [
         image:
           'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/418/892/square_480/EGH_IntroCloudFlareWorkers_Final.png',
         path: '/playlists/introduction-to-cloudflare-workers-5aa3',
+      },
+      {
+        name: 'Advanced',
+        title: 'Composing Closures and Callbacks in JavaScript',
+        byline: 'John Lindquist',
+        image:
+          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/402/036/full/EGH_ComposingCallbacks_Final.png',
+        path: '/playlists/composing-closures-and-callbacks-in-javascript-1223',
       },
     ],
   },

--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -228,8 +228,8 @@ const homepageData = [
       'In this workshop, Jason Lengstorf will take you from an empty project folder all the way through deployment of a Twilio-powered video chat app built on Gatsby.',
   },
   {
-    id: 'learnInPublic',
-    name: 'Learn in Public',
+    id: 'buildInPublic',
+    name: 'Build in Public',
     title: 'How to Livestream Code and Design on Twitch',
     path: '/playlists/how-to-livestream-code-and-design-on-twitch-6646',
     image:

--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -230,6 +230,17 @@ const homepageData = [
       'In this workshop, Jason Lengstorf will take you from an empty project folder all the way through deployment of a Twilio-powered video chat app built on Gatsby.',
   },
   {
+    id: 'learnInPublic',
+    name: 'Learn in Public',
+    title: 'How to Livestream Code and Design on Twitch',
+    path: '/playlists/how-to-livestream-code-and-design-on-twitch-6646',
+    image:
+      'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/292/full/output-onlinepngtools.png',
+    byline: 'Chris Biscardi',
+    description:
+      'Demonstrate technical proficiency by building in public. This course will take you from creating a Twitch account, all the way through setting up OBS, creating scenes, and defining an ultra-efficient workflow.',
+  },
+  {
     id: 'portfolioProject',
     name: 'Portfolio Project',
     title: 'Create an eCommerce Store with Next.js and Stripe Checkout',

--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -49,14 +49,6 @@ const homepageData = [
           'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/418/892/square_480/EGH_IntroCloudFlareWorkers_Final.png',
         path: '/playlists/introduction-to-cloudflare-workers-5aa3',
       },
-      {
-        name: 'Advanced',
-        title: 'Composing Closures and Callbacks in JavaScript',
-        byline: 'John Lindquist',
-        image:
-          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/402/036/full/EGH_ComposingCallbacks_Final.png',
-        path: '/playlists/composing-closures-and-callbacks-in-javascript-1223',
-      },
     ],
   },
   {
@@ -262,6 +254,17 @@ const homepageData = [
     byline: 'Tomasz Łakomy',
     description:
       'Use cutting-edge tools and leverage the best developer experience provided by Next.js to build your developer portfolio blog.',
+  },
+  {
+    id: 'advancedCourse',
+    name: 'Mind-Expanding',
+    title: 'Composing Closures and Callbacks in JavaScript',
+    path: '/playlists/composing-closures-and-callbacks-in-javascript-1223',
+    image:
+      'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/402/036/full/EGH_ComposingCallbacks_Final.png',
+    byline: 'John Lindquist',
+    description:
+      'This course is for aspiring lead developers. John Lindquist guides you from a blank JavaScript file all the way through creating a library of reusable functions, solving Callback Hell with composition, implementing debouncing, and building a word game among several other examples.',
   },
   {
     id: 'mdxConf',

--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -251,6 +251,19 @@ const homepageData = [
       'Build a modern eCommerce store with the best-in-class tools available to web developers to add to your portfolio.',
   },
   {
+    id: 'portfolioBlog',
+    name: 'Portfolio Blog',
+    title:
+      'Build a site from scratch with Next.js, TypeScript, Emotion and Netlify',
+    path:
+      'playlists/build-a-blog-with-next-js-typescript-emotion-and-netlify-adcc',
+    image:
+      'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/387/163/square_480/netlify-ts.png',
+    byline: 'Tomasz Łakomy',
+    description:
+      'Use cutting-edge tools and leverage the best developer experience provided by Next.js to build your developer portfolio blog.',
+  },
+  {
     id: 'mdxConf',
     name: 'Future of Markdown',
     title: 'MDX Conf 2020',

--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -49,6 +49,14 @@ const homepageData = [
           'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/418/892/square_480/EGH_IntroCloudFlareWorkers_Final.png',
         path: '/playlists/introduction-to-cloudflare-workers-5aa3',
       },
+      {
+        name: 'Hot',
+        title: 'Using DynamoDB with Next.js',
+        byline: 'Lee Robinson',
+        image:
+          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/411/838/full/EGH_DynamoDB.png',
+        path: '/playlists/using-dynamodb-with-next-js-b40c',
+      },
     ],
   },
   {

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -26,7 +26,7 @@ const Home: FunctionComponent = () => {
     id: 'stateManagement',
   })
   const sideProject: any = find(homepageData, {id: 'sideProject'})
-  const learnInPublic: any = find(homepageData, {id: 'learnInPublic'})
+  const buildInPublic: any = find(homepageData, {id: 'buildInPublic'})
   const portfolioProject: any = find(homepageData, {id: 'portfolioProject'})
   const portfolioBlog: any = find(homepageData, {id: 'portfolioBlog'})
   const mdxConf: any = find(homepageData, {id: 'mdxConf'})
@@ -354,34 +354,34 @@ const Home: FunctionComponent = () => {
             <Card className="border-none my-4">
               <>
                 <div className="flex space-x-5">
-                  {learnInPublic.image && (
-                    <Link href={learnInPublic.path}>
+                  {buildInPublic.image && (
+                    <Link href={buildInPublic.path}>
                       <a className="block flex-shrink-0 sm:w-auto w-20">
                         <Image
-                          src={learnInPublic.image}
+                          src={buildInPublic.image}
                           width={160}
                           height={160}
-                          alt={`illustration for ${learnInPublic.title}`}
+                          alt={`illustration for ${buildInPublic.title}`}
                         />
                       </a>
                     </Link>
                   )}
                   <div className="flex flex-col justify-center items-start">
                     <h2 className=" uppercase font-semibold text-xs tracking-tight text-gray-700 mb-1">
-                      {learnInPublic.name}
+                      {buildInPublic.name}
                     </h2>
-                    <Link href={learnInPublic.path}>
+                    <Link href={buildInPublic.path}>
                       <a className="hover:text-blue-600">
                         <h3 className="text-xl font-bold leading-tighter">
-                          {learnInPublic.title}
+                          {buildInPublic.title}
                         </h3>
                       </a>
                     </Link>
                     <div className="text-xs text-gray-600 mb-2">
-                      {learnInPublic.byline}
+                      {buildInPublic.byline}
                     </div>
                     <Markdown className="prose prose-sm max-w-none">
-                      {learnInPublic.description}
+                      {buildInPublic.description}
                     </Markdown>
                   </div>
                 </div>

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -25,6 +25,7 @@ const Home: FunctionComponent = () => {
   const stateManagement: any = find(homepageData, {
     id: 'stateManagement',
   })
+  const advancedCourse: any = find(homepageData, {id: 'advancedCourse'})
   const sideProject: any = find(homepageData, {id: 'sideProject'})
   const buildInPublic: any = find(homepageData, {id: 'buildInPublic'})
   const portfolioProject: any = find(homepageData, {id: 'portfolioProject'})
@@ -311,10 +312,6 @@ const Home: FunctionComponent = () => {
                 </div>
               </>
             </Card>
-            <div className="grid xl:grid-cols-2 lg:grid-cols-1 md:grid-cols-2 grid-cols-1 gap-5">
-              <CardVerticalWithStack data={devEssentials} />
-              <CardVerticalWithStack data={freeCourses} />
-            </div>
             <Card className="border-none my-4">
               <>
                 <div className="flex space-x-5">
@@ -346,6 +343,47 @@ const Home: FunctionComponent = () => {
                     </div>
                     <Markdown className="prose prose-sm max-w-none">
                       {portfolioBlog.description}
+                    </Markdown>
+                  </div>
+                </div>
+              </>
+            </Card>
+            <div className="grid xl:grid-cols-2 lg:grid-cols-1 md:grid-cols-2 grid-cols-1 gap-5">
+              <CardVerticalWithStack data={devEssentials} />
+              <CardVerticalWithStack data={freeCourses} />
+            </div>
+
+            <Card className="border-none my-4">
+              <>
+                <div className="flex space-x-5">
+                  {advancedCourse.image && (
+                    <Link href={advancedCourse.path}>
+                      <a className="block flex-shrink-0 sm:w-auto w-20">
+                        <Image
+                          src={advancedCourse.image}
+                          width={160}
+                          height={160}
+                          alt={`illustration for ${advancedCourse.title}`}
+                        />
+                      </a>
+                    </Link>
+                  )}
+                  <div className="flex flex-col justify-center items-start">
+                    <h2 className=" uppercase font-semibold text-xs tracking-tight text-gray-700 mb-1">
+                      {advancedCourse.name}
+                    </h2>
+                    <Link href={advancedCourse.path}>
+                      <a className="hover:text-blue-600">
+                        <h3 className="text-xl font-bold leading-tighter">
+                          {advancedCourse.title}
+                        </h3>
+                      </a>
+                    </Link>
+                    <div className="text-xs text-gray-600 mb-2">
+                      {advancedCourse.byline}
+                    </div>
+                    <Markdown className="prose prose-sm max-w-none">
+                      {advancedCourse.description}
                     </Markdown>
                   </div>
                 </div>

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -28,6 +28,7 @@ const Home: FunctionComponent = () => {
   const sideProject: any = find(homepageData, {id: 'sideProject'})
   const learnInPublic: any = find(homepageData, {id: 'learnInPublic'})
   const portfolioProject: any = find(homepageData, {id: 'portfolioProject'})
+  const portfolioBlog: any = find(homepageData, {id: 'portfolioBlog'})
   const mdxConf: any = find(homepageData, {id: 'mdxConf'})
   const topics: any = find(homepageData, {id: 'topics'})
   const swag: any = find(homepageData, {id: 'swag'})
@@ -317,34 +318,34 @@ const Home: FunctionComponent = () => {
             <Card className="border-none my-4">
               <>
                 <div className="flex space-x-5">
-                  {sideProject.image && (
-                    <Link href={sideProject.path}>
+                  {portfolioBlog.image && (
+                    <Link href={portfolioBlog.path}>
                       <a className="block flex-shrink-0 sm:w-auto w-20">
                         <Image
-                          src={sideProject.image}
+                          src={portfolioBlog.image}
                           width={160}
                           height={160}
-                          alt={`illustration for ${sideProject.title}`}
+                          alt={`illustration for ${portfolioBlog.title}`}
                         />
                       </a>
                     </Link>
                   )}
                   <div className="flex flex-col justify-center items-start">
                     <h2 className=" uppercase font-semibold text-xs tracking-tight text-gray-700 mb-1">
-                      {sideProject.name}
+                      {portfolioBlog.name}
                     </h2>
-                    <Link href={sideProject.path}>
+                    <Link href={portfolioBlog.path}>
                       <a className="hover:text-blue-600">
                         <h3 className="text-xl font-bold leading-tighter">
-                          {sideProject.title}
+                          {portfolioBlog.title}
                         </h3>
                       </a>
                     </Link>
                     <div className="text-xs text-gray-600 mb-2">
-                      {sideProject.byline}
+                      {portfolioBlog.byline}
                     </div>
                     <Markdown className="prose prose-sm max-w-none">
-                      {sideProject.description}
+                      {portfolioBlog.description}
                     </Markdown>
                   </div>
                 </div>
@@ -381,6 +382,42 @@ const Home: FunctionComponent = () => {
                     </div>
                     <Markdown className="prose prose-sm max-w-none">
                       {learnInPublic.description}
+                    </Markdown>
+                  </div>
+                </div>
+              </>
+            </Card>
+            <Card className="border-none my-4">
+              <>
+                <div className="flex space-x-5">
+                  {sideProject.image && (
+                    <Link href={sideProject.path}>
+                      <a className="block flex-shrink-0 sm:w-auto w-20">
+                        <Image
+                          src={sideProject.image}
+                          width={160}
+                          height={160}
+                          alt={`illustration for ${sideProject.title}`}
+                        />
+                      </a>
+                    </Link>
+                  )}
+                  <div className="flex flex-col justify-center items-start">
+                    <h2 className=" uppercase font-semibold text-xs tracking-tight text-gray-700 mb-1">
+                      {sideProject.name}
+                    </h2>
+                    <Link href={sideProject.path}>
+                      <a className="hover:text-blue-600">
+                        <h3 className="text-xl font-bold leading-tighter">
+                          {sideProject.title}
+                        </h3>
+                      </a>
+                    </Link>
+                    <div className="text-xs text-gray-600 mb-2">
+                      {sideProject.byline}
+                    </div>
+                    <Markdown className="prose prose-sm max-w-none">
+                      {sideProject.description}
                     </Markdown>
                   </div>
                 </div>

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -26,6 +26,7 @@ const Home: FunctionComponent = () => {
     id: 'stateManagement',
   })
   const sideProject: any = find(homepageData, {id: 'sideProject'})
+  const learnInPublic: any = find(homepageData, {id: 'learnInPublic'})
   const portfolioProject: any = find(homepageData, {id: 'portfolioProject'})
   const mdxConf: any = find(homepageData, {id: 'mdxConf'})
   const topics: any = find(homepageData, {id: 'topics'})
@@ -344,6 +345,42 @@ const Home: FunctionComponent = () => {
                     </div>
                     <Markdown className="prose prose-sm max-w-none">
                       {sideProject.description}
+                    </Markdown>
+                  </div>
+                </div>
+              </>
+            </Card>
+            <Card className="border-none my-4">
+              <>
+                <div className="flex space-x-5">
+                  {learnInPublic.image && (
+                    <Link href={learnInPublic.path}>
+                      <a className="block flex-shrink-0 sm:w-auto w-20">
+                        <Image
+                          src={learnInPublic.image}
+                          width={160}
+                          height={160}
+                          alt={`illustration for ${learnInPublic.title}`}
+                        />
+                      </a>
+                    </Link>
+                  )}
+                  <div className="flex flex-col justify-center items-start">
+                    <h2 className=" uppercase font-semibold text-xs tracking-tight text-gray-700 mb-1">
+                      {learnInPublic.name}
+                    </h2>
+                    <Link href={learnInPublic.path}>
+                      <a className="hover:text-blue-600">
+                        <h3 className="text-xl font-bold leading-tighter">
+                          {learnInPublic.title}
+                        </h3>
+                      </a>
+                    </Link>
+                    <div className="text-xs text-gray-600 mb-2">
+                      {learnInPublic.byline}
+                    </div>
+                    <Markdown className="prose prose-sm max-w-none">
+                      {learnInPublic.description}
                     </Markdown>
                   </div>
                 </div>


### PR DESCRIPTION
This PR updates the home page by adding: 

-  "Using DynamoDB with Next.js" in the feature section
-  A full card for "Composing Closures and Callbacks in JavaScript"
-  A Portfolio Blog card for "Build a site from scratch with Next.js, TypeScript, Emotion and Netlify" 
-  A Build in Public card for "How to Livestream Code and Design on Twitch" 

<img width="668" alt="CleanShot 2021-01-07 at 18 28 18@2x" src="https://user-images.githubusercontent.com/57044804/103967118-26fa4b80-5116-11eb-94c5-d11b1391ea35.png">



![90s computer - 238t2dNVAI7SMMA4Bb](https://user-images.githubusercontent.com/57044804/103963559-6fae0680-510e-11eb-8f3e-39d7e6971eea.gif)

