### PR TITLE
make a component for curated search pages

### DIFF
--- a/src/components/search/curated/angular/index.tsx
+++ b/src/components/search/curated/angular/index.tsx
@@ -1,81 +1,17 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import angularPageData from './angular-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
 const SearchAngular = () => {
-  const location = 'css landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn Angular using the best screencast tutorial videos online.`
-  const title = `In-Depth Up-to-Date Angular Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(angularPageData, {id: 'beginner'})
-  const intermediate: any = find(angularPageData, {id: 'intermediate'})
-  const advanced: any = find(angularPageData, {id: 'advanced'})
-
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/300/full/angular2.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="AWS"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/300/full/angular2.png"
-        >
-          {`
-Description of Angular
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'Angular',
+        name: 'angular',
+        description: `Description text for Angular`,
+      }}
+      pageData={angularPageData}
+    />
   )
 }
 

--- a/src/components/search/curated/angularjs/index.tsx
+++ b/src/components/search/curated/angularjs/index.tsx
@@ -1,82 +1,18 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import angularjsPageData from './angularjs-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
-const SearchAngular = () => {
-  const location = 'angularjs landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn AngularJS using the best screencast tutorial videos online.`
-  const title = `In-Depth AngularJS Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(angularjsPageData, {id: 'beginner'})
-  const intermediate: any = find(angularjsPageData, {id: 'intermediate'})
-  const advanced: any = find(angularjsPageData, {id: 'advanced'})
-
+const SearchAngularJs = () => {
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/002/full/angularjs.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="AngularJS"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/002/full/angularjs.png"
-        >
-          {`
-Description of AngularJS
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'AngularJS',
+        name: 'angularjs',
+        description: `Description text for AngularJS`,
+      }}
+      pageData={angularjsPageData}
+    />
   )
 }
 
-export default SearchAngular
+export default SearchAngularJs

--- a/src/components/search/curated/aws/index.tsx
+++ b/src/components/search/curated/aws/index.tsx
@@ -1,82 +1,18 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import awsPageData from './aws-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
-const SearchAngular = () => {
-  const location = 'aws landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn AWS using the best screencast tutorial videos online.`
-  const title = `In-Depth Up-to-Date AWS Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(awsPageData, {id: 'beginner'})
-  const intermediate: any = find(awsPageData, {id: 'intermediate'})
-  const advanced: any = find(awsPageData, {id: 'advanced'})
-
+const SearchAws = () => {
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/090/full/aws.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="AWS"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/090/full/aws.png"
-        >
-          {`
-Description of AWS
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'AWS',
+        name: 'aws',
+        description: `Description text for AWS`,
+      }}
+      pageData={awsPageData}
+    />
   )
 }
 
-export default SearchAngular
+export default SearchAws

--- a/src/components/search/curated/css/index.tsx
+++ b/src/components/search/curated/css/index.tsx
@@ -1,81 +1,17 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import cssPageData from './css-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
 const SearchCSS = () => {
-  const location = 'css landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn CSS using the best screencast tutorial videos online.`
-  const title = `In-Depth Up-to-Date CSS Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(cssPageData, {id: 'beginner'})
-  const intermediate: any = find(cssPageData, {id: 'intermediate'})
-  const advanced: any = find(cssPageData, {id: 'advanced'})
-
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/175/full/csslang.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="CSS"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/175/full/csslang.png"
-        >
-          {`
-Description of TypeScript
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'CSS',
+        name: 'css',
+        description: `Description text for CSS`,
+      }}
+      pageData={cssPageData}
+    />
   )
 }
 

