### PR TITLE
Show error message when we cannot change the email

### DIFF
--- a/src/machines/request-email-change-machine.ts
+++ b/src/machines/request-email-change-machine.ts
@@ -1,0 +1,81 @@
+import {Machine, assign, DoneEventObject as _DoneEventObject} from 'xstate'
+
+export type DoneEventObject = _DoneEventObject
+
+interface StateSchema {
+  states: {
+    idle: {}
+    edit: {}
+    loading: {}
+    success: {}
+    failure: {}
+  }
+}
+
+export type Event =
+  | {type: 'EDIT'}
+  | {type: 'CANCEL'}
+  | {type: 'SUBMIT'; data: {newEmail: string}}
+  | _DoneEventObject
+
+export interface Context {
+  newEmail?: string
+  error?: string
+}
+
+const setNewEmail = assign<Context, DoneEventObject>({
+  newEmail: (_, event) => {
+    return event.data.newEmail
+  },
+})
+
+export const requestEmailChangeMachine = Machine<Context, StateSchema, Event>({
+  id: 'requestEmailChange',
+  initial: 'idle',
+  context: {
+    newEmail: undefined,
+    error: undefined,
+  },
+  states: {
+    idle: {
+      on: {EDIT: 'edit'},
+    },
+    edit: {
+      on: {
+        SUBMIT: 'loading',
+        CANCEL: 'idle',
+      },
+    },
+    loading: {
+      entry: [setNewEmail],
+      invoke: {
+        id: 'makeEmailChangeRequest',
+        src: 'requestChange',
+        onDone: {
+          target: 'success',
+          actions: [
+            assign({
+              error: (_, event) => {
+                return event.data.success === false
+                  ? event.data.message
+                  : undefined
+              },
+            }),
+          ],
+        },
+        onError: {
+          target: 'failure',
+          actions: assign({
+            error: (_, event) => event.data,
+          }),
+        },
+      },
+    },
+    success: {
+      on: {EDIT: 'edit'},
+    },
+    failure: {
+      on: {EDIT: 'edit'},
+    },
+  },
+})


### PR DESCRIPTION
This PR makes it clear whether the email change request went through or not. If we aren't able to make the change automatically, they user is directed to contact support.

There were going to be 3 or 4 related pieces of React state to manage all of this, so I decided to transition it to an XState machine. That makes the whole thing more manageable.

Related issue: https://github.com/eggheadio/egghead-next/issues/409

https://user-images.githubusercontent.com/694063/107583946-470fa580-6bc1-11eb-8064-686959f5067e.mp4


![](https://media2.giphy.com/media/13YiWsipGEVzrO/200.gif?cid=5a38a5a2m8jwj4ed033biusc0tplp1xnxsj96sao1ruq64av&rid=200.gif)


