### PR TITLE
Add team capacity indications on team page

### DIFF
--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -9,29 +9,95 @@ import isEmpty from 'lodash/isEmpty'
 interface TeamData {
   inviteUrl: string
   members: Array<any>
+  numberOfMembers: number
+  capacity: number
   isFull: boolean
 }
 
 const normalizeTeamData = (viewer: any): TeamData | undefined => {
   if (!!viewer?.team) {
+    const members = viewer.team.members || []
+
     // Managed Subscription
     return {
       inviteUrl: viewer.team.invite_url,
-      members: viewer.team.members || [],
-      isFull: viewer.team.user_limit <= viewer.team.members.length,
+      members: members,
+      numberOfMembers: members.length,
+      capacity: viewer.team.user_limit,
+      isFull: viewer.team.user_limit <= members.length,
     }
   } else if (!isEmpty(viewer?.team_accounts)) {
     // Team Account that this user is an Owner of
     // *grab the first, assuming just one team account for now
     const team = viewer.team_accounts[0]
+    const members = team.members || []
 
     return {
       inviteUrl: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/team-invite/${team.invite_token}`,
-      members: team.members || [],
-      isFull: team.user_limit <= team.members.length,
+      members,
+      numberOfMembers: members.length,
+      capacity: team.user_limit,
+      isFull: team.user_limit <= members.length,
     }
   }
   // implicitly return undefined if the user doesn't have a team
+}
+
+const TeamComposition = ({teamData}: {teamData: TeamData}) => {
+  const {numberOfMembers, capacity} = teamData
+
+  const valid =
+    typeof numberOfMembers === 'number' &&
+    numberOfMembers > 0 &&
+    typeof capacity === 'number' &&
+    capacity > 0
+
+  if (valid) {
+    return <span>{`(${numberOfMembers}/${capacity})`}</span>
+  } else {
+    return null
+  }
+}
+
+const AtCapacityNotice = ({teamData}: {teamData: TeamData}) => {
+  if (!teamData.isFull) {
+    return null
+  }
+
+  return (
+    <div
+      className="relative px-4 py-1 mt-4 mb-4 leading-normal text-orange-700 bg-orange-100 dark:text-orange-100 dark:bg-orange-800 rounded"
+      role="alert"
+    >
+      <span className="absolute inset-y-0 left-0 flex items-center ml-4">
+        <svg
+          className="w-6 h-6"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+      </span>
+      <p className="ml-8">
+        Your team account is full. If you'd like to add more members to your
+        team, please contact{' '}
+        <a
+          className="font-bold underline transition-colors ease-in-out duration-150"
+          href="mailto:support@egghead.io"
+        >
+          support@egghead.io
+        </a>{' '}
+        to increase the number of seats.
+      </p>
+    </div>
+  )
 }
 
 const Team = () => {
@@ -68,7 +134,10 @@ const Team = () => {
               label={true}
             />
           </div>
-          <h3>Current Team Members:</h3>
+          <AtCapacityNotice teamData={teamData} />
+          <h3>
+            Current Team Members <TeamComposition teamData={teamData} />
+          </h3>
           <ul>
             {teamData.members.map((member: any) => {
               return <li key={member.email}>{member.email}</li>

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -30,6 +30,8 @@ const normalizeTeamData = (viewer: any): TeamData | undefined => {
       numberOfMembers: members.length,
       capacity: viewer.team.user_limit,
       isFull: viewer.team.user_limit <= members.length,
+      accountSlug: undefined,
+      stripeCustomerId: undefined,
     }
   } else if (!isEmpty(viewer?.team_accounts)) {
     // Team Account that this user is an Owner of


### PR DESCRIPTION
- List # of members / # of seats
- Show warning when seats are full and prompt user to upgrade
subscription

<img width="1039" alt="CleanShot 2021-03-15 at 11 34 40@2x" src="https://user-images.githubusercontent.com/694063/111187917-80518180-8582-11eb-9b7d-5e7caba59073.png">


![](https://media0.giphy.com/media/p48o3O4mfDbI21yRyt/200.gif?cid=5a38a5a2utfd0vqi5lhn5xtafjhqzypr4jptnkcyj76arg7w&rid=200.gif)