--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import {NextSeo} from 'next-seo'
+import Card from 'components/pages/home/card'
+import Collection from 'components/pages/home/collection'
+import Topic from '../components/topic'
+import {find} from 'lodash'
+
+import DefaultCTA from './default-cta'
+
+type CuratedEssentialProps = {
+  topic: {
+    name: string
+    label: string
+    title?: string
+    description: string
+  }
+  pageData?: any
+  CTAComponent?: React.FC
+}
+
+const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
+  topic,
+  pageData,
+  children,
+  CTAComponent,
+}) => {
+  const location = `${topic} landing`
+  const description = `Life is too short for lonnnnnng boring videos. Learn ${topic.label} using the best screencast tutorial videos online.`
+  const title =
+    topic.title ||
+    `In-Depth ${topic.label} Tutorials for ${new Date().getFullYear()}`
+
+  const beginner: any = find(pageData, {id: 'beginner'})
+  const intermediate: any = find(pageData, {id: 'intermediate'})
+  const advanced: any = find(pageData, {id: 'advanced'})
+
+  return (
+    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+      <NextSeo
+        description={description}
+        title={title}
+        titleTemplate={'%s | egghead.io'}
+        twitter={{
+          site: `@eggheadio`,
+          cardType: 'summary',
+        }}
+        openGraph={{
+          title,
+          description: description,
+          site_name: 'egghead',
+          images: [
+            {
+              url: `https://og-image-react-egghead.now.sh/topic/${topic.name}?orientation=landscape&v=20201104`,
+            },
+          ],
+        }}
+      />
+      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
+        <Topic
+          className="col-span-8"
+          title={topic.label}
+          imageUrl={`https://og-image-react-egghead.now.sh/topic/${topic.name}?orientation=portrait&v=20201104`}
+        >
+          {topic.description}
+        </Topic>
+        {CTAComponent ? <CTAComponent /> : <DefaultCTA location={location} />}
+      </div>
+      {beginner && intermediate && advanced && (
+        <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
+          <Card resource={beginner} location={location}>
+            <Collection />
+          </Card>
+          <Card resource={intermediate} location={location} className="h-full">
+            <Collection />
+          </Card>
+          <Card resource={advanced} location={location} className="h-full">
+            <Collection />
+          </Card>
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}
+
+export default SearchCuratedEssential

--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -16,6 +16,8 @@ type CuratedEssentialProps = {
   }
   pageData?: any
   CTAComponent?: React.FC
+  ogImage?: string
+  verticalImage?: string
 }
 
 const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
@@ -23,6 +25,8 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
   pageData,
   children,
   CTAComponent,
+  ogImage,
+  verticalImage,
 }) => {
   const location = `${topic} landing`
   const description = `Life is too short for lonnnnnng boring videos. Learn ${topic.label} using the best screencast tutorial videos online.`
@@ -50,7 +54,9 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
           site_name: 'egghead',
           images: [
             {
-              url: `https://og-image-react-egghead.now.sh/topic/${topic.name}?orientation=landscape&v=20201104`,
+              url:
+                ogImage ||
+                `https://og-image-react-egghead.now.sh/topic/${topic.name}?orientation=landscape&v=20201104`,
             },
           ],
         }}
@@ -59,7 +65,10 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
         <Topic
           className="col-span-8"
           title={topic.label}
-          imageUrl={`https://og-image-react-egghead.now.sh/topic/${topic.name}?orientation=portrait&v=20201104`}
+          imageUrl={
+            verticalImage ||
+            `https://og-image-react-egghead.now.sh/topic/${topic.name}?orientation=portrait&v=20201104`
+          }
         >
           {topic.description}
         </Topic>

--- a/src/components/search/curated/default-cta.tsx
+++ b/src/components/search/curated/default-cta.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import Image from 'next/image'
+import ExternalTrackedLink from '../../external-tracked-link'
+
+const DefaultCTA: React.FC<{location: string}> = ({location}) => {
+  return (
+    <ExternalTrackedLink
+      eventName="clicked epic react banner"
+      params={{location}}
+      className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
+      href="https://epicreact.dev"
+    >
+      <Image
+        priority
+        quality={100}
+        width={417}
+        height={463}
+        src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
+        alt="epicreact.dev by Kent C. Dodds"
+      />
+    </ExternalTrackedLink>
+  )
+}
+
+export default DefaultCTA

--- a/src/components/search/curated/next/index.tsx
+++ b/src/components/search/curated/next/index.tsx
@@ -1,82 +1,18 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import nextPageData from './next-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
-const SearchAngular = () => {
-  const location = 'next landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn Next.js using the best screencast tutorial videos online.`
-  const title = `In-Depth Up-to-Date Next.js Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(nextPageData, {id: 'beginner'})
-  const intermediate: any = find(nextPageData, {id: 'intermediate'})
-  const advanced: any = find(nextPageData, {id: 'advanced'})
-
+const SearchNext = () => {
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/074/full/nextjs.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="Next.js"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/074/full/nextjs.png"
-        >
-          {`
-Description of Next.js
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'Next.js',
+        name: 'next',
+        description: `Description text for Next.js`,
+      }}
+      pageData={nextPageData}
+    />
   )
 }
 
-export default SearchAngular
+export default SearchNext

