### PR TITLE
adds a generic topic/tag header

### DIFF
--- a/src/components/search/generic-topic.tsx
+++ b/src/components/search/generic-topic.tsx
@@ -1,0 +1,66 @@
+import React, {FunctionComponent} from 'react'
+import Markdown from 'react-markdown'
+import Image from 'next/image'
+import {NextSeo} from 'next-seo'
+
+type TopicProps = {
+  title: string
+  children?: string
+  imageUrl?: string
+  className?: string
+  description?: string
+}
+
+const GenericTopic: FunctionComponent<TopicProps> = ({
+  title,
+  children,
+  className,
+  imageUrl,
+  description,
+}) => {
+  return (
+    <>
+      <NextSeo
+        description={description}
+        title={title}
+        titleTemplate={'Learn %s | egghead.io'}
+        twitter={{
+          site: `@eggheadio`,
+          cardType: 'summary',
+        }}
+        openGraph={{
+          title,
+          description: description,
+          site_name: 'egghead',
+          images: [
+            {
+              url: imageUrl || '',
+            },
+          ],
+        }}
+      />
+      <div
+        className={`bg-white dark:bg-gray-800 dark:text-gray-200 grid grid-cols-8 h-full relative items-start overflow-hidden rounded-md  ${
+          className ? className : ''
+        }`}
+      >
+        {imageUrl && (
+          <div className="overflow-hidden sm:col-span-2 col-span-2 w-full h-full p-6">
+            <Image src={imageUrl} width={480} height={480} />
+          </div>
+        )}
+        <div className="sm:col-span-6 col-span-6 sm:p-8 p-4 sm:pr-3 flex flex-col justify-start h-full">
+          <h1 className="sm:text-2xl text-xl font-bold">{title}</h1>
+          {description && (
+            <Markdown
+              source={description}
+              className="prose dark:prose-dark pt-2 sm:text-base text-sm leading-normal text-gray-800 dark:text-gray-200 mt-0"
+            />
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default GenericTopic

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -88,6 +88,8 @@ const Search: FunctionComponent<SearchProps> = ({
     )
   }
 
+  console.debug(`topic check`, topic)
+
   return (
     <>
       <Head>
@@ -164,14 +166,14 @@ const Search: FunctionComponent<SearchProps> = ({
                   <SearchReact />
                 </motion.div>
               )}
-              {topic && topic.slug !== 'react' && (
-                <GenericTopic
-                  title={topic.label}
-                  imageUrl={topic.image_480_url}
-                  description={topic.description}
-                />
-              )}
             </AnimatePresence>
+            {!isEmpty(topic) && topic.slug !== 'react' && (
+              <GenericTopic
+                title={topic.label}
+                imageUrl={topic.image_480_url}
+                description={topic.description}
+              />
+            )}
             <motion.div
               className="max-w-screen-xl mx-auto"
               layout

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -22,6 +22,8 @@ import SearchReact from 'components/search/curated/react'
 import ReactMarkdown from 'react-markdown'
 import {NextSeo} from 'next-seo'
 import {isArray} from 'lodash'
+import Topic from './components/topic'
+import GenericTopic from './generic-topic'
 
 const ALGOLIA_INDEX_NAME =
   process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || 'content_production'
@@ -30,6 +32,7 @@ type SearchProps = {
   searchClient?: any
   searchState?: any
   instructor?: any
+  topic?: any
 }
 
 const Search: FunctionComponent<SearchProps> = ({
@@ -37,6 +40,7 @@ const Search: FunctionComponent<SearchProps> = ({
   searchClient,
   searchState,
   instructor,
+  topic,
   ...rest
 }) => {
   const [isFilterShown, setShowFilter] = useToggle(false)
@@ -82,6 +86,18 @@ const Search: FunctionComponent<SearchProps> = ({
       noInstructorsSelected(searchState) &&
       onlyTheseTagsSelected(isArray(topics) ? topics : [topics], searchState)
     )
+  }
+
+  topic && console.debug(`the topic is: ${topic.label}`, topic)
+
+  let TopicComponent: React.FunctionComponent<any> = () => <div />
+
+  switch (topic) {
+    case 'react':
+      TopicComponent = SearchReact
+      break
+    default:
+      TopicComponent = Topic
   }
 
   return (
@@ -159,6 +175,13 @@ const Search: FunctionComponent<SearchProps> = ({
                 >
                   <SearchReact />
                 </motion.div>
+              )}
+              {topic && topic.slug !== 'react' && (
+                <GenericTopic
+                  title={topic.label}
+                  imageUrl={topic.image_480_url}
+                  description={topic.description}
+                />
               )}
             </AnimatePresence>
             <motion.div

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -88,18 +88,6 @@ const Search: FunctionComponent<SearchProps> = ({
     )
   }
 
-  topic && console.debug(`the topic is: ${topic.label}`, topic)
-
-  let TopicComponent: React.FunctionComponent<any> = () => <div />
-
-  switch (topic) {
-    case 'react':
-      TopicComponent = SearchReact
-      break
-    default:
-      TopicComponent = Topic
-  }
-
   return (
     <>
       <Head>

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -14,7 +14,6 @@ export function getTags() {
 }
 
 export async function getTag(slug: string) {
-  console.log('****', slug)
   const endpoint = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/tags/${slug}`
   const {data} = await axios.get(endpoint)
 

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -14,6 +14,7 @@ export function getTags() {
 }
 
 export async function getTag(slug: string) {
+  console.log('****', slug)
   const endpoint = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/tags/${slug}`
   const {data} = await axios.get(endpoint)
 

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -179,14 +179,13 @@ export const getServerSideProps: GetServerSideProps = async function ({
   const selectedTopics = initialSearchState.refinementList?._tags
 
   if (selectedTopics?.length === 1 && !selectedTopics.includes('undefined')) {
-    console.log('SELECTED TOPICS', selectedTopics)
     const topic = first<string>(selectedTopics)
     try {
       if (topic) {
         initialTopic = await getTag(topic)
       }
     } catch (error) {
-      console.error(error.config.url)
+      console.error(error)
     }
   }
 


### PR DESCRIPTION
This is low effort, but adds a generic topic header for all filtered landing pages:

![image](https://user-images.githubusercontent.com/86834/106042196-90c0a200-6091-11eb-9953-c6c5962642a1.png)


![](https://media.giphy.com/media/yZBcp2lnHfgHr42n7R/giphy.gif)