### PR TITLE
Proof of Concept: Customization for instructor's header

### DIFF
--- a/src/components/search/components/topic.tsx
+++ b/src/components/search/components/topic.tsx
@@ -15,8 +15,6 @@ const Topic: FunctionComponent<TopicProps> = ({
   imageUrl,
 }) => {
   const isRenderProp = typeof children === 'function'
-  console.log('children', children)
-  console.log('children(Markdown)', children(Markdown))
   return (
     <div
       className={`bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm grid grid-cols-8 h-full relative items-start overflow-hidden rounded-md border border-gray-100 dark:border-gray-800 ${

--- a/src/components/search/components/topic.tsx
+++ b/src/components/search/components/topic.tsx
@@ -3,7 +3,7 @@ import Markdown from 'react-markdown'
 
 type TopicProps = {
   title: string
-  children?: string
+  children?: any
   imageUrl?: string
   className?: string
 }
@@ -14,6 +14,9 @@ const Topic: FunctionComponent<TopicProps> = ({
   className,
   imageUrl,
 }) => {
+  const isRenderProp = typeof children === 'function'
+  console.log('children', children)
+  console.log('children(Markdown)', children(Markdown))
   return (
     <div
       className={`bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm grid grid-cols-8 h-full relative items-start overflow-hidden rounded-md border border-gray-100 dark:border-gray-800 ${
@@ -30,7 +33,8 @@ const Topic: FunctionComponent<TopicProps> = ({
       />
       <div className="sm:col-span-6 col-span-6 flex flex-col justify-start h-full p-8">
         <h1 className="sm:text-2xl text-xl font-bold mb-2">{title}</h1>
-        {children && (
+        {children && isRenderProp && children(Markdown)}
+        {children && !isRenderProp && (
           <Markdown className="prose dark:prose-dark pt-2 sm:text-base text-sm leading-normal text-gray-800 dark:text-gray-200 mt-0">
             {children}
           </Markdown>

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -25,6 +25,8 @@ import {NextSeo} from 'next-seo'
 import {isArray} from 'lodash'
 import SearchCuratedEssential from './curated/curated-essential'
 
+import instructorsIndex from './instructors'
+
 const ALGOLIA_INDEX_NAME =
   process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || 'content_production'
 
@@ -99,6 +101,12 @@ const Search: FunctionComponent<SearchProps> = ({
 
     return tag && numberOfRefinements === 1 && !topics.includes(tag)
   }
+
+  const shouldDisplayLandingPageForInstructor = (slug: string) => {
+    return typeof instructorsIndex[slug] !== 'undefined'
+  }
+
+  const Instructor = instructor && instructorsIndex[instructor.slug]
 
   return (
     <>
@@ -187,7 +195,7 @@ const Search: FunctionComponent<SearchProps> = ({
             </div>
           </div>
           {!isEmpty(instructor) && (
-            <div className="max-w-screen-xl mx-auto md:p-16 p-0 md:pt-16 pt-5 flex xl:px-0 px-5 md:flex-row flex-col md:space-y-0 space-y-2 justify-center">
+            <>
               <NextSeo
                 title={`Learn web development from ${instructor.full_name} on egghead`}
                 twitter={{
@@ -204,22 +212,33 @@ const Search: FunctionComponent<SearchProps> = ({
                   ],
                 }}
               />
-              <div className="flex items-center md:justify-center justify-start flex-shrink-0">
-                <Image
-                  className="rounded-full"
-                  width={128}
-                  height={128}
-                  layout="intrinsic"
-                  src={instructor.avatar_url}
-                />
-              </div>
-              <div className="md:pl-8">
-                <h1 className="text-2xl font-bold">{instructor.full_name}</h1>
-                <ReactMarkdown className="prose dark:prose-dark mt-0">
-                  {instructor.bio_short}
-                </ReactMarkdown>
-              </div>
-            </div>
+
+              {shouldDisplayLandingPageForInstructor(instructor.slug) && (
+                <Instructor instructor={instructor} />
+              )}
+
+              {!shouldDisplayLandingPageForInstructor(instructor.slug) && (
+                <div className="max-w-screen-xl mx-auto md:p-16 p-0 md:pt-16 pt-5 flex xl:px-0 px-5 md:flex-row flex-col md:space-y-0 space-y-2 justify-center">
+                  <div className="flex items-center md:justify-center justify-start flex-shrink-0">
+                    <Image
+                      className="rounded-full"
+                      width={128}
+                      height={128}
+                      layout="intrinsic"
+                      src={instructor.avatar_url}
+                    />
+                  </div>
+                  <div className="md:pl-8">
+                    <h1 className="text-2xl font-bold">
+                      {instructor.full_name}
+                    </h1>
+                    <ReactMarkdown className="prose dark:prose-dark mt-0">
+                      {instructor.bio_short}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              )}
+            </>
           )}
 
           {shouldDisplayLandingPageForTopics('javascript') && (

--- a/src/components/search/instructors/colby-fayock/colby-fayock-page.stories.mdx
+++ b/src/components/search/instructors/colby-fayock/colby-fayock-page.stories.mdx
@@ -1,0 +1,14 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks'
+import SearchColbyFayock from './index'
+
+<Meta title="components/search/instructors/colby-fayock" />
+
+# Curated Landing Page
+
+<Canvas>
+  <Story name="Default">
+    <div className="bg-gray-100 p-5">
+      <SearchColbyFayock />
+    </div>
+  </Story>
+</Canvas>

--- a/src/components/search/instructors/colby-fayock/index.tsx
+++ b/src/components/search/instructors/colby-fayock/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import Topic from '../../components/topic'
+
+const SearchColbyFayock = ({instructor}) => {
+  return (
+    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
+        <Topic
+          className="col-span-8"
+          title={instructor.full_name}
+          imageUrl="https://res.cloudinary.com/fay/image/upload/v1612054925/cosmo-square_vqhl59.jpg"
+        >
+          {(Markdown: any) => (
+            <>
+              <Markdown className="prose dark:prose-dark pt-2 sm:text-base text-sm leading-normal text-gray-800 dark:text-gray-200 mt-0">
+                {instructor.bio_short}
+              </Markdown>
+            </>
+          )}
+        </Topic>
+        <Link href="/playlists/create-an-ecommerce-store-with-next-js-and-stripe-checkout-562c">
+          <a className="block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center">
+            <Image
+              className="mx-auto"
+              priority
+              quality={100}
+              width={300}
+              height={300}
+              src="https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/412/781/square_480/ecommerce-stripe-next.png"
+              alt="illustration for Create an eCommerce Store with Next.js and Stripe Checkout"
+            />
+            <p className="sm:text-l text-m text-gray-500 font-medium mt-3">
+              Instructor's Pick
+            </p>
+            <p className="sm:text-xl text-m font-bold mt-1">
+              Create an eCommerce Store with Next.js and Stripe Checkout
+            </p>
+          </a>
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default SearchColbyFayock

--- a/src/components/search/instructors/index.tsx
+++ b/src/components/search/instructors/index.tsx
@@ -1,0 +1,5 @@
+import SearchColbyFayock from './colby-fayock'
+
+export default {
+  'colby-fayock': SearchColbyFayock,
+}


### PR DESCRIPTION
Note: Not intended to be merged

Put together a PoC with what could be a way for instructors to customize their page. It's pretty much based on the curated topics, but tried to make it in a way where instructors could add their own header without having to touch the core search page component.

I'm not entirely familiar with Typescript so please ignore my ignorance with a few things (particularly where I put "any" to make things work".

Curious on thoughts about it, but thought it could be a fun way to expose it for others to hop in and make something easily.