### PR TITLE
Add table of members to team page fetched from gql

### DIFF
--- a/src/lib/teams.ts
+++ b/src/lib/teams.ts
@@ -1,0 +1,41 @@
+import {GraphQLClient} from 'graphql-request'
+import config from './config'
+
+const graphQLClient = new GraphQLClient(config.graphQLEndpoint)
+
+export async function loadTeams(token: string) {
+  const query = /* GraphQL */ `
+    query getAccounts {
+      accounts {
+        data {
+          id
+          slug
+          members {
+            id
+            roles
+            email
+            name
+            date_added
+          }
+        }
+      }
+    }
+  `
+  const authorizationHeader = token && {
+    authorization: `Bearer ${token}`,
+  }
+
+  graphQLClient.setHeaders({
+    ...authorizationHeader,
+  })
+
+  try {
+    const {accounts} = await graphQLClient.request(query)
+    console.log({accounts})
+    return accounts
+  } catch (e) {
+    console.error(e)
+    console.error(e.response.errors)
+    return
+  }
+}


### PR DESCRIPTION
Displays more data about each team member in a table on the team page.

This table will be a natural place to add controls for managing members of the team (i.e. removing them if needed).

<img width="1062" alt="CleanShot 2021-03-30 at 16 18 39@2x" src="https://user-images.githubusercontent.com/694063/113058767-2f41b000-9174-11eb-885e-db92cf0a59c1.png">


![](https://media4.giphy.com/media/l3q2Wl7Wpz09Z5hfi/giphy.gif?cid=5a38a5a21pfwdophxxm4nt22jber4j4doxg8fww50n6ukmel&rid=giphy.gif)
