### PR TITLE
Adjusted headline and q+a on value paths page

### DIFF
--- a/src/pages/level-up/index.mdx
+++ b/src/pages/level-up/index.mdx
@@ -1,6 +1,6 @@
 import LoginRequired from '../../components/login-required'
 export const meta = {
-  title: `Level up your career as a Web Developer`,
+  title: `Get 1-on-1 Career Planning Help`,
 }
 
 import UltimateGuide from 'layouts/ultimate-guide'
@@ -46,11 +46,9 @@ import EmailEntryForm from 'components/pages/level-up/email-entry-form'
 
 <EmailEntryForm />
 
-### What does getting involved include?
+### What exactly am I signing up for?
 
-We're not sure yet! Everyone's job hunt is different and there's no formula to
-rely on. So all you're committing to is a phone call – let's talk and find out
-how our _team of experts_ can help you land that job you're chasing.
+All you're committing to is a phone call – let's talk and find out how our _team of experts_ can help you land that job you're chasing. Everyone's job hunt is different and there's no formula to rely on. We want to hear what parts of the process you're personally struggling with, and talk through possible solutions.
 
 ### What does egghead get out of this?
 


### PR DESCRIPTION
Changed the headline and some of the Q&A text on the value paths landing page to see if it clarifies what we're asking of people and improves conversions.

- Changed main headline from "Level up your career as a Web Developer" (general) to "Get 1-on-1 Career Planning Help" (specific)

- Changed the first Q&A question.

Before:
> ### What does getting involved include?
> We're not sure yet! Everyone's job hunt is different and there's no formula to rely on. So all you're committing to is a phone call – let's talk and find out how our team of experts can help you land that job you're chasing.

After:
> ### What exactly am I signing up for?
> All you're committing to is a phone call – let's talk and find out how our _team of experts_ can help you land that job you're chasing. Everyone's job hunt is different and there's no formula to rely on. We want to hear what parts of the process you're personally struggling with, and talk through possible solutions.