### PR TITLE
emotion 11 fix

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
 import {AppProps, NextWebVitalsMetric} from 'next/app'
-import {CacheProvider} from '@emotion/react'
 import {MDXProvider} from '@mdx-js/react'
 import {ViewerProvider} from 'context/viewer-context'
 import {DefaultSeo, SocialProfileJsonLd} from 'next-seo'
-import {cache} from '@emotion/css'
 import AppLayout from 'components/app/layout'
 import mdxComponents from 'components/mdx'
 import defaultSeoConfig from 'next-seo.json'
@@ -22,6 +20,8 @@ import RouteLoadingIndicator from 'components/route-loading-indicator'
 import {useRouter} from 'next/router'
 import {ThemeProvider} from 'next-themes'
 import {Toaster} from 'react-hot-toast'
+
+// console.log('cache: ', cache)
 
 declare global {
   interface Window {
@@ -101,9 +101,7 @@ const App: React.FC<AppProps> = ({Component, pageProps}) => {
             <CioProvider>
               <ConvertkitProvider>
                 <MDXProvider components={mdxComponents}>
-                  <CacheProvider value={cache}>
-                    {getLayout(Component, pageProps)}
-                  </CacheProvider>
+                  {getLayout(Component, pageProps)}
                 </MDXProvider>
               </ConvertkitProvider>
             </CioProvider>


### PR DESCRIPTION
Got rid of `CacheProvider` in the `_app.tsx`.
According to this example on vercel's GH: https://github.com/vercel/next.js/tree/canary/examples/with-emotion-vanilla



![](https://media1.giphy.com/media/TGh95hgIVvTiPD3UKw/200.gif?cid=5a38a5a2tbzmohtefhw2v40gsystvco6n67xqyn2fzosa7h5&rid=200.gif)
