### PR TITLE
Fix TagList items alignment

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -469,7 +469,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   </h2>
                   {pairWithResources.map((resource: any) => {
                     return (
-                      <div>
+                      <div key={resource.slug}>
                         <CardHorizontal
                           className="border my-4 border-opacity-10 border-gray-400 dark:border-gray-700"
                           resource={resource}
@@ -675,7 +675,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 </h2>
                 {pairWithResources.map((resource: any) => {
                   return (
-                    <div>
+                    <div key={resource.slug}>
                       <CardHorizontal
                         className="border my-4 border-opacity-10 border-gray-400 dark:border-gray-500"
                         resource={resource}

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -325,10 +325,8 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   />
                 )}
                 <div className="flex items-center flex-col md:flex-row flex-wrap">
-                  <div className="md:mr-4 mt-3">
-                    <TagList tags={courseTags} courseSlug={course.slug} />
-                  </div>
-                  <div className="flex items-center md:justify-start justify-center md:mr-4 mt-3">
+                  <TagList tags={courseTags} courseSlug={course.slug} />
+                  <div className="flex items-center md:justify-start justify-center md:mr-4 mt-4">
                     {duration && (
                       <div className="mr-4">
                         <Duration duration={convertTimeWithTitles(duration)} />

--- a/src/components/layouts/tag-list.tsx
+++ b/src/components/layouts/tag-list.tsx
@@ -12,7 +12,7 @@ const TagList: FunctionComponent<{
 }> = ({
   tags,
   courseSlug,
-  className = 'flex flex-col sm:flex-row flex-wrap items-center',
+  className = 'flex justify-center md:justify-start flex-wrap items-center',
 }) => {
   return (
     <>
@@ -21,7 +21,7 @@ const TagList: FunctionComponent<{
           {tags.map((tag: any, index: number) => (
             <li
               key={index}
-              className="inline-flex items-center mr-4 mt-3 sm:mt-4"
+              className="inline-flex items-center mr-4 mt-2 sm:mt-3"
             >
               <Link href={`/q/${tag.name}`}>
                 <a

--- a/src/components/layouts/tag-list.tsx
+++ b/src/components/layouts/tag-list.tsx
@@ -19,7 +19,10 @@ const TagList: FunctionComponent<{
       {!isEmpty(tags) && (
         <ul className={className}>
           {tags.map((tag: any, index: number) => (
-            <li key={index} className="inline-flex items-center pr-4 pt-2">
+            <li
+              key={index}
+              className="inline-flex items-center mr-4 mt-3 sm:mt-4"
+            >
               <Link href={`/q/${tag.name}`}>
                 <a
                   onClick={() => {

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -71,7 +71,7 @@ const CourseIndex: React.FC<{courses: any}> = ({courses = []}) => {
                 <li key={course.slug}>
                   <article className="relative group dark:bg-gray-800 bg-white rounded-md max-w-max-content flex space-x-5 h-full shadow-sm">
                     <div className="flex flex-col">
-                      <header className="flex space-x-5 items-center p-5 border-b border-gray-50 dark:border-gray-800">
+                      <header className="flex flex-col md:flex-row md:space-x-5 space-y-4 md:space-y-0 items-center p-5 border-b border-gray-50 dark:border-gray-800">
                         <figure className="flex flex-col flex-shrink-0">
                           <Link href={course.path}>
                             <a tabIndex={-1}>
@@ -84,10 +84,10 @@ const CourseIndex: React.FC<{courses: any}> = ({courses = []}) => {
                             </a>
                           </Link>
                         </figure>
-                        <div>
+                        <div className="flex flex-col items-center md:items-start">
                           <Link href={course.path}>
                             <a>
-                              <h1 className="sm:text-lg text-lg font-bold leading-tight hover:underline">
+                              <h1 className="sm:text-lg text-lg font-bold leading-tight hover:underline text-center md:text-left">
                                 {course.title}
                               </h1>
                             </a>
@@ -103,7 +103,7 @@ const CourseIndex: React.FC<{courses: any}> = ({courses = []}) => {
                             </span>
                           </div>
                           <TagList
-                            className="flex flex-wrap items-center text-sm"
+                            className="flex justify-center md:justify-start flex-wrap items-center text-sm"
                             tags={course.tags}
                             courseSlug={course.slug}
                           />


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/1519448/106386818-782cf080-63df-11eb-9475-efe61584a79d.jpg)

after:
![before](https://user-images.githubusercontent.com/1519448/106386821-7b27e100-63df-11eb-957b-f977f3cf5635.jpg)


also tweaked Course card:
before:
![before](https://user-images.githubusercontent.com/1519448/106388997-ab747d00-63e9-11eb-8898-29ea4a28b624.jpg)

after:
![after](https://user-images.githubusercontent.com/1519448/106389001-afa09a80-63e9-11eb-9094-78bca01c98c9.jpg)



![](https://media4.giphy.com/media/3o7TKA1v46boXGB69y/200.gif?cid=5a38a5a2brut59g5422qpft7204z7td5z00j3606bhdlkvtq&rid=200.gif)
