### PR TITLE
Show new email after change confirmed

### DIFF
--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -18,11 +18,13 @@ type ViewerContextType = {
   logout?: any
   loading: boolean
   refreshUser?: any
+  setViewerEmail: (newEmail: string) => void
 }
 
 const defaultViewerContext: ViewerContextType = {
   authenticated: false,
   loading: true,
+  setViewerEmail: (_) => {},
 }
 
 export function useViewer() {
@@ -37,6 +39,12 @@ function useAuthedViewer() {
   const [loading, setLoading] = React.useState(true)
   const [loggingOut, setLoggingOut] = React.useState(false)
   const previousViewer = React.useRef(viewer)
+
+  const setViewerEmail = (newEmail: string) => {
+    setViewer((prevViewer: any) => {
+      return {...prevViewer, email: newEmail}
+    })
+  }
 
   useTokenSigner()
   useAffiliateAssigner(viewerId, getAccessTokenFromCookie())
@@ -149,6 +157,7 @@ function useAuthedViewer() {
   const values = React.useMemo(
     () => ({
       viewer,
+      setViewerEmail,
       logout: () => {
         setLoggingOut(true)
       },

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -4,11 +4,9 @@ import queryString from 'query-string'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 import isEmpty from 'lodash/isEmpty'
-import {useRouter} from 'next/router'
 import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
 import useTokenSigner from '../hooks/use-token-signer'
 import useAffiliateAssigner from '../hooks/use-affiliate-assigner'
-import useLogRocket from '../hooks/use-logrocket'
 
 export const auth = new Auth()
 

--- a/src/pages/email-change-request/[token].tsx
+++ b/src/pages/email-change-request/[token].tsx
@@ -16,7 +16,7 @@ async function confirmEmailChangeRequest(token: any) {
 const EmailChangeRequest: React.FunctionComponent = () => {
   const router = useRouter()
   const {token} = router.query
-  const {viewer, refreshUser} = useViewer()
+  const {viewer, setViewerEmail} = useViewer()
 
   return (
     <LoginRequired>
@@ -34,11 +34,13 @@ const EmailChangeRequest: React.FunctionComponent = () => {
                 <button
                   className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
                   onClick={async () => {
-                    const data = await confirmEmailChangeRequest(token)
+                    const {
+                      success,
+                      new_email,
+                    } = await confirmEmailChangeRequest(token)
 
-                    if (data.success === true) {
-                      // refresh the user to get the latest email before redirecting
-                      await refreshUser()
+                    if (success === true) {
+                      setViewerEmail(new_email)
 
                       router.replace('/user')
                     }

--- a/src/pages/email-change-request/[token].tsx
+++ b/src/pages/email-change-request/[token].tsx
@@ -3,7 +3,6 @@ import LoginRequired from 'components/login-required'
 import axios from 'axios'
 import {useRouter} from 'next/router'
 import {useViewer} from 'context/viewer-context'
-import isEmpty from 'lodash/isEmpty'
 
 async function confirmEmailChangeRequest(token: any) {
   const {data} = await axios.get(
@@ -16,7 +15,7 @@ async function confirmEmailChangeRequest(token: any) {
 const EmailChangeRequest: React.FunctionComponent = () => {
   const router = useRouter()
   const {token} = router.query
-  const {viewer, setViewerEmail} = useViewer()
+  const {setViewerEmail} = useViewer()
 
   return (
     <LoginRequired>


### PR DESCRIPTION
After a user confirms the update of their email address, the viewer context gets updated with that new email so that it displays correctly when they are redirect back to the `/user` page.


![](https://media3.giphy.com/media/uAuNp08i7ybYI/200w.gif?cid=5a38a5a277rw0cjlyivsl3vaq9y92bo2qkzzhy4vrj2q7yoz&rid=200w.gif)
