### PR TITLE
Fix light mode messaging, esp link text color

### DIFF
--- a/src/components/users/request-email-change-form.tsx
+++ b/src/components/users/request-email-change-form.tsx
@@ -62,31 +62,33 @@ const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProp
                 Email
               </h2>
               <p>Your email address:</p>
-              {state.matches('edit') && (
-                <p className="text-sm text-gray-600 dark:text-gray-200">
-                  To ensure that you have access to this email address, we will
-                  send an email to that account with a confirmation link.
-                </p>
-              )}
-              {state.matches('success') && !state.context.error && (
-                <p className="text-sm text-gray-400">
-                  Your email change request has been received. A confirmation
-                  email has been sent to {state.context.newEmail}.
-                </p>
-              )}
-              {state.matches('success') && !!state.context.error && (
-                <p className="text-sm text-gray-400">
-                  We weren't able to automatically update your email. Please
-                  contact{' '}
-                  <a
-                    className="text-gray-200 hover:text-blue-600 transition-colors ease-in-out duration-150"
-                    href="mailto:support@egghead.io"
-                  >
-                    support@egghead.io
-                  </a>{' '}
-                  to get further help with this request.
-                </p>
-              )}
+              <div className="text-sm text-gray-600 dark:text-gray-200">
+                {state.matches('edit') && (
+                  <p>
+                    To ensure that you have access to this email address, we
+                    will send an email to that account with a confirmation link.
+                  </p>
+                )}
+                {state.matches('success') && !state.context.error && (
+                  <p>
+                    Your email change request has been received. A confirmation
+                    email has been sent to {state.context.newEmail}.
+                  </p>
+                )}
+                {state.matches('success') && !!state.context.error && (
+                  <p>
+                    We weren't able to automatically update your email. Please
+                    contact{' '}
+                    <a
+                      className="font-bold hover:text-blue-600 transition-colors ease-in-out duration-150"
+                      href="mailto:support@egghead.io"
+                    >
+                      support@egghead.io
+                    </a>{' '}
+                    to get further help with this request.
+                  </p>
+                )}
+              </div>
               <div className="flex flex-row space-x-2">
                 <input
                   id="email"


### PR DESCRIPTION
This PR fixes an inaccessible color contrast issue with the link text.

Before and After video


https://user-images.githubusercontent.com/694063/108258923-26e26800-7126-11eb-9d9a-669e39dcab65.mp4


![](https://media4.giphy.com/media/26AHusiZ8IhPANw7S/giphy.gif?cid=5a38a5a2yhe76abqna1cgfgbxl44r9lwzz4c7ylx3kvjb5pg&rid=giphy.gif)
