### PR TITLE
Hide Comments tab if no comments

### DIFF
--- a/src/components/pages/lessons/Transcript_.tsx
+++ b/src/components/pages/lessons/Transcript_.tsx
@@ -93,8 +93,6 @@ const Transcript: FunctionComponent<TranscriptProps> = ({
     return null
   }
 
-  console.log({transcript, enhancedTranscript})
-
   return (
     <>
       <ReactMarkdown

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -740,9 +740,7 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                 </>
               )}
               <Tabs
-                defaultIndex={
-                  defaultView === 'comments' && commentsAvailable ? 1 : 0
-                }
+                index={defaultView === 'comments' && commentsAvailable ? 1 : 0}
                 onChange={(index) => {
                   setPlayerPrefs({
                     defaultView:

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -754,7 +754,7 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
               >
                 <TabList className="md:text-lg text-normal font-semibold bg-transparent space-x-1">
                   {transcriptAvailable && <Tab>Transcript</Tab>}
-                  <Tab>Comments</Tab>
+                  {commentsAvailable && <Tab>Comments</Tab>}
                 </TabList>
                 <TabPanels className="md:mt-6 mt-3">
                   {transcriptAvailable && (


### PR DESCRIPTION
1. `Comments` tab is hidden now if there are no comments
2. Fixed default tab index we store in cookies

![1](https://user-images.githubusercontent.com/1519448/104750444-ca71de80-575c-11eb-9ba4-43e88bf9e8e2.jpg)

vs

![2](https://user-images.githubusercontent.com/1519448/104750452-ccd43880-575c-11eb-91fd-638c49ebc967.jpg)


![](https://media2.giphy.com/media/453QsWPQj5bsQaqp8M/200.gif?cid=5a38a5a2prr5btqosuxibyu6h8t6q5nhudd9d50ldhkq0h3e&rid=200.gif)
