### PR TITLE
Get latest invoice to display current charged amount

### DIFF
--- a/src/components/users/subscription-details.tsx
+++ b/src/components/users/subscription-details.tsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import Link from 'next/link'
 import {track} from '../../utils/analytics'
 import {useViewer} from 'context/viewer-context'
+import get from 'lodash/get'
 
 type SubscriptionDetailsProps = {
   stripeCustomerId: string
@@ -44,13 +45,18 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = (
   }, [stripeCustomerId, slug])
 
   const subscriptionName = subscriptionData && subscriptionData.product?.name
+  const subscriptionUnitAmount = get(
+    subscriptionData,
+    'latestInvoice.amount_due',
+    subscriptionData?.price?.unit_amount,
+  )
   const subscriptionPrice =
     subscriptionData?.price &&
     new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: subscriptionData.price.currency,
       minimumFractionDigits: 0,
-    }).format(subscriptionData.price.unit_amount / 100)
+    }).format(subscriptionUnitAmount / 100)
 
   return (
     <>

--- a/src/pages/api/stripe/billing/session.ts
+++ b/src/pages/api/stripe/billing/session.ts
@@ -21,21 +21,26 @@ const StripeCheckoutSession = async (
         throw new Error(`no session loaded for ${req.query.session_id}`)
 
       const customer = await stripe.customers.retrieve(customer_id, {
-        expand: ['default_source'],
+        expand: ['default_source', 'subscriptions.data.latest_invoice'],
       })
 
       const subscription = customer.subscriptions?.data[0]
 
       if (subscription) {
         const price = get(first(subscription.items.data), 'price')
+        const latestInvoice = get(subscription, 'latest_invoice')
 
         const {product: product_id} = price
 
         const product = await stripe.products.retrieve(product_id)
 
-        res
-          .status(200)
-          .json({portalUrl: session.url, subscription, price, product})
+        res.status(200).json({
+          portalUrl: session.url,
+          subscription,
+          price,
+          product,
+          latestInvoice,
+        })
       } else {
         res.status(200).json({portalUrl: session.url, customer})
       }


### PR DESCRIPTION
The yearly subscription is tiered, so you can't access `price.unit_amount` [stripe doc](https://stripe.com/docs/api/prices/object#price_object-unit_amount).

This grabs the `subscriptions.latest_invoice` so that we can display the `amount_due` to the user instead of 0 dollars.

![woo](https://media0.giphy.com/media/eMgVkxAYL5pLnz7cvZ/giphy.gif?cid=74e95743mczjihscui6u0twnaaqk1idustgvyuurs1hgtmtf&rid=giphy.gif)