### PR TITLE
Display current/new email, better error handling

### DIFF
--- a/src/pages/email-change-request/[token].tsx
+++ b/src/pages/email-change-request/[token].tsx
@@ -1,19 +1,80 @@
 import * as React from 'react'
 import LoginRequired from 'components/login-required'
-import axios from 'axios'
 import {useRouter} from 'next/router'
 import {useViewer} from 'context/viewer-context'
 import toast from 'react-hot-toast'
+import axios from 'axios'
+import isEmpty from 'lodash/isEmpty'
+import {
+  getAuthorizationHeader,
+  getTokenFromCookieHeaders,
+  AUTH_DOMAIN,
+} from 'utils/auth'
 
 async function confirmEmailChangeRequest(token: any) {
-  const {data} = await axios.get(
+  const {data} = await axios.patch(
     `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/email_change_requests/${token}`,
+    {},
+    {
+      headers: {...getAuthorizationHeader()},
+    },
   )
 
   return data
 }
 
-const EmailChangeRequest: React.FunctionComponent = () => {
+type emailChangeRequestData = {
+  new_email: string
+  current_email: string
+}
+
+export async function getServerSideProps(context: any) {
+  const {token} = context.params
+  const {eggheadToken} = getTokenFromCookieHeaders(
+    context.req.headers.cookie as string,
+  )
+
+  let props = {
+    validToken: false,
+    newEmail: '',
+    currentEmail: '',
+  }
+
+  try {
+    const {data}: {data: emailChangeRequestData} = await axios.get(
+      `${AUTH_DOMAIN}/api/v1/email_change_requests/${token}`,
+      {
+        headers: {
+          Authorization: `Bearer ${eggheadToken}`,
+        },
+      },
+    )
+
+    const newEmail = data['new_email']
+    const currentEmail = data['current_email']
+
+    props = {
+      ...props,
+      validToken: !isEmpty(newEmail) && !isEmpty(currentEmail),
+      newEmail,
+      currentEmail,
+    }
+  } catch (e) {
+    if (e.response.status === 404) {
+      props.validToken = false
+    }
+  }
+
+  return {
+    props,
+  }
+}
+
+const EmailChangeRequest: React.FunctionComponent<{
+  validToken: boolean
+  newEmail: string
+  currentEmail: string
+}> = ({validToken, newEmail, currentEmail}) => {
   const router = useRouter()
   const {token} = router.query
   const {setViewerEmail} = useViewer()
@@ -27,12 +88,64 @@ const EmailChangeRequest: React.FunctionComponent = () => {
               Email Change Request
             </h2>
             <div className="sm:mt-8 mt-4 sm:mx-auto sm:w-full sm:max-w-xl">
-              <p className="text-center pb-8">
+              <p className="text-center pb-4">
                 Click 'confirm' to complete your email change request.
               </p>
+              {validToken && (
+                <p className="text-center mb-4 p-4 bg-blue-50 dark:bg-gray-800 rounded">
+                  {currentEmail} → {newEmail}
+                </p>
+              )}
+              {!validToken && (
+                <div
+                  className="relative px-4 py-3 mb-4 leading-normal text-red-700 bg-red-100 dark:text-red-100 dark:bg-red-800 rounded"
+                  role="alert"
+                >
+                  <span className="absolute inset-y-0 left-0 flex items-center ml-4">
+                    <svg
+                      className="w-6 h-6"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  </span>
+                  <p className="ml-8">
+                    This link for changing your email has been used or has
+                    expired. Feel free to{' '}
+                    <a
+                      className="font-bold underline transition-colors ease-in-out duration-150"
+                      href="/user"
+                    >
+                      request a new link
+                    </a>
+                    . Please contact{' '}
+                    <a
+                      className="font-bold underline transition-colors ease-in-out duration-150"
+                      href="mailto:support@egghead.io"
+                    >
+                      support@egghead.io
+                    </a>{' '}
+                    to get further help with this request.
+                  </p>
+                </div>
+              )}
               <div className="flex justify-center items-center w-full">
                 <button
-                  className="text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded"
+                  className={`text-white bg-red-500 border-0 py-2 px-8 focus:outline-none rounded
+                    ${
+                      validToken
+                        ? 'hover:bg-red-600'
+                        : 'cursor-not-allowed opacity-50'
+                    }`}
+                  disabled={!validToken}
                   onClick={async () => {
                     try {
                       const {
@@ -45,13 +158,17 @@ const EmailChangeRequest: React.FunctionComponent = () => {
 
                         toast.success(
                           "You've successfully updated your email address",
+                          {icon: '✅'},
                         )
                         router.replace('/user')
                       }
                     } catch (e) {
                       toast.error(
                         'This link for changing your email has been used or has expired. Feel free to request a new link.',
-                        {duration: 6000, icon: '❌'},
+                        {
+                          duration: 6000,
+                          icon: '❌',
+                        },
                       )
                     }
                   }}


### PR DESCRIPTION
Updates to the Email Change Request Confirmation page:

1. Display the current and new email before the user confirms.
2. If the token is already expired when the page loads, tell the user and give them options for how to deal with it.

<img width="1100" alt="CleanShot 2021-02-16 at 15 19 54@2x" src="https://user-images.githubusercontent.com/694063/108125125-a52f0380-706d-11eb-963e-a36b7cc290df.png">

<img width="1099" alt="CleanShot 2021-02-16 at 15 19 46@2x" src="https://user-images.githubusercontent.com/694063/108125131-a7915d80-706d-11eb-8feb-c861b3fb9f32.png">


![](https://media2.giphy.com/media/WrmzE1YAJIM3gfrU2m/200.gif?cid=5a38a5a2c5fzmpavf5bksq8fg9dud7xs7j044hiubgic5eym&rid=200.gif)
