### PR TITLE
feature: CSS Grid course

### DIFF
--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -1,22 +1,22 @@
 const homepageData = [
   {
     id: 'jumbotron',
-    title: 'Declarative UIs without CSS with elm-ui',
+    title: 'Build Modern Layouts with CSS Grid',
     byline: 'featured course',
-    description: `elm-ui separates out style and layout so you leverage Elm in the way you build an interface. You'll learn how to design a UI with a declarative mindset through building a form, creating layouts, and positioning elements on the screen.`,
+    description: `CSS Grid is a new technology that allows you to problem solve at the page-layout level. Learn how to create two-dimensional layouts that adapt content to the available space and intelligently size and position items within those bounds. `,
     image:
-      'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615284992/next.egghead.io/resources/declarative-uis-without-css-with-elm-ui/illustration-declarative-uis-without-css-with-elm-ui_2x.png',
+      'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/418/653/full/EGH_modern-layouts-css__1000.png',
     background:
-      'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615288976/next.egghead.io/resources/declarative-uis-without-css-with-elm-ui/background-declarative-uis-without-css-with-elm-ui.svg',
-    path: '/courses/declarative-uis-without-css-with-elm-ui-93bd',
-    slug: 'declarative-uis-without-css-with-elm-ui-93bd',
+      'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615913074/egghead-next-pages/build-modern-layouts-with-css-grid/background-build-modern-layouts-with-css-grid.svg',
+    path: '/courses/build-modern-layouts-with-css-grid-d3f5',
+    slug: 'build-modern-layouts-with-css-grid-d3f5',
     instructor: {
-      name: 'Flavio Corpa',
-      slug: 'flavio-corpa',
-      path: '/q/resources-by-flavio-corpa',
-      twitter: 'FlavioCorpa',
+      name: 'Hiroko Nishimura',
+      slug: 'hiro-nishimura',
+      path: '/q/resources-by-hiro-nishimura',
+      twitter: 'hirokonishimura',
       image:
-        'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/154/medium/avatar.jpg',
+        'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/458/medium/IMG_20190627_100655_466.jpg',
     },
   },
   {
@@ -101,13 +101,21 @@ There are a number of tried and true methods that will allow you to learn more e
           'build-a-corgi-up-boop-web-app-with-netlify-serverless-functions-and-hasura-553c',
       },
       {
-        name: 'Ship anywhere',
-        title: 'Containerize Apps with Docker',
-        byline: 'Joel Lord ・1h 24m・Course',
+        name: 'layout design',
+        id: 'elm-ui',
+        title: 'Declarative UIs without CSS with elm-ui',
+        byline: 'Flavio Corpa ・1h 27m・Course',
         image:
-          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/410/102/full/egh_intro-to-docker.png',
-        path:
-          '/playlists/containerize-full-stack-javascript-applications-with-docker-30a8',
+          'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615284992/next.egghead.io/resources/declarative-uis-without-css-with-elm-ui/illustration-declarative-uis-without-css-with-elm-ui_2x.png',
+        path: '/courses/declarative-uis-without-css-with-elm-ui-93bd',
+        instructor: {
+          name: 'Flavio Corpa',
+          slug: 'flavio-corpa',
+          path: '/q/resources-by-flavio-corpa',
+          twitter: 'FlavioCorpa',
+          image:
+            'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/154/medium/avatar.jpg',
+        },
       },
     ],
   },

