### PR TITLE
Add generic invite link support for team accounts

### DIFF
--- a/src/components/app/header.tsx
+++ b/src/components/app/header.tsx
@@ -60,7 +60,7 @@ const Header: FunctionComponent = () => {
                 </a>
               </Link>
             )}
-            {!isEmpty(viewer?.team) && (
+            {(!isEmpty(viewer?.team) || !isEmpty(viewer?.team_accounts)) && (
               <Link href={`/team`}>
                 <a
                   onClick={() =>

--- a/src/pages/team-invite/[token].tsx
+++ b/src/pages/team-invite/[token].tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import {useViewer} from '../../context/viewer-context'
+import {GetServerSideProps} from 'next'
+import {AUTH_DOMAIN, getAuthorizationHeader} from 'utils/auth'
+import axios from 'axios'
+import toast from 'react-hot-toast'
+import {useRouter} from 'next/router'
+
+const handleJoinTeam = async (token: string, router: any) => {
+  try {
+    await axios.post(
+      `${AUTH_DOMAIN}//api/v1/accounts/team_invite/${token}`,
+      {},
+      {
+        headers: {...getAuthorizationHeader()},
+      },
+    )
+
+    toast.success("You've successfully joined this team", {
+      icon: '✅',
+    })
+
+    router.replace('/')
+  } catch (e) {
+    toast.error(
+      "There was an issue joining the team. Please contact the team's account administrator if the issue persists.",
+      {
+        duration: 6000,
+        icon: '❌',
+      },
+    )
+  }
+}
+
+const TeamInvite: React.FunctionComponent<{
+  token: string
+  teamData: any
+}> = ({token, teamData}) => {
+  const {authToken, loading} = useViewer()
+  const router = useRouter()
+
+  const alreadySignedIn = !loading && typeof authToken === 'string'
+
+  return (
+    <section className="mb-32">
+      <div className="p-4 w-full">
+        <div className="w-full mx-auto md:py-32 py-16 flex flex-col items-center justify-center text-gray-900 dark:text-trueGray-100">
+          <h2 className="text-center text-3xl leading-9 font-bold">
+            Team Invite
+          </h2>
+          <div className="sm:mt-8 mt-4 sm:mx-auto sm:w-full sm:max-w-xl">
+            <p className="text-center pb-4">
+              You've been invited by{' '}
+              <span className="font-bold">{teamData.team_owner}</span> to join
+              their team on egghead. Click 'Join Team' to accept the invitation
+              and get full access to everything on egghead.
+            </p>
+            {!alreadySignedIn && (
+              <p className="text-center mb-4 p-4 bg-blue-50 dark:bg-gray-800 rounded">
+                You need to{' '}
+                <a
+                  href="/login"
+                  className="text-blue-600 hover:text-blue-800 cursor-pointer transition-colors ease-in-out duration-150"
+                >
+                  sign in
+                </a>{' '}
+                before you can accept this invitation. Revisit this page after
+                signing in to proceed.
+              </p>
+            )}
+            <div className="flex justify-center items-center w-full">
+              <button
+                className={`text-white bg-green-600 border-0 py-2 px-8 focus:outline-none rounded
+                    ${
+                      alreadySignedIn
+                        ? 'hover:bg-green-700'
+                        : 'cursor-not-allowed opacity-50'
+                    }`}
+                disabled={!alreadySignedIn}
+                onClick={() => handleJoinTeam(token, router)}
+              >
+                Join Team
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({req, params}) => {
+  const token = params && (params.token as string)
+  const viewTeamInviteUrl = `${AUTH_DOMAIN}/api/v1/accounts/team_invite/${token}`
+  const {data} = await axios.get(viewTeamInviteUrl)
+
+  return {
+    props: {
+      teamData: data,
+      token,
+    },
+  }
+}
+
+export default TeamInvite

--- a/src/pages/team-invite/[token].tsx
+++ b/src/pages/team-invite/[token].tsx
@@ -32,6 +32,8 @@ const handleJoinTeam = async (token: string, router: any) => {
   }
 }
 
+const TOKEN_NOT_RECOGNIZED = 'TOKEN_NOT_RECOGNIZED'
+
 const TeamInvite: React.FunctionComponent<{
   token: string
   teamData: any
@@ -40,6 +42,16 @@ const TeamInvite: React.FunctionComponent<{
   const router = useRouter()
 
   const alreadySignedIn = !loading && typeof authToken === 'string'
+
+  React.useEffect(() => {
+    if (token === TOKEN_NOT_RECOGNIZED) {
+      toast.error('This is not a recognized team invite link.', {
+        duration: 6000,
+        icon: '❌',
+      })
+      router.replace('/')
+    }
+  }, [token])
 
   return (
     <section className="mb-32">
@@ -92,13 +104,18 @@ const TeamInvite: React.FunctionComponent<{
 export const getServerSideProps: GetServerSideProps = async ({req, params}) => {
   const token = params && (params.token as string)
   const viewTeamInviteUrl = `${AUTH_DOMAIN}/api/v1/accounts/team_invite/${token}`
-  const {data} = await axios.get(viewTeamInviteUrl)
 
-  return {
-    props: {
-      teamData: data,
-      token,
-    },
+  try {
+    const {data} = await axios.get(viewTeamInviteUrl)
+
+    return {
+      props: {
+        teamData: data,
+        token,
+      },
+    }
+  } catch (e) {
+    return {props: {teamData: {}, token: TOKEN_NOT_RECOGNIZED}}
   }
 }
 

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -4,20 +4,52 @@ import LoginRequired from '../components/login-required'
 import {useRouter} from 'next/router'
 import {FunctionComponent} from 'react'
 import useClipboard from 'react-use-clipboard'
+import isEmpty from 'lodash/isEmpty'
+
+interface TeamData {
+  inviteUrl: string
+  members: Array<any>
+  isFull: boolean
+}
+
+const normalizeTeamData = (viewer: any): TeamData | undefined => {
+  if (!!viewer?.team) {
+    // Managed Subscription
+    return {
+      inviteUrl: viewer.team.invite_url,
+      members: viewer.team.members || [],
+      isFull: viewer.team.user_limit <= viewer.team.members.length,
+    }
+  } else if (!isEmpty(viewer?.team_accounts)) {
+    // Team Account that this user is an Owner of
+    // *grab the first, assuming just one team account for now
+    const team = viewer.team_accounts[0]
+
+    return {
+      inviteUrl: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/team/invite/${team.invite_token}`,
+      members: team.members || [],
+      isFull: team.user_limit <= team.members.length,
+    }
+  }
+  // implicitly return undefined if the user doesn't have a team
+}
 
 const Team = () => {
   const {viewer, loading} = useViewer()
   const router = useRouter()
 
+  const teamData = normalizeTeamData(viewer)
+  const teamDataAvailable = typeof teamData !== 'undefined'
+
   React.useEffect(() => {
-    if (!loading && !viewer.team) {
+    if (!loading && !teamDataAvailable) {
       router.push('/')
     }
-  }, [viewer, loading])
+  }, [loading, teamDataAvailable])
 
   return (
     <LoginRequired>
-      {!loading && viewer?.team && (
+      {!loading && !!teamData && (
         <div className="lg:prose-lg prose xl:prose-xl max-w-screen-xl mx-auto mb-24">
           <h1>Team Account</h1>
           <p>
@@ -29,16 +61,16 @@ const Team = () => {
           </p>
           <p>Your invite link to add new team members is: </p>
           <div className="flex items-center">
-            <code>{viewer.team.invite_url}</code>
+            <code>{teamData.inviteUrl}</code>
             <CopyToClipboard
-              stringToCopy={viewer.team.invite_url}
+              stringToCopy={teamData.inviteUrl}
               className="inline-block"
               label={true}
             />
           </div>
           <h3>Current Team Members:</h3>
           <ul>
-            {viewer.team?.members?.map((member: any) => {
+            {teamData.members.map((member: any) => {
               return <li key={member.email}>{member.email}</li>
             })}
           </ul>

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -26,7 +26,7 @@ const normalizeTeamData = (viewer: any): TeamData | undefined => {
     const team = viewer.team_accounts[0]
 
     return {
-      inviteUrl: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/team/invite/${team.invite_token}`,
+      inviteUrl: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/team-invite/${team.invite_token}`,
       members: team.members || [],
       isFull: team.user_limit <= team.members.length,
     }

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import {useViewer} from '../context/viewer-context'
-import LoginRequired from '../components/login-required'
+import {useViewer} from '../../context/viewer-context'
+import LoginRequired from '../../components/login-required'
 import {useRouter} from 'next/router'
 import {FunctionComponent} from 'react'
 import useClipboard from 'react-use-clipboard'


### PR DESCRIPTION
- Account owners of a Team Account now see the 'Team' link show up in the nav bar.
- Account owners of a Team Account can go to their team page to see a listing of their team's members and get a generic invite link.
- Users visiting a generic team invite link will see a confirmation page where they can accept the invite if they are logged in.

See [this PR](https://github.com/eggheadio/egghead-rails/pull/4422) for a video showcasing the new behavior.

<img width="913" alt="CleanShot 2021-03-10 at 14 29 20@2x" src="https://user-images.githubusercontent.com/694063/110693469-15343380-81ad-11eb-810e-c0da9f7420a0.png">


![](https://media1.giphy.com/media/gjdG2O7FOpaso/giphy.gif?cid=5a38a5a2vruorsnzuvb4f0r2a5ble3c4xdb682utiz6ggxwc&rid=giphy.gif)
