### PR TITLE
added modern js essentials for react to dependencies list to update i…

### DIFF
--- a/src/data/courseDependenciesData.js
+++ b/src/data/courseDependenciesData.js
@@ -3316,6 +3316,12 @@ const courseDependencyData = (courseSlug) =>
           typescript: '^3.2.1',
         },
       },
+      {
+        slug: 'modern-javascript-essentials-for-react',
+        dependencies: {
+          javascript: 'ES6',
+        },
+      },
     ],
     {slug: courseSlug},
   )


### PR DESCRIPTION
![](https://media3.giphy.com/media/bAplZhiLAsNnG/200.gif?cid=5a38a5a2gak0nezkjmmk4p5yxj82cqcfepio80r8cxma0mvo&rid=200.gif)

Added modern js essentials for React to dependencies list to update it to a playlist from a course. This I believe should fix the issue of the broken link on https://egghead.io/learn/react/beginners/js-before-react.