### PR TITLE
Add SAML Sign In page

### DIFF
--- a/src/components/users/saml-sign-in-form.tsx
+++ b/src/components/users/saml-sign-in-form.tsx
@@ -1,0 +1,90 @@
+import React, {FunctionComponent} from 'react'
+import * as yup from 'yup'
+import {Formik} from 'formik'
+
+const loginSchema = yup.object().shape({
+  email: yup.string().email().required('enter your email'),
+})
+
+type SamlSignInFormProps = {
+  switchToStandardAuth: Function
+}
+
+const SamlSignInForm: FunctionComponent<SamlSignInFormProps> = ({
+  switchToStandardAuth,
+}) => {
+  return (
+    <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+      <Formik
+        initialValues={{user_email: ''}}
+        validationSchema={loginSchema}
+        onSubmit={() => {}}
+      >
+        {(props) => {
+          const {values, isSubmitting, handleChange, handleBlur} = props
+          return (
+            <form
+              action={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/managed_subscriptions/saml_init`}
+            >
+              <label
+                htmlFor="email"
+                className="block leading-5 text-sm font-semibold"
+              >
+                SSO Email address
+              </label>
+              <div className="mt-1 relative rounded-md shadow-sm">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <svg
+                    className="h-5 w-5 text-gray-400"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                    <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                  </svg>
+                </div>
+                <input
+                  id="user_email"
+                  name="user_email"
+                  type="email"
+                  value={values.user_email}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="you@company.com"
+                  className="py-3 text-gray-900 placeholder-gray-400 focus:ring-indigo-500 focus:border-blue-500 block w-full pl-10 border-gray-300 rounded-md"
+                  required
+                />
+                <input name="user[email]" hidden value={values.user_email} />
+              </div>
+              <div className="flex flex-col space-y-2">
+                <div className="flex justify-center items-center w-full">
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                  >
+                    Continue with SSO
+                  </button>
+                </div>
+                <a
+                  className="pt-4 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150"
+                  href="/login"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    switchToStandardAuth()
+                  }}
+                >
+                  Sign In (or up) with Email or OAuth
+                </a>
+              </div>
+            </form>
+          )
+        }}
+      </Formik>
+    </div>
+  )
+}
+
+export default SamlSignInForm

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -7,6 +7,87 @@ import Image from 'next/image'
 import {IconGithub} from 'components/pages/lessons/code-link'
 import ExternalTrackedLink from '../components/external-tracked-link'
 
+const SamlLoginForm: FunctionComponent = ({switchToStandardAuth}) => {
+  return (
+    <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+      <Formik
+        initialValues={{user_email: ''}}
+        validationSchema={loginSchema}
+        onSubmit={() => {}}
+      >
+        {(props) => {
+          const {
+            values,
+            isSubmitting,
+            handleChange,
+            handleBlur,
+            handleSubmit,
+          } = props
+          return (
+            <form
+              action={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/managed_subscriptions/saml_init`}
+            >
+              <label
+                htmlFor="email"
+                className="block leading-5 text-sm font-semibold"
+              >
+                SSO Email address
+              </label>
+              <div className="mt-1 relative rounded-md shadow-sm">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <svg
+                    className="h-5 w-5 text-gray-400"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                    <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                  </svg>
+                </div>
+                <input
+                  id="user_email"
+                  name="user_email"
+                  type="email"
+                  value={values.user_email}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="you@company.com"
+                  className="py-3 text-gray-900 placeholder-gray-400 focus:ring-indigo-500 focus:border-blue-500 block w-full pl-10 border-gray-300 rounded-md"
+                  required
+                />
+                <input name="user[email]" hidden value={values.user_email} />
+              </div>
+              <div className="flex flex-col space-y-2">
+                <div className="flex justify-center items-center w-full">
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                  >
+                    Continue with SSO
+                  </button>
+                </div>
+                <a
+                  className="pt-4 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150"
+                  href="/login"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    switchToStandardAuth()
+                  }}
+                >
+                  Sign In (or up) with Email or OAuth
+                </a>
+              </div>
+            </form>
+          )
+        }}
+      </Formik>
+    </div>
+  )
+}
+
 const loginSchema = yup.object().shape({
   email: yup.string().email().required('enter your email'),
 })