--- a/src/components/search/instructors/hiroko-nishimura/hiroko-nishimura-page-data.ts
+++ b/src/components/search/instructors/hiroko-nishimura/hiroko-nishimura-page-data.ts
@@ -1,0 +1,26 @@
+const HirokoNishimuraPageData = [
+  {
+    id: 'instructor-data',
+    name: 'Hiroko Nishimura',
+    bio: `AWS Community Hero. Founder of AWS Newbies and LinkedIn Learning instructor.`,
+    twitterHandle: 'hirokonishimura',
+    websiteURL: 'https://hirokonishimura.com/',
+    slug: 'resources-by-hiro-nishimura',
+    location: 'Hiroko Nishimura Instructor Page',
+    imageUrl:
+      'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/458/medium/IMG_20190627_100655_466.jpg',
+    feature: {
+      title: 'Build Modern Layouts with CSS Grid',
+      description:
+        'CSS Grid is a new technology that allows you to problem solve at the page-layout level. Learn how to create two-dimensional layouts that adapt content to the available space and intelligently size and position items within those bounds.',
+      byline: 'Featured Course ・ CSS ・ 22m',
+      image:
+        'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/418/653/full/EGH_modern-layouts-css__1000.png',
+      backgroundImage:
+        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615917970/egghead-next-pages/build-modern-layouts-with-css-grid/instructor-page-background-CTA.svg',
+      path: '/courses/build-modern-layouts-with-css-grid-d3f5',
+    },
+  },
+]
+
+export default HirokoNishimuraPageData

--- a/src/components/search/instructors/hiroko-nishimura/index.tsx
+++ b/src/components/search/instructors/hiroko-nishimura/index.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import SearchInstructorEssential from '../instructor-essential'
+import HirokoNishimuraPageData from './hiroko-nishimura-page-data'
+import ResourceCta from 'components/search/instructors/resource-cta'
+import find from 'lodash/find'
+
+export default function SearchHirokoNishimura({instructor}: {instructor: any}) {
+  const instructorData: any = find(HirokoNishimuraPageData, {
+    id: 'instructor-data',
+  })
+
+  const combinedInstructor = {...instructor, ...instructorData}
+
+  return (
+    <SearchInstructorEssential
+      instructor={combinedInstructor}
+      CTAComponent={<ResourceCta instructorData={instructorData} />}
+    />
+  )
+}

--- a/src/components/search/instructors/index.tsx
+++ b/src/components/search/instructors/index.tsx
@@ -3,6 +3,7 @@ import SearchColbyFayock from './colby-fayock'
 import SearchJohnLindquist from './john-lindquist'
 import SearchLaurieBarth from './laurie-barth'
 import SearchFlavioCorpa from './flavio-corpa'
+import SearchHirokoNishimura from './hiroko-nishimura'
 
 const InstructorsIndex: any = {
   'dan-abramov': SearchDanAbramov,
@@ -10,6 +11,7 @@ const InstructorsIndex: any = {
   'john-lindquist': SearchJohnLindquist,
   'laurie-barth': SearchLaurieBarth,
   'flavio-corpa': SearchFlavioCorpa,
+  'hiro-nishimura': SearchHirokoNishimura,
 }
 
 export default InstructorsIndex

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ const IndexPage: FunctionComponent = () => {
           images: [
             {
               url:
-                'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615288249/next.egghead.io/cards/egghead.io-declarative-uis-without-css-with-elm-ui_2x.png',
+                'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1615844448/egghead-next-pages/build-modern-layouts-with-css-grid/og-image.png',
             },
           ],
         }}


### PR DESCRIPTION
## Changes made
Update home page and Hiro's instructor page with [CSS Grid course](https://egghead.io/courses/build-modern-layouts-with-css-grid-d3f5) CTAs.


We can take this PR and start pulling in data from sanity for the pages that need it. The course object in sanity has the necessary data to do so


![Build the portfolio you need to be a badass web developer   egghead io](https://user-images.githubusercontent.com/6188161/111359347-c6314700-8661-11eb-82f6-13fe3a41abdf.png)

![Learn web development from Hiroko Nishimura on egghead  egghead io](https://user-images.githubusercontent.com/6188161/111359335-c3365680-8661-11eb-9b5c-470c24eff829.png)



![](https://media2.giphy.com/media/Ki2GJjJTlLK2k/giphy.gif?cid=5a38a5a29fdv1ahusrmsuqf658hvqwho0rzic8hju99dytt5&rid=giphy.gif)

