### PR TITLE
Allow any user with egghead account to view "account management" page

### DIFF
--- a/src/components/app/header.tsx
+++ b/src/components/app/header.tsx
@@ -69,35 +69,14 @@ const Header: FunctionComponent = () => {
                 </a>
               </Link>
             )}
-            {!isEmpty(viewer.accounts) ? (
-              <Link href={`/accounts/${viewer.accounts[0].slug}`}>
-                <a
-                  onClick={() =>
-                    track('clicked account', {
-                      location: 'header',
-                    })
-                  }
-                  className="flex items-center space-x-2 p-3 hover:text-blue-700 hover:underline"
-                >
-                  <img
-                    alt="avatar"
-                    className="w-8 rounded-full"
-                    src={viewer.avatar_url}
-                  />
-                  <span>
-                    {viewer.name}
-                    {viewer.is_pro && ' ⭐️'}
-                  </span>
-                </a>
-              </Link>
-            ) : (
-              <div
-                className="flex items-center space-x-2 p-3"
-                onClick={() => {
-                  track(`clicked user name area`, {
+            <Link href="/user">
+              <a
+                onClick={() =>
+                  track('clicked account', {
                     location: 'header',
                   })
-                }}
+                }
+                className="flex items-center space-x-2 p-3 hover:text-blue-700 hover:underline"
               >
                 <img
                   alt="avatar"
@@ -108,8 +87,8 @@ const Header: FunctionComponent = () => {
                   {viewer.name}
                   {viewer.is_pro && ' ⭐️'}
                 </span>
-              </div>
-            )}
+              </a>
+            </Link>
             <DarkModeToggle />
           </div>
         ) : (

--- a/src/components/users/request-email-change-form.tsx
+++ b/src/components/users/request-email-change-form.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import {Formik} from 'formik'
+import * as yup from 'yup'
+import axios from 'axios'
+
+const emailChangeSchema = yup.object().shape({
+  email: yup.string().email().required('enter your email'),
+})
+
+export type RequestEmailChangeFormProps = {
+  originalEmail: string
+}
+
+async function requestEmailChange(newEmail: string) {
+  const {data} = await axios.post(
+    `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/email_change_requests`,
+    {
+      email: newEmail,
+    },
+  )
+
+  return data
+}
+
+const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProps> = ({
+  originalEmail,
+}) => {
+  const VIEW_MODE = 'VIEW_MODE'
+  const EDIT_MODE = 'EDIT_MODE'
+  const [mode, setMode] = React.useState(VIEW_MODE)
+
+  const [
+    changeRequestSubmittedFor,
+    setChangeRequestSubmittedFor,
+  ] = React.useState<string | null>(null)
+
+  return (
+    <Formik
+      initialValues={{email: originalEmail}}
+      validationSchema={emailChangeSchema}
+      onSubmit={async (values) => {
+        await requestEmailChange(values.email)
+        setChangeRequestSubmittedFor(values.email)
+        setMode(VIEW_MODE)
+      }}
+    >
+      {(props) => {
+        const {
+          values,
+          isSubmitting,
+          handleChange,
+          handleBlur,
+          handleSubmit,
+          setFieldValue,
+        } = props
+        return (
+          <form onSubmit={handleSubmit}>
+            <div className="flex flex-col space-y-2">
+              <h2 className="text-xl border-b">Email</h2>
+              <p>Your email address:</p>
+              {mode === EDIT_MODE && (
+                <p className="text-sm text-gray-600">
+                  To ensure that you have access to this email address, we will
+                  send an email to that account with a confirmation link.
+                </p>
+              )}
+              {changeRequestSubmittedFor && (
+                <p className="text-sm text-gray-600">
+                  Your email change request has been received. A confirmation
+                  email has been sent to {changeRequestSubmittedFor}.
+                </p>
+              )}
+              <div className="flex flex-row space-x-2">
+                <input
+                  id="email"
+                  type="email"
+                  value={mode === VIEW_MODE ? originalEmail : values.email}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="you@company.com"
+                  required
+                  disabled={isSubmitting || mode !== EDIT_MODE}
+                  className="bg-gray-200 focus:outline-none focus:shadow-outline border border-gray-300 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
+                />
+                {mode === VIEW_MODE && (
+                  <button
+                    onClick={() => setMode(EDIT_MODE)}
+                    className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
+                  >
+                    Edit
+                  </button>
+                )}
+                {mode === EDIT_MODE && (
+                  <>
+                    <button
+                      type="submit"
+                      className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
+                      disabled={isSubmitting}
+                    >
+                      Submit
+                    </button>
+                    <button
+                      onClick={() => {
+                        setFieldValue('email', originalEmail)
+                        setMode(VIEW_MODE)
+                      }}
+                      className="text-black bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-gray-300 rounded"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          </form>
+        )
+      }}
+    </Formik>
+  )
+}
+
+export default RequestEmailChangeForm

--- a/src/pages/api/stripe/billing/session.ts
+++ b/src/pages/api/stripe/billing/session.ts
@@ -13,13 +13,9 @@ const StripeCheckoutSession = async (
 
       if (!customer_id) throw new Error('no customer id')
 
-      const account_slug = req.query.account_slug
-
       const session = await stripe.billingPortal.sessions.create({
         customer: customer_id,
-        return_url: account_slug
-          ? `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/accounts/${account_slug}`
-          : process.env.NEXT_PUBLIC_DEPLOYMENT_URL,
+        return_url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/user`,
       })
       if (!session)
         throw new Error(`no session loaded for ${req.query.session_id}`)

--- a/src/pages/email-change-request/[token].tsx
+++ b/src/pages/email-change-request/[token].tsx
@@ -40,11 +40,7 @@ const EmailChangeRequest: React.FunctionComponent = () => {
                       // refresh the user to get the latest email before redirecting
                       await refreshUser()
 
-                      if (isEmpty(viewer.accounts)) {
-                        router.replace('/')
-                      } else {
-                        router.replace(`/accounts/${viewer.accounts[0].slug}`)
-                      }
+                      router.replace('/user')
                     }
                   }}
                 >

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -72,7 +72,6 @@ const User: React.FunctionComponent<
       minimumFractionDigits: 0,
     }).format(subscriptionData.price.unit_amount / 100)
 
-  // TODO: Do I need to add loginRequired prop back in below
   return (
     <LoginRequired>
       <main className="pb-10 lg:py-3 lg:px-8">

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -36,7 +36,7 @@ const User: React.FunctionComponent<
   }
 
   React.useEffect(() => {
-    const loadAccountForSlug = async (slug) => {
+    const loadAccountForSlug = async (slug: undefined | string) => {
       if (slug) {
         const account: any = await loadAccount(slug, authToken)
         setAccount(account)

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import {loadAccount} from 'lib/accounts'
-import {GetServerSideProps} from 'next'
-import {getTokenFromCookieHeaders} from 'utils/auth'
 import LoginRequired, {LoginRequiredParams} from 'components/login-required'
 import axios from 'axios'
 import Link from 'next/link'

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -7,157 +7,24 @@ import axios from 'axios'
 import Link from 'next/link'
 import {useViewer} from 'context/viewer-context'
 import {track} from '../../utils/analytics'
-import {Formik} from 'formik'
-import * as yup from 'yup'
-
-const emailChangeSchema = yup.object().shape({
-  email: yup.string().email().required('enter your email'),
-})
-
-export type RequestEmailChangeFormProps = {
-  originalEmail: string
-}
-
-async function requestEmailChange(newEmail: string) {
-  const {data} = await axios.post(
-    `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/email_change_requests`,
-    {
-      email: newEmail,
-    },
-  )
-
-  return data
-}
-
-const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProps> = ({
-  originalEmail,
-}) => {
-  const VIEW_MODE = 'VIEW_MODE'
-  const EDIT_MODE = 'EDIT_MODE'
-  const [mode, setMode] = React.useState(VIEW_MODE)
-
-  const [
-    changeRequestSubmittedFor,
-    setChangeRequestSubmittedFor,
-  ] = React.useState<string | null>(null)
-
-  return (
-    <Formik
-      initialValues={{email: originalEmail}}
-      validationSchema={emailChangeSchema}
-      onSubmit={async (values) => {
-        await requestEmailChange(values.email)
-        setChangeRequestSubmittedFor(values.email)
-        setMode(VIEW_MODE)
-      }}
-    >
-      {(props) => {
-        const {
-          values,
-          isSubmitting,
-          handleChange,
-          handleBlur,
-          handleSubmit,
-          setFieldValue,
-        } = props
-        return (
-          <>
-            <form onSubmit={handleSubmit}>
-              <div className="flex flex-col space-y-2">
-                <h2 className="text-xl border-b">Email</h2>
-                <p>Your email address:</p>
-                {mode === EDIT_MODE && (
-                  <p className="text-sm text-gray-600">
-                    To ensure that you have access to this email address, we
-                    will send an email to that account with a confirmation link.
-                  </p>
-                )}
-                {changeRequestSubmittedFor && (
-                  <p className="text-sm text-gray-600">
-                    Your email change request has been received. A confirmation
-                    email has been sent to {changeRequestSubmittedFor}.
-                  </p>
-                )}
-                <div className="flex flex-row space-x-2">
-                  <input
-                    id="email"
-                    type="email"
-                    value={mode === VIEW_MODE ? originalEmail : values.email}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                    placeholder="you@company.com"
-                    required
-                    disabled={isSubmitting || mode !== EDIT_MODE}
-                    className="bg-gray-200 focus:outline-none focus:shadow-outline border border-gray-300 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
-                  />
-                  {mode === VIEW_MODE && (
-                    <button
-                      onClick={() => setMode(EDIT_MODE)}
-                      className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
-                    >
-                      Edit
-                    </button>
-                  )}
-                  {mode === EDIT_MODE && (
-                    <>
-                      <button
-                        type="submit"
-                        className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
-                        disabled={isSubmitting}
-                      >
-                        Submit
-                      </button>
-                      <button
-                        onClick={() => {
-                          setFieldValue('email', originalEmail)
-                          setMode(VIEW_MODE)
-                        }}
-                        className="text-black bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-gray-300 rounded"
-                      >
-                        Cancel
-                      </button>
-                    </>
-                  )}
-                </div>
-              </div>
-            </form>
-          </>
-        )
-      }}
-    </Formik>
-  )
-}
-
-export const getServerSideProps: GetServerSideProps = async function ({
-  req,
-  params,
-}) {
-  const {loginRequired, eggheadToken} = getTokenFromCookieHeaders(
-    req.headers.cookie as string,
-  )
-  const account: any =
-    params?.slug && (await loadAccount(params.slug as string, eggheadToken))
-  return {
-    props: {
-      loginRequired,
-      account,
-    },
-  }
-}
+import RequestEmailChangeForm from 'components/users/request-email-change-form'
+import get from 'lodash/get'
 
 type ViewerAccount = {
   stripe_customer_id: string
   slug: string
 }
 
-const Account: React.FunctionComponent<
+const User: React.FunctionComponent<
   LoginRequiredParams & {account: ViewerAccount}
-> = ({loginRequired, account = {}}) => {
+> = () => {
+  const [account, setAccount] = React.useState<any>({})
   const [subscriptionData, setSubscriptionData] = React.useState<any>()
-  const {stripe_customer_id, slug} = account
-  const {viewer} = useViewer()
+  const {stripe_customer_id} = account
+  const {viewer, authToken} = useViewer()
 
-  const {email: currentEmail} = viewer || {}
+  const {email: currentEmail, accounts} = viewer || {}
+  const {slug} = get(accounts, '[0]', {})
 
   const recur = (price: any) => {
     const {
@@ -169,6 +36,18 @@ const Account: React.FunctionComponent<
     if (interval === 'month' && interval_count === 1) return 'month'
     if (interval === 'year' && interval_count === 1) return 'year'
   }
+
+  React.useEffect(() => {
+    const loadAccountForSlug = async (slug) => {
+      if (slug) {
+        const account: any = await loadAccount(slug, authToken)
+        setAccount(account)
+      }
+    }
+
+    loadAccountForSlug(slug)
+  }, [slug, authToken])
+
   React.useEffect(() => {
     if (stripe_customer_id) {
       axios
@@ -195,8 +74,9 @@ const Account: React.FunctionComponent<
       minimumFractionDigits: 0,
     }).format(subscriptionData.price.unit_amount / 100)
 
+  // TODO: Do I need to add loginRequired prop back in below
   return (
-    <LoginRequired loginRequired={loginRequired}>
+    <LoginRequired>
       <main className="pb-10 lg:py-3 lg:px-8">
         <div className="lg:grid lg:grid-cols-12 lg:gap-x-5">
           {/* Account details */}
@@ -312,4 +192,4 @@ const Account: React.FunctionComponent<
   )
 }
 
-export default Account
+export default User


### PR DESCRIPTION
The account management page has been restricted to users with active subscriptions. That was necessitated by the slug in the URL which corresponded to their membership. This PR moves the account management page from `/accounts/<slug>` to `/user`. It can. now be visited by anyone. Only users with an active membership will see their subscription details.


![](https://media0.giphy.com/media/3ohzdUi5U8LBb4GD4s/200.gif?cid=5a38a5a2ndgr1wf16unxixim5gxicbhoct5tnhderijecm9p&rid=200.gif)