@@ -20,6 +101,9 @@ type LoginFormProps = {
   formClassName?: string
   track?: any
 }
+
+const STANDARD_AUTH_MODE = 'STANDARD_AUTH_MODE'
+const SSO_AUTH_MODE = 'SSO_AUTH_MODE'
 
 const LoginForm: FunctionComponent<LoginFormProps> = ({
   image = (
@@ -42,6 +126,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
 }) => {
   const [isSubmitted, setIsSubmitted] = React.useState(false) // false
   const [isError, setIsError] = React.useState(false)
+  const [authMode, setAuthMode] = React.useState(STANDARD_AUTH_MODE)
   const {requestSignInEmail} = useViewer()
 
   return (
@@ -79,129 +164,147 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
               </h2>
             </>
           ))}
-        <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
-          {!isSubmitted && !isError && (
-            <Formik
-              initialValues={{email: ''}}
-              validationSchema={loginSchema}
-              onSubmit={(values) => {
-                setIsSubmitted(true)
-                requestSignInEmail(values.email)
-                  .then(() => {
-                    track && track(values.email)
-                  })
-                  .catch(() => {
-                    setIsSubmitted(false)
-                    setIsError(true)
-                  })
-              }}
-            >
-              {(props) => {
-                const {
-                  values,
-                  isSubmitting,
-                  handleChange,
-                  handleBlur,
-                  handleSubmit,
-                } = props
-                return (
-                  <>
-                    <form onSubmit={handleSubmit} className={formClassName}>
-                      <label
-                        htmlFor="email"
-                        className="block leading-5 text-sm font-semibold"
-                      >
-                        {label}
-                      </label>
-                      <div className="mt-1 relative rounded-md shadow-sm">
-                        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                          <svg
-                            className="h-5 w-5 text-gray-400"
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            aria-hidden="true"
-                          >
-                            <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-                            <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
-                          </svg>
-                        </div>
-                        <input
-                          id="email"
-                          type="email"
-                          value={values.email}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          placeholder="you@company.com"
-                          className="py-3 text-gray-900 placeholder-gray-400 focus:ring-indigo-500 focus:border-blue-500 block w-full pl-10 border-gray-300 rounded-md"
-                          required
-                        />
-                      </div>
-
-                      <div className="flex flex-col space-y-2">
-                        <div className="flex justify-center items-center w-full">
-                          <button
-                            type="submit"
-                            disabled={isSubmitting}
-                            className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
-                          >
-                            {button}
-                          </button>
-                        </div>
-                        <p className="font-bold text-sm text-center uppercase text-gray-500 dark:text-gray-400">
-                          or
-                        </p>
-                        <ExternalTrackedLink
-                          href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
-                          eventName="clicked github login"
-                          className="flex justify-center mt-4 py-3 px-5 text-white bg-black hover:bg-gray-800 active:bg-gray-700 rounded-md transition-all ease-in-out duration-300"
+        {authMode === SSO_AUTH_MODE ? (
+          <SamlLoginForm
+            switchToStandardAuth={() => {
+              setAuthMode(STANDARD_AUTH_MODE)
+            }}
+          />
+        ) : (
+          <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+            {!isSubmitted && !isError && (
+              <Formik
+                initialValues={{email: ''}}
+                validationSchema={loginSchema}
+                onSubmit={(values) => {
+                  setIsSubmitted(true)
+                  requestSignInEmail(values.email)
+                    .then(() => {
+                      track && track(values.email)
+                    })
+                    .catch(() => {
+                      setIsSubmitted(false)
+                      setIsError(true)
+                    })
+                }}
+              >
+                {(props) => {
+                  const {
+                    values,
+                    isSubmitting,
+                    handleChange,
+                    handleBlur,
+                    handleSubmit,
+                  } = props
+                  return (
+                    <>
+                      <form onSubmit={handleSubmit} className={formClassName}>
+                        <label
+                          htmlFor="email"
+                          className="block leading-5 text-sm font-semibold"
                         >
-                          <div className="flex items-center dark:text-gray-100">
-                            <span className="mr-2 flex items-center justify-center">
-                              <IconGithub className="fill-current" />
-                            </span>
-                            Sign In (or up) with GitHub
+                          {label}
+                        </label>
+                        <div className="mt-1 relative rounded-md shadow-sm">
+                          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                            <svg
+                              className="h-5 w-5 text-gray-400"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 20 20"
+                              fill="currentColor"
+                              aria-hidden="true"
+                            >
+                              <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                              <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                            </svg>
                           </div>
-                        </ExternalTrackedLink>
-                      </div>
-                    </form>
-                  </>
-                )
-              }}
-            </Formik>
-          )}
-          {isSubmitted && (
-            <div className="text-center leading-tight space-y-4">
-              <h3 className="text-xl leading-tighter font-semibold">
-                Please check your inbox for your sign in link.
-              </h3>
-              <p>
-                Sometimes this can land in SPAM! While we hope that isn't the
-                case if it doesn't arrive in a minute or three, please check.
-              </p>
-            </div>
-          )}
-          {isError && (
-            <div className="text-text">
-              <p>
-                Login Link Not Sent{' '}
-                <span role="img" aria-label="sweating">
-                  😅
-                </span>
-              </p>
-              <p className="pt-3">
-                Are you using an aggressive ad blocker such as Privacy Badger?
-                Please disable it for this site and reload the page to try
-                again.
-              </p>
-              <p className="pt-3">
-                If you <strong>aren't</strong> running aggressive adblocking
-                please check the console for errors and email support@egghead.io
-                with any info and we will help you ASAP.
-              </p>
-            </div>
-          )}
-        </div>
+                          <input
+                            id="email"
+                            type="email"
+                            value={values.email}
+                            onChange={handleChange}
+                            onBlur={handleBlur}
+                            placeholder="you@company.com"
+                            className="py-3 text-gray-900 placeholder-gray-400 focus:ring-indigo-500 focus:border-blue-500 block w-full pl-10 border-gray-300 rounded-md"
+                            required
+                          />
+                        </div>
+
+                        <div className="flex flex-col space-y-2">
+                          <div className="flex justify-center items-center w-full">
+                            <button
+                              type="submit"
+                              disabled={isSubmitting}
+                              className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                            >
+                              {button}
+                            </button>
+                          </div>
+                          <p className="font-bold text-sm text-center uppercase text-gray-500 dark:text-gray-400">
+                            or
+                          </p>
+                          <ExternalTrackedLink
+                            href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
+                            eventName="clicked github login"
+                            className="flex justify-center mt-4 py-3 px-5 text-white bg-black hover:bg-gray-800 active:bg-gray-700 rounded-md transition-all ease-in-out duration-300"
+                          >
+                            <div className="flex items-center dark:text-gray-100">
+                              <span className="mr-2 flex items-center justify-center">
+                                <IconGithub className="fill-current" />
+                              </span>
+                              Sign In (or up) with GitHub
+                            </div>
+                          </ExternalTrackedLink>
+                          <a
+                            className="pt-4 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150"
+                            href="/login"
+                            onClick={(e) => {
+                              e.preventDefault()
+                              setAuthMode(SSO_AUTH_MODE)
+                            }}
+                          >
+                            Sign In (or up) with Single Sign-On (SSO)
+                          </a>
+                        </div>
+                      </form>
+                    </>
+                  )
+                }}
+              </Formik>
+            )}
+            {isSubmitted && (
+              <div className="text-center leading-tight space-y-4">
+                <h3 className="text-xl leading-tighter font-semibold">
+                  Please check your inbox for your sign in link.
+                </h3>
+                <p>
+                  Sometimes this can land in SPAM! While we hope that isn't the
+                  case if it doesn't arrive in a minute or three, please check.
+                </p>
+              </div>
+            )}
+            {isError && (
+              <div className="text-text">
+                <p>
+                  Login Link Not Sent{' '}
+                  <span role="img" aria-label="sweating">
+                    😅
+                  </span>
+                </p>
+                <p className="pt-3">
+                  Are you using an aggressive ad blocker such as Privacy Badger?
+                  Please disable it for this site and reload the page to try
+                  again.
+                </p>
+                <p className="pt-3">
+                  If you <strong>aren't</strong> running aggressive adblocking
+                  please check the console for errors and email
+                  support@egghead.io with any info and we will help you ASAP.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -6,87 +6,7 @@ import {useViewer} from 'context/viewer-context'
 import Image from 'next/image'
 import {IconGithub} from 'components/pages/lessons/code-link'
 import ExternalTrackedLink from '../components/external-tracked-link'
-
-const SamlLoginForm: FunctionComponent = ({switchToStandardAuth}) => {
-  return (
-    <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
-      <Formik
-        initialValues={{user_email: ''}}
-        validationSchema={loginSchema}
-        onSubmit={() => {}}
-      >
-        {(props) => {
-          const {
-            values,
-            isSubmitting,
-            handleChange,
-            handleBlur,
-            handleSubmit,
-          } = props
-          return (
-            <form
-              action={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/managed_subscriptions/saml_init`}
-            >
-              <label
-                htmlFor="email"
-                className="block leading-5 text-sm font-semibold"
-              >
-                SSO Email address
-              </label>
-              <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <svg
-                    className="h-5 w-5 text-gray-400"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-                    <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
-                  </svg>
-                </div>
-                <input
-                  id="user_email"
-                  name="user_email"
-                  type="email"
-                  value={values.user_email}
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  placeholder="you@company.com"
-                  className="py-3 text-gray-900 placeholder-gray-400 focus:ring-indigo-500 focus:border-blue-500 block w-full pl-10 border-gray-300 rounded-md"
-                  required
-                />
-                <input name="user[email]" hidden value={values.user_email} />
-              </div>
-              <div className="flex flex-col space-y-2">
-                <div className="flex justify-center items-center w-full">
-                  <button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
-                  >
-                    Continue with SSO
-                  </button>
-                </div>
-                <a
-                  className="pt-4 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150"
-                  href="/login"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    switchToStandardAuth()
-                  }}
-                >
-                  Sign In (or up) with Email or OAuth
-                </a>
-              </div>
-            </form>
-          )
-        }}
-      </Formik>
-    </div>
-  )
-}
+import SamlSignInForm from '../components/users/saml-sign-in-form'
 
 const loginSchema = yup.object().shape({
   email: yup.string().email().required('enter your email'),
@@ -165,7 +85,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
             </>
           ))}
         {authMode === SSO_AUTH_MODE ? (
-          <SamlLoginForm
+          <SamlSignInForm
             switchToStandardAuth={() => {
               setAuthMode(STANDARD_AUTH_MODE)
             }}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -183,7 +183,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                               setAuthMode(SSO_AUTH_MODE)
                             }}
                           >
-                            Sign In (or up) with Single Sign-On (SSO)
+                            Enterprise Login (SSO)
                           </a>
                         </div>
                       </form>


### PR DESCRIPTION
_See a video of this workflow end-to-end in [this comment](https://github.com/eggheadio/egghead-rails/issues/4370#issuecomment-786165262)_

This adds an SSO Sign In variant of the Sign In page as an alternative to the standard Magic Link / OAuth sign in. This sign in variant requires that the user's organization has worked with egghead support to set up all the behind the scenes SAML stuff first.

Here is a look at how you toggle between the two Sign In variants:


https://user-images.githubusercontent.com/694063/109213508-4c9aed00-7776-11eb-8986-459f2f916df3.mp4

Prior art on this from Stripe:


https://user-images.githubusercontent.com/694063/109213597-676d6180-7776-11eb-859c-d914d9c765fb.mp4

---


![](https://media3.giphy.com/media/IhgLtdYLoAeZw1U8TM/200.gif?cid=5a38a5a2lr9u98yv6uj9m12g9j6zh30abzkp5mes3gxcr8by&rid=200.gif)
