### PR TITLE
Visually separate magic link and oauth buttons

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -138,28 +138,32 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                         />
                       </div>
 
-                      <div className="flex justify-center items-center w-full">
-                        <button
-                          type="submit"
-                          disabled={isSubmitting}
-                          className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
-                        >
-                          {button}
-                        </button>
-                      </div>
-
-                      <ExternalTrackedLink
-                        href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
-                        eventName="clicked github login"
-                        className="flex justify-center mt-4 py-3 px-5 text-white bg-black hover:bg-gray-800 active:bg-gray-700 rounded-md transition-all ease-in-out duration-300"
-                      >
-                        <div className="flex items-center dark:text-gray-100">
-                          <span className="mr-2 flex items-center justify-center">
-                            <IconGithub className="fill-current" />
-                          </span>
-                          Sign In (or up) with GitHub
+                      <div className="flex flex-col space-y-2">
+                        <div className="flex justify-center items-center w-full">
+                          <button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                          >
+                            {button}
+                          </button>
                         </div>
-                      </ExternalTrackedLink>
+                        <p className="font-bold text-sm text-center uppercase text-gray-500 dark:text-gray-400">
+                          or
+                        </p>
+                        <ExternalTrackedLink
+                          href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
+                          eventName="clicked github login"
+                          className="flex justify-center mt-4 py-3 px-5 text-white bg-black hover:bg-gray-800 active:bg-gray-700 rounded-md transition-all ease-in-out duration-300"
+                        >
+                          <div className="flex items-center dark:text-gray-100">
+                            <span className="mr-2 flex items-center justify-center">
+                              <IconGithub className="fill-current" />
+                            </span>
+                            Sign In (or up) with GitHub
+                          </div>
+                        </ExternalTrackedLink>
+                      </div>
                     </form>
                   </>
                 )


### PR DESCRIPTION
Most sites I see that offer internal sign up as well as oauth separate the buttons visually, usually with an _OR_. This PR adds that kind of thing to the sign in page.

<img width="579" alt="CleanShot 2021-02-24 at 13 54 44@2x" src="https://user-images.githubusercontent.com/694063/109058040-21e26300-76a8-11eb-8120-f04a5994aa77.png">

### Prior Art

Atlassian

<img width="495" alt="CleanShot 2021-02-24 at 13 57 06@2x" src="https://user-images.githubusercontent.com/694063/109058667-e5fbcd80-76a8-11eb-91ed-7e4f68e9654f.png">

Notion

<img width="454" alt="CleanShot 2021-02-24 at 13 57 49@2x" src="https://user-images.githubusercontent.com/694063/109058703-f0b66280-76a8-11eb-9371-fcb41b626fb0.png">

Freshbooks

<img width="530" alt="CleanShot 2021-02-24 at 14 02 01@2x" src="https://user-images.githubusercontent.com/694063/109058715-f3b15300-76a8-11eb-89da-c6610997cb67.png">
