### PR TITLE
remove theater mode

### DIFF
--- a/src/components/pages/lessons/lesson-info.tsx
+++ b/src/components/pages/lessons/lesson-info.tsx
@@ -20,7 +20,6 @@ type LessonInfoProps = {
   ]
   description: string
   [cssRelated: string]: any
-  nextUp: any
   playerState: any
   autoplay: {enabled: boolean}
 }
@@ -30,7 +29,6 @@ const LessonInfo: FunctionComponent<LessonInfoProps> = ({
   instructor,
   tags,
   description,
-  nextUp,
   lesson,
   playerState,
   autoplay,

--- a/src/components/pages/lessons/overlay/next-up-overlay.tsx
+++ b/src/components/pages/lessons/overlay/next-up-overlay.tsx
@@ -12,14 +12,14 @@ const NextUpOverlay: React.FunctionComponent<{
   onClickRewatch?: () => void
 }> = ({lesson, send, nextUp, nextLesson, onClickRewatch = noop}) => {
   const {nextLessonTitle, nextUpPath} = nextUp
-  const courseImage = lesson?.course?.square_cover_480_url
+  const courseImage = lesson?.collection?.square_cover_480_url
   return (
     <>
       {courseImage && (
-        <div className="w-12 h-12 md:w-16 md:h-16 lg:w-20 lg:h-20 relative flex-shrink-0">
+        <div className="w-16 h-16 md:w-32 md:h-32 lg:w-48 lg:h-48 relative flex-shrink-0">
           <Image
             src={courseImage}
-            alt={`illustration of ${lesson.course.title} course`}
+            alt={`illustration of ${lesson.collection.title} course`}
             layout="fill"
           />
         </div>
@@ -52,20 +52,6 @@ const NextUpOverlay: React.FunctionComponent<{
             <IconPlay className="w-6 mr-2" /> Play next
           </a>
         </Link>
-      </div>
-      <div className="mt-8 text-xs md:mt-10">
-        Feeling stuck?{' '}
-        <a
-          onClick={() => {
-            track('clicked feeling stuck', {
-              lesson: lesson.slug,
-            })
-          }}
-          href="#"
-          className="font-semibold"
-        >
-          Get help from egghead community
-        </a>
       </div>
     </>
   )

--- a/src/components/pages/lessons/overlay/next-up-overlay.tsx
+++ b/src/components/pages/lessons/overlay/next-up-overlay.tsx
@@ -6,12 +6,9 @@ import noop from 'utils/noop'
 
 const NextUpOverlay: React.FunctionComponent<{
   lesson: any
-  send: any
-  nextUp: any
   nextLesson: any
   onClickRewatch?: () => void
-}> = ({lesson, send, nextUp, nextLesson, onClickRewatch = noop}) => {
-  const {nextLessonTitle, nextUpPath} = nextUp
+}> = ({lesson, nextLesson, onClickRewatch = noop}) => {
   const courseImage = lesson?.collection?.square_cover_480_url
   return (
     <>
@@ -26,7 +23,7 @@ const NextUpOverlay: React.FunctionComponent<{
       )}
       <div className="mt-4 md:mt-4">Up Next</div>
       <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
-        {nextLesson.title || nextLessonTitle}
+        {nextLesson.title}
       </h3>
       <div className="flex mt-6 md:mt-8">
         <button
@@ -40,7 +37,7 @@ const NextUpOverlay: React.FunctionComponent<{
         >
           <IconRefresh className="w-6 mr-2" /> Watch again
         </button>
-        <Link href={nextLesson.path || nextUpPath || '#'}>
+        <Link href={nextLesson.path || '#'}>
           <a
             onClick={() => {
               track('clicked play next', {

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -36,7 +36,6 @@ import Eggo from 'components/icons/eggo'
 import Image from 'next/image'
 import cookieUtil from 'utils/cookies'
 import useBreakpoint from 'utils/breakpoints'
-import NextUpList from 'components/pages/lessons/next-up-list'
 import Share from 'components/share'
 import LessonDownload from 'components/pages/lessons/lesson-download'
 import {useNextForCollection, useNextUpData} from 'hooks/use-next-up-data'
@@ -143,7 +142,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
 
   const {
     instructor,
-    next_up_url,
     transcript,
     transcript_url,
     http_url,
@@ -170,7 +168,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
     }
   }, [media_url])
 
-  const nextUp = useNextUpData(next_up_url)
   const nextLesson = useNextForCollection(collection, lesson.slug)
   const enhancedTranscript = useEnhancedTranscript(transcript_url)
   const transcriptAvailable = transcript || enhancedTranscript
@@ -188,8 +185,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
   const getProgress = (lessonView: any) => {
     if (lessonView?.collection_progress) {
       return lessonView.collection_progress
-    } else if (nextUp.nextUpData?.list?.progress) {
-      return nextUp.nextUpData.list.progress
     }
   }
 
@@ -209,11 +204,11 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
   }, [currentPlayerState])
 
   const checkAutoPlay = () => {
-    if (autoplay && (nextLesson || nextUp.nextUpPath)) {
+    if (autoplay && nextLesson) {
       setMedia(false)
       send('AUTO_PLAY')
-      router.push(nextLesson.path || nextUp.nextUpPath)
-    } else if (nextLesson || nextUp.nextUpPath) {
+      router.push(nextLesson.path)
+    } else if (nextLesson) {
       send(`NEXT`)
     } else {
       send(`RECOMMEND`)
@@ -222,7 +217,7 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
 
   const completeVideo = (lessonView: any) => {
     if (lessonView) {
-      const hasNextLesson = nextLesson || nextUp.nextUpPath
+      const hasNextLesson = nextLesson
       const progress = getProgress(lessonView)
       if (!hasNextLesson && progress?.rate_url) {
         send('RATE')
@@ -307,7 +302,7 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
       setWatchCount(
         Number(
           cookieUtil.set(`egghead-watch-count`, 0, {
-            expires: 7,
+            expires: 15,
           }),
         ),
       )
@@ -442,9 +437,7 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                       <OverlayWrapper>
                         <NextUpOverlay
                           lesson={lesson}
-                          send={send}
                           nextLesson={nextLesson}
-                          nextUp={nextUp}
                           onClickRewatch={() => {
                             send('VIEW')
                             if (actualPlayerRef.current) {
@@ -494,13 +487,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
               </div>
               <div className="relative h-full">
                 <div className="absolute top-0 bottom-0 left-0 right-0">
-                  {!playerState.matches('loading') && !collection && nextUp && (
-                    <NextUpList
-                      nextUp={nextUp}
-                      currentLessonSlug={lesson.slug}
-                      nextToVideo
-                    />
-                  )}
                   {collection && collection.lessons && (
                     <CollectionLessonsList
                       course={collection}
@@ -646,7 +632,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                     tags={tags}
                     description={description}
                     course={collection}
-                    nextUp={nextUp}
                     lesson={lesson}
                     playerState={playerState}
                     className="space-y-6"

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -28,7 +28,6 @@ import {useEnhancedTranscript} from 'hooks/use-enhanced-transcript'
 import useLastResource from 'hooks/use-last-resource'
 import SortingHat from 'components/survey/sorting-hat'
 import getAccessTokenFromCookie from 'utils/get-access-token-from-cookie'
-import AutoplayToggle from 'components/pages/lessons/autoplay-toggle'
 import RecommendNextStepOverlay from 'components/pages/lessons/overlay/recommend-next-step-overlay'
 import Markdown from 'react-markdown'
 import Link from 'next/link'
@@ -47,7 +46,6 @@ import CodeLink, {
   IconGithub,
 } from 'components/pages/lessons/code-link'
 import getDependencies from 'data/courseDependencies'
-import TheaterModeToggle from 'components/pages/lessons/theater-mode-toggle'
 
 const tracer = getTracer('lesson-page')
 
@@ -119,7 +117,7 @@ const MAX_FREE_VIEWS = 7
 
 const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
   const {md} = useBreakpoint()
-  const {theater, setPlayerPrefs} = useEggheadPlayerPrefs()
+  const {setPlayerPrefs} = useEggheadPlayerPrefs()
   const {height} = useWindowSize()
   const [ref, {width: videoWidth}] = useMeasure<any>()
   const HEADER_HEIGHT = 80

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -126,15 +126,8 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
   const CONTENT_OFFSET = height < 450 ? 30 : 120
   const HEIGHT_OFFSET = HEADER_HEIGHT + CONTENT_OFFSET
   const [lessonMaxWidth, setLessonMaxWidth] = React.useState(0)
-  const [theaterMode, setTheaterMode] = React.useState(theater || false)
   const [media, setMedia] = React.useState<any>()
-  const toggleTheaterMode = () => {
-    setPlayerPrefs({theater: !theaterMode})
-    setTheaterMode(!theaterMode)
-  }
-  const theaterModeOn = () => {
-    setTheaterMode(true)
-  }
+
   const [lesson, setLesson] = React.useState<any>(initialLesson)
   const router = useRouter()
   const playerRef = React.useRef(null)
@@ -326,18 +319,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
   }, [initialLesson.slug])
 
   React.useEffect(() => {
-    if (md) {
-      theaterModeOn()
-      window.addEventListener('resize', theaterModeOn)
-    } else {
-      setTheaterMode(theater)
-    }
-    return () => {
-      window.removeEventListener('resize', theaterModeOn)
-    }
-  }, [md, theater])
-
-  React.useEffect(() => {
     setLessonMaxWidth(Math.round((height - HEIGHT_OFFSET) * 1.77))
   }, [height])
 
@@ -509,66 +490,36 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                 </div>
               </div>
             </div>
-            {!theaterMode && (
-              <div className="flex flex-shrink-0 bg-white flex-col 2xl:w-1/5 w-3/12 border-l border-gray-100">
-                <div className="p-4 border-b border-gray-100">
-                  <Course course={collection} currentLessonSlug={lesson.slug} />
-                </div>
-                <div className="relative h-full">
-                  <div className="absolute top-0 bottom-0 left-0 right-0">
-                    {!playerState.matches('loading') &&
-                      !collection &&
-                      nextUp &&
-                      !theaterMode && (
-                        <NextUpList
-                          nextUp={nextUp}
-                          currentLessonSlug={lesson.slug}
-                          nextToVideo
-                        />
-                      )}
-                    {collection && collection.lessons && !theaterMode && (
-                      <CollectionLessonsList
-                        course={collection}
-                        currentLessonSlug={lesson.slug}
-                        progress={lessonView?.collection_progress}
-                        nextToVideo
-                      />
-                    )}
-                  </div>
-                </div>
-                <div className="xl:py-4 py-2 xl:px-4 px-2 flex items-center justify-between border-t border-gray-100">
-                  {/*<AutoplayToggle enabled={playerVisible && next_up_url} />*/}
-                  <TheaterModeToggle
-                    toggleTheaterMode={toggleTheaterMode}
-                    theaterMode={theaterMode}
-                  />
+            <div className="flex flex-shrink-0 bg-white flex-col 2xl:w-1/5 w-3/12 border-l border-gray-100">
+              <div className="p-4 border-b border-gray-100">
+                <Course course={collection} currentLessonSlug={lesson.slug} />
+              </div>
+              <div className="relative h-full">
+                <div className="absolute top-0 bottom-0 left-0 right-0">
+                  {!playerState.matches('loading') && !collection && nextUp && (
+                    <NextUpList
+                      nextUp={nextUp}
+                      currentLessonSlug={lesson.slug}
+                      nextToVideo
+                    />
+                  )}
+                  {collection && collection.lessons && (
+                    <CollectionLessonsList
+                      course={collection}
+                      currentLessonSlug={lesson.slug}
+                      progress={lessonView?.collection_progress}
+                      nextToVideo
+                    />
+                  )}
                 </div>
               </div>
-            )}
-          </div>
-          {theaterMode && (
-            <div
-              className="flex items-center justify-end py-2 px-3 text-white space-x-5 mx-auto"
-              css={{maxWidth: lessonMaxWidth}}
-            >
-              {/*<AutoplayToggle onDark enabled={playerVisible && next_up_url} />*/}
-              {!md && (
-                <TheaterModeToggle
-                  toggleTheaterMode={toggleTheaterMode}
-                  theaterMode={theaterMode}
-                />
-              )}
             </div>
-          )}
+          </div>
         </div>
 
         <div>
           <div
-            className={`grid ${
-              theaterMode
-                ? 'lg:grid-cols-12 max-w-screen-xl'
-                : 'lg:grid-cols-1 max-w-screen-lg'
-            } lg:gap-12 gap-8 grid-cols-1 mx-auto divide-y md:divide-transparent divide-gray-50`}
+            className={`grid lg:grid-cols-1 max-w-screen-lg lg:gap-12 gap-8 grid-cols-1 mx-auto divide-y md:divide-transparent divide-gray-50`}
           >
             <div className="md:col-span-8 md:row-start-1 row-start-1 md:space-y-10 space-y-6">
               <div className="space-y-4">
@@ -577,41 +528,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                   <h1 className="font-extrabold tracking-tight leading-tighter text-xl lg:text-3xl">
                     {title}
                   </h1>
-                )}
-                <div className="sm:text-base text-sm sm:pt-2 w-full flex sm:items-center sm:flex-row flex-col sm:space-x-6 sm:space-y-0 space-y-2">
-                  {lesson?.code_url && (
-                    <CodeLink
-                      onClick={() => {
-                        track(`clicked open code`, {
-                          lesson: lesson.slug,
-                        })
-                      }}
-                      url={lesson.code_url}
-                      icon={<IconCode />}
-                    >
-                      Open code for this lesson
-                    </CodeLink>
-                  )}
-                  {lesson?.repo_url && (
-                    <CodeLink
-                      onClick={() => {
-                        track(`clicked open github`, {
-                          lesson: lesson.slug,
-                        })
-                      }}
-                      url={lesson.repo_url}
-                      icon={<IconGithub />}
-                    >
-                      Open code on GitHub
-                    </CodeLink>
-                  )}
-                  <LessonDownload lesson={lesson} />
-                </div>
-
-                {description && (
-                  <Markdown className="prose sm:prose-xl max-w-none font-medium">
-                    {description}
-                  </Markdown>
                 )}
                 <div className="pt-4 flex md:flex-row flex-col w-full justify-between flex-wrap md:space-x-8 md:space-y-0 space-y-5 md:items-center">
                   <div className="md:w-auto w-full flex justify-between items-center space-x-5">
@@ -685,30 +601,46 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                     </div>
                   </div>
                 </div>
+                <div className="sm:text-base text-sm sm:pt-2 w-full flex sm:items-center sm:flex-row flex-col sm:space-x-6 sm:space-y-0 space-y-2">
+                  {lesson?.code_url && (
+                    <CodeLink
+                      onClick={() => {
+                        track(`clicked open code`, {
+                          lesson: lesson.slug,
+                        })
+                      }}
+                      url={lesson.code_url}
+                      icon={<IconCode />}
+                    >
+                      Open code for this lesson
+                    </CodeLink>
+                  )}
+                  {lesson?.repo_url && (
+                    <CodeLink
+                      onClick={() => {
+                        track(`clicked open github`, {
+                          lesson: lesson.slug,
+                        })
+                      }}
+                      url={lesson.repo_url}
+                      icon={<IconGithub />}
+                    >
+                      Open code on GitHub
+                    </CodeLink>
+                  )}
+                  <LessonDownload lesson={lesson} />
+                </div>
+
+                {description && (
+                  <Markdown className="prose sm:prose-xl max-w-none font-medium">
+                    {description}
+                  </Markdown>
+                )}
               </div>
               {md && (
                 <>
                   <Course course={collection} currentLessonSlug={lesson.slug} />
-                  {!playerState.matches('loading') &&
-                    !collection &&
-                    nextUp &&
-                    theaterMode && (
-                      <div className="bg-yellow-500">
-                        <NextUpList
-                          nextUp={nextUp}
-                          currentLessonSlug={lesson.slug}
-                          nextToVideo={false}
-                        />
-                      </div>
-                    )}
-                  {collection && collection.lessons && theaterMode && (
-                    <CollectionLessonsList
-                      course={collection}
-                      currentLessonSlug={lesson.slug}
-                      progress={lessonView?.collection_progress}
-                      nextToVideo={false}
-                    />
-                  )}
+
                   <LessonInfo
                     autoplay={{enabled: false}}
                     title={title}
@@ -748,53 +680,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                 </TabPanels>
               </Tabs>
             </div>
-            {theaterMode && (
-              <div className="md:col-span-4 flex flex-col space-y-4">
-                {!md && (
-                  <>
-                    <Course
-                      course={collection}
-                      currentLessonSlug={lesson.slug}
-                    />
-                    {!playerState.matches('loading') &&
-                      !collection &&
-                      nextUp &&
-                      theaterMode && (
-                        <NextUpList
-                          nextUp={nextUp}
-                          currentLessonSlug={lesson.slug}
-                          nextToVideo={false}
-                        />
-                      )}
-                    {collection && collection.lessons && theaterMode && (
-                      <CollectionLessonsList
-                        course={collection}
-                        currentLessonSlug={lesson.slug}
-                        progress={lessonView?.collection_progress}
-                        nextToVideo={false}
-                      />
-                    )}
-                  </>
-                )}
-
-                {!md && (
-                  <>
-                    <LessonInfo
-                      autoplay={{enabled: false}}
-                      title={title}
-                      instructor={instructor}
-                      tags={tags}
-                      description={description}
-                      course={collection}
-                      nextUp={nextUp}
-                      lesson={lesson}
-                      playerState={playerState}
-                      className="space-y-6"
-                    />
-                  </>
-                )}
-              </div>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
The implementation for "theater mode" was complicated so I'd like to focus on the very basic aspects of the page and then we can expand when those are rock solid.

It was making it difficult to update because it required multiple touch points for any change.

![](https://media.giphy.com/media/xT1XGBvFlMhqaizyUw/giphy-downsized.gif)