--- a/src/components/search/curated/node/index.tsx
+++ b/src/components/search/curated/node/index.tsx
@@ -1,82 +1,18 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import nodePageData from './node-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
-const SearchAngular = () => {
-  const location = 'node landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn Node.js using the best screencast tutorial videos online.`
-  const title = `In-Depth Up-to-Date Node.js Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(nodePageData, {id: 'beginner'})
-  const intermediate: any = find(nodePageData, {id: 'intermediate'})
-  const advanced: any = find(nodePageData, {id: 'advanced'})
-
+const SearchNode = () => {
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/256/full/nodejslogo.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="Node.js"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/256/full/nodejslogo.png"
-        >
-          {`
-Description of Angular
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'Next.js',
+        name: 'next',
+        description: `Description text for Next.js`,
+      }}
+      pageData={nodePageData}
+    />
   )
 }
 
-export default SearchAngular
+export default SearchNode

--- a/src/components/search/curated/typescript/index.tsx
+++ b/src/components/search/curated/typescript/index.tsx
@@ -1,81 +1,17 @@
 import React from 'react'
-import {NextSeo} from 'next-seo'
-import Card from 'components/pages/home/card'
-import Collection from 'components/pages/home/collection'
-import Topic from '../../components/topic'
 import typescriptPageData from './typescript-page-data'
-import {find} from 'lodash'
-import Image from 'next/image'
-import ExternalTrackedLink from 'components/external-tracked-link'
+import SearchCuratedEssential from '../curated-essential'
 
 const SearchTypescript = () => {
-  const location = 'typescript landing'
-  const description = `Life is too short for lonnnnnng boring videos. Learn TypeScript using the best screencast tutorial videos online.`
-  const title = `In-Depth Up-to-Date TypeScript Tutorials for ${new Date().getFullYear()}`
-
-  const beginner: any = find(typescriptPageData, {id: 'beginner'})
-  const intermediate: any = find(typescriptPageData, {id: 'intermediate'})
-  const advanced: any = find(typescriptPageData, {id: 'advanced'})
-
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
-      <NextSeo
-        description={description}
-        title={title}
-        titleTemplate={'%s | egghead.io'}
-        twitter={{
-          site: `@eggheadio`,
-          cardType: 'summary',
-        }}
-        openGraph={{
-          title,
-          description: description,
-          site_name: 'egghead',
-          images: [
-            {
-              url: `https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/377/full/typescriptlang.png`,
-            },
-          ],
-        }}
-      />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
-        <Topic
-          className="col-span-8"
-          title="TypeScript"
-          imageUrl="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/377/full/typescriptlang.png"
-        >
-          {`
-Description of Typescript
-`}
-        </Topic>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          params={{location}}
-          className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
-          href="https://epicreact.dev"
-        >
-          <Image
-            priority
-            quality={100}
-            width={417}
-            height={463}
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
-            alt="epicreact.dev by Kent C. Dodds"
-          />
-        </ExternalTrackedLink>
-      </div>
-      <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
-        <Card resource={beginner} location={location}>
-          <Collection />
-        </Card>
-        <Card resource={intermediate} location={location} className="h-full">
-          <Collection />
-        </Card>
-        <Card resource={advanced} location={location} className="h-full">
-          <Collection />
-        </Card>
-      </div>
-    </div>
+    <SearchCuratedEssential
+      topic={{
+        label: 'TypeScript',
+        name: 'typescript',
+        description: `Description text for TypeScript`,
+      }}
+      pageData={typescriptPageData}
+    />
   )
 }
 

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -24,6 +24,8 @@ import ReactMarkdown from 'react-markdown'
 import {NextSeo} from 'next-seo'
 import {isArray} from 'lodash'
 import GenericTopic from './generic-topic'
+import SearchCuratedEssential from './curated/curated-essential'
+import typescriptPageData from './curated/typescript/typescript-page-data'
 
 const ALGOLIA_INDEX_NAME =
   process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || 'content_production'
@@ -242,11 +244,7 @@ const Search: FunctionComponent<SearchProps> = ({
 
           {!isEmpty(topic) && shouldDisplayDefault(CURATED_PAGES) && (
             <div className="dark:bg-gray-900 bg-gray-50 md:-mt-5">
-              <GenericTopic
-                title={topic.label}
-                imageUrl={topic.image_480_url}
-                description={topic.description}
-              />
+              <SearchCuratedEssential topic={topic} />
             </div>
           )}
 


### PR DESCRIPTION
This makes a reusable component for curated search pages.

![image](https://user-images.githubusercontent.com/86834/106369329-6840de00-6305-11eb-87b9-4c38c799aeb9.png)

If `pageData` is available it tries to find `beginner`, `intermediate`, and `advanced` data and displays it accordingly. `children` extend the component for more complex uses. A `CTAComponent` can be passed in otherwise it uses the configured default.

![](https://media.giphy.com/media/RMZTwoYFElXtVRG4o4/giphy-downsized.gif)