### PR TITLE
Add Email Change flow to Account Mgmt page

### DIFF
--- a/src/pages/accounts/[slug].tsx
+++ b/src/pages/accounts/[slug].tsx
@@ -7,6 +7,105 @@ import axios from 'axios'
 import Link from 'next/link'
 import {useViewer} from 'context/viewer-context'
 import {track} from '../../utils/analytics'
+import {Formik} from 'formik'
+import * as yup from 'yup'
+
+const editEmailSchema = yup.object().shape({
+  email: yup.string().email().required('enter your email'),
+})
+
+export type EditEmailFormProps = {
+  originalEmail: string
+}
+
+const EditEmailForm: React.FunctionComponent<EditEmailFormProps> = ({
+  originalEmail,
+}) => {
+  const VIEW_MODE = 'VIEW_MODE'
+  const EDIT_MODE = 'EDIT_MODE'
+  const [mode, setMode] = React.useState(VIEW_MODE)
+
+  return (
+    <Formik
+      initialValues={{email: originalEmail}}
+      validationSchema={editEmailSchema}
+      onSubmit={(values) => {
+        // need to validate that this email is available
+        // validateEmail(values.email)
+        console.log(values.email)
+        setMode(VIEW_MODE)
+      }}
+    >
+      {(props) => {
+        const {
+          values,
+          isSubmitting,
+          handleChange,
+          handleBlur,
+          handleSubmit,
+          setFieldValue,
+        } = props
+        return (
+          <>
+            <form onSubmit={handleSubmit}>
+              <div className="flex flex-col space-y-2">
+                <h2 className="text-xl border-b">Email</h2>
+                <p>Your email address:</p>
+                {mode === EDIT_MODE && (
+                  <p className="text-sm text-gray-600">
+                    Warning: this is the email you'll use to access egghead,
+                    make sure it is an account you have access to.
+                  </p>
+                )}
+                <div className="flex flex-row space-x-2">
+                  <input
+                    id="email"
+                    type="email"
+                    value={values.email}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="you@company.com"
+                    required
+                    disabled={mode !== EDIT_MODE}
+                    className="bg-gray-200 focus:outline-none focus:shadow-outline border border-gray-300 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
+                    // className="form-input bg-gray-100 rounded-md p-3 w-full border border-transparent focus:outline-none focus:border-gray-400 placeholder-gray-600"
+                  />
+                  {mode === VIEW_MODE && (
+                    <button
+                      onClick={() => setMode(EDIT_MODE)}
+                      className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
+                    >
+                      Edit
+                    </button>
+                  )}
+                  {mode === EDIT_MODE && (
+                    <>
+                      <button
+                        type="submit"
+                        className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
+                      >
+                        Save
+                      </button>
+                      <button
+                        onClick={() => {
+                          setFieldValue('email', originalEmail)
+                          setMode(VIEW_MODE)
+                        }}
+                        className="text-black bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-gray-300 rounded"
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </form>
+          </>
+        )
+      }}
+    </Formik>
+  )
+}
 
 export const getServerSideProps: GetServerSideProps = async function ({
   req,
@@ -36,6 +135,8 @@ const Account: React.FunctionComponent<
   const [subscriptionData, setSubscriptionData] = React.useState<any>()
   const {stripe_customer_id, slug} = account
   const {viewer} = useViewer()
+
+  const [email, setEmail] = React.useState('josh@egghead.io')
 
   const recur = (price: any) => {
     const {
@@ -77,6 +178,10 @@ const Account: React.FunctionComponent<
     <LoginRequired loginRequired={loginRequired}>
       <main className="pb-10 lg:py-3 lg:px-8">
         <div className="lg:grid lg:grid-cols-12 lg:gap-x-5">
+          {/* Account details */}
+          <div className="sm:px-6 lg:px-0 lg:col-span-9">
+            <EditEmailForm originalEmail={email} />
+          </div>
           {/* Payment details */}
           <div className="sm:px-6 lg:px-0 lg:col-span-9">
             {subscriptionData && (

--- a/src/pages/accounts/[slug].tsx
+++ b/src/pages/accounts/[slug].tsx
@@ -36,12 +36,18 @@ const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProp
   const EDIT_MODE = 'EDIT_MODE'
   const [mode, setMode] = React.useState(VIEW_MODE)
 
+  const [
+    changeRequestSubmittedFor,
+    setChangeRequestSubmittedFor,
+  ] = React.useState<string | null>(null)
+
   return (
     <Formik
       initialValues={{email: originalEmail}}
       validationSchema={emailChangeSchema}
       onSubmit={async (values) => {
         await requestEmailChange(values.email)
+        setChangeRequestSubmittedFor(values.email)
         setMode(VIEW_MODE)
       }}
     >
@@ -66,11 +72,17 @@ const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProp
                     will send an email to that account with a confirmation link.
                   </p>
                 )}
+                {changeRequestSubmittedFor && (
+                  <p className="text-sm text-gray-600">
+                    Your email change request has been received. A confirmation
+                    email has been sent to {changeRequestSubmittedFor}.
+                  </p>
+                )}
                 <div className="flex flex-row space-x-2">
                   <input
                     id="email"
                     type="email"
-                    value={values.email}
+                    value={mode === VIEW_MODE ? originalEmail : values.email}
                     onChange={handleChange}
                     onBlur={handleBlur}
                     placeholder="you@company.com"

--- a/src/pages/accounts/[slug].tsx
+++ b/src/pages/accounts/[slug].tsx
@@ -157,8 +157,6 @@ const Account: React.FunctionComponent<
   const {stripe_customer_id, slug} = account
   const {viewer} = useViewer()
 
-  console.log(viewer)
-
   const {email: currentEmail} = viewer || {}
 
   const recur = (price: any) => {

--- a/src/pages/email-change-request/[token].tsx
+++ b/src/pages/email-change-request/[token].tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import LoginRequired from 'components/login-required'
+import axios from 'axios'
+import {useRouter} from 'next/router'
+import {useViewer} from 'context/viewer-context'
+import isEmpty from 'lodash/isEmpty'
+
+async function confirmEmailChangeRequest(token: any) {
+  const {data} = await axios.get(
+    `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/email_change_requests/${token}`,
+  )
+
+  return data
+}
+
+const EmailChangeRequest: React.FunctionComponent = () => {
+  const router = useRouter()
+  const {token} = router.query
+  const {viewer, refreshUser} = useViewer()
+
+  return (
+    <LoginRequired>
+      <section className="mb-32">
+        <div className="p-4 w-full">
+          <div className="w-full mx-auto md:py-32 py-16 flex flex-col items-center justify-center text-gray-900 dark:text-trueGray-100">
+            <h2 className="text-center text-3xl leading-9 font-bold">
+              Email Change Request
+            </h2>
+            <div className="sm:mt-8 mt-4 sm:mx-auto sm:w-full sm:max-w-xl">
+              <p className="text-center pb-8">
+                Click 'confirm' to complete your email change request.
+              </p>
+              <div className="flex justify-center items-center w-full">
+                <button
+                  className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
+                  onClick={async () => {
+                    const data = await confirmEmailChangeRequest(token)
+
+                    if (data.success === true) {
+                      // refresh the user to get the latest email before redirecting
+                      await refreshUser()
+
+                      if (isEmpty(viewer.accounts)) {
+                        router.replace('/')
+                      } else {
+                        router.replace(`/accounts/${viewer.accounts[0].slug}`)
+                      }
+                    }
+                  }}
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </LoginRequired>
+  )
+}
+
+export default EmailChangeRequest


### PR DESCRIPTION
This PR introduces an email change flow.

1. An authenticated user can request a change to their email from Acct Mgmt
2. The user will receive an email at the new email address with a Change Request confirmation link
3. egghead-next renders the confirmation page with a 'Confirm' button
4. If the authenticated user clicks the 'Confirm' button, their request will be completed

Here is a video of the end-to-end flow:

https://user-images.githubusercontent.com/694063/105902902-db381500-5fe4-11eb-82c2-35bd43bf5aff.mp4

A couple notes:
- The styling could use some work. I took an MVP approach to that.
- As you may have noticed at the end of the video, it required a refresh of the page to see the updated email on Acct Mgmt. I'm struggling to get through the tangle of `viewer-context` to allow the updated email to flow through. I'd appreciate any insights or an assist on getting that piece polished.


![](https://media0.giphy.com/media/efUcLJePY6RkA/200.gif?cid=5a38a5a2hhrj4pk0dzdcagtvar093b6qmkpxt7jh6arjoilw&rid=200.gif)
