### PR TITLE
Fix negative margin on Talk video

### DIFF
--- a/src/pages/talks/[slug].tsx
+++ b/src/pages/talks/[slug].tsx
@@ -136,7 +136,7 @@ const Talk: FunctionComponent<LessonProps> = ({initialLesson}) => {
         <script src="//cdn.bitmovin.com/player/web/8/bitmovinplayer.js" />
       </Head>
       <div>
-        <div className="bg-black -mt-3 sm:-mt-5 sm:-mx-8 -mx-5">
+        <div className="bg-black -mt-3 sm:-mt-5 -mx-5">
           <div
             className="w-full m-auto"
             css={{


### PR DESCRIPTION
problem described in https://github.com/eggheadio/egghead-next/issues/522

before:
![before](https://user-images.githubusercontent.com/1519448/112947003-e8859300-913e-11eb-8073-e436fb0ff5e9.gif)

after:
![after](https://user-images.githubusercontent.com/1519448/112947018-ede2dd80-913e-11eb-9ff2-f7e39924075c.gif)



![](https://media3.giphy.com/media/C6TUZ559o8hAA/giphy.gif?cid=5a38a5a2kmjdr8rjqczw2raycsgjhv2evlf3e6i5q600bg69&rid=giphy.gif)
