### PR TITLE
Tweaks on the Course and Lesson pages

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -400,14 +400,14 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   >
                     <div className="dark:text-gray-900 flex flex-row items-center border px-2 py-1 rounded hover:bg-gray-200 bg-gray-100 transition-colors text-sm xs:text-base">
                       <BookmarkIcon
-                        className={`w-4 h-4 mr-1`}
+                        className="w-4 h-4 mr-1"
                         fill={isFavorite}
                       />{' '}
                       Bookmark
                     </div>
                   </button>
                 ) : (
-                  <div className="dark:text-gray-900 flex flex-row items-center border px-2 py-1 rounded bg-gray-100 opacity-30">
+                  <div className="dark:text-gray-900 flex flex-row items-center border px-2 py-1 rounded bg-gray-100 text-sm xs:text-base opacity-30">
                     <BookmarkIcon className="w-4 h-4 mr-1" /> Bookmark
                   </div>
                 )}
@@ -426,7 +426,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                     </a>
                   </Link>
                 ) : (
-                  <div className="flex flex-row items-center border px-2 py-1 rounded bg-gray-100 opacity-30">
+                  <div className="flex flex-row items-center border px-2 py-1 rounded bg-gray-100 text-sm xs:text-base opacity-30">
                     <FolderDownloadIcon className="w-4 h-4 mr-1" /> Download
                   </div>
                 )}
@@ -445,7 +445,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                     </a>
                   </Link>
                 ) : (
-                  <div className="flex flex-row items-center border px-2 py-1 rounded bg-gray-100 opacity-30">
+                  <div className="flex flex-row items-center border px-2 py-1 rounded bg-gray-100 text-sm xs:text-base opacity-30">
                     <RSSIcon className="w-4 h-4 mr-1" /> RSS
                   </div>
                 )}

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -111,6 +111,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
 }) => {
   const courseDependencies: any = getDependencies(course.slug)
   const [isFavorite, setIsFavorite] = React.useState(false)
+  const [clickable, setIsClickable] = React.useState(true)
 
   const defaultPairWithResources: any[] = take(
     [
@@ -389,21 +390,27 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 {toggle_favorite_url ? (
                   <button
                     onClick={() => {
-                      track(
-                        `clicked ${isFavorite ? 'remove' : 'add'} bookmark`,
-                        {
-                          course: course.slug,
-                        },
-                      )
-                      axios.post(toggle_favorite_url).then((resp) => {
-                        setIsFavorite(!isFavorite)
-                        toast(
-                          `Course ${
-                            isFavorite ? 'removed from' : 'added to'
-                          } Bookmarks`,
-                          {duration: 1000},
+                      if (clickable) {
+                        setIsClickable(false)
+                        track(
+                          `clicked ${isFavorite ? 'remove' : 'add'} bookmark`,
+                          {
+                            course: course.slug,
+                          },
                         )
-                      })
+                        setTimeout(() => {
+                          setIsClickable(true)
+                        }, 1000)
+                        axios.post(toggle_favorite_url).then((resp) => {
+                          setIsFavorite(!isFavorite)
+                          toast(
+                            `Course ${
+                              isFavorite ? 'removed from' : 'added to'
+                            } Bookmarks`,
+                            {duration: 1000},
+                          )
+                        })
+                      }
                     }}
                   >
                     <div className="dark:text-gray-900 flex flex-row items-center border px-2 py-1 rounded hover:bg-gray-200 bg-gray-100 transition-colors text-sm xs:text-base">

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import Markdown from 'react-markdown'
+import toast from 'react-hot-toast'
 import InstructorProfile from 'components/pages/courses/instructor-profile'
 import PlayIcon from 'components/pages/courses/play-icon'
 import getDependencies from 'data/courseDependencies'
@@ -396,6 +397,12 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                       )
                       axios.post(toggle_favorite_url)
                       setIsFavorite(!isFavorite)
+                      toast(
+                        `Course ${
+                          isFavorite ? 'removed from' : 'added to'
+                        } Bookmarks`,
+                        {duration: 1000},
+                      )
                     }}
                   >
                     <div className="dark:text-gray-900 flex flex-row items-center border px-2 py-1 rounded hover:bg-gray-200 bg-gray-100 transition-colors text-sm xs:text-base">

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -395,14 +395,15 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                           course: course.slug,
                         },
                       )
-                      axios.post(toggle_favorite_url)
-                      setIsFavorite(!isFavorite)
-                      toast(
-                        `Course ${
-                          isFavorite ? 'removed from' : 'added to'
-                        } Bookmarks`,
-                        {duration: 1000},
-                      )
+                      axios.post(toggle_favorite_url).then((resp) => {
+                        setIsFavorite(!isFavorite)
+                        toast(
+                          `Course ${
+                            isFavorite ? 'removed from' : 'added to'
+                          } Bookmarks`,
+                          {duration: 1000},
+                        )
+                      })
                     }}
                   >
                     <div className="dark:text-gray-900 flex flex-row items-center border px-2 py-1 rounded hover:bg-gray-200 bg-gray-100 transition-colors text-sm xs:text-base">

--- a/src/components/pages/lessons/collection-lessons-list.tsx
+++ b/src/components/pages/lessons/collection-lessons-list.tsx
@@ -36,17 +36,14 @@ const CollectionLessonsList: FunctionComponent<NextUpListProps> = ({
 
   return lessons ? (
     <div className="h-full overflow-hidden">
-      {/* <span className="font-semibold opacity-80 uppercase text-xs leading-wide">
-        Lessons
-      </span> */}
-      <div className="overflow-hidden bg-white dark:bg-gray-900 dark:border-gray-800 border-gray-100 h-full rounded-md lg:rounded-none border lg:border-none">
+      <div className="overflow-hidden bg-white dark:bg-gray-900 dark:border-gray-800 border-gray-100 h-96 lg:h-full rounded-md lg:rounded-none border lg:border-none">
         <SimpleBar
           autoHide={false}
           className="h-full"
           scrollableNodeProps={{ref: scrollableNodeRef}}
         >
           <ol
-            className="overflow-y-auto h-full"
+            className="h-full"
             css={{
               maxHeight: 300,
               '@media (min-width: 768px)': {


### PR DESCRIPTION
1. Fixed Bookmark, Download and RSS buttons sizes on the Course page
![01-fix-buttons](https://user-images.githubusercontent.com/1519448/108336356-9fa3fb80-71dc-11eb-83e7-9b8029f84410.gif)


2. Add toast message when user adds/removes the course to/from Bookmarks
![02-toast](https://user-images.githubusercontent.com/1519448/108336380-a599dc80-71dc-11eb-8534-b1a5ec39cf1a.gif)


3. Fix SimpleBar styles for the NextUp list on mobile
4. Multiple clicks on Bookmark button are avoided now



![](https://media2.giphy.com/media/IgjAo7ZmCmoOiHy5dU/giphy.gif?cid=5a38a5a2hbeoj5ahj4b58x9a4200vc3cvkj5gu55xithyuev&rid=giphy.gif)


