### PR TITLE
Merge sanity course data when present

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -185,7 +185,6 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
     multiModuleLineheight,
   } = courseDependencies
 
-  console.log('course:', course)
   const {
     title,
     image_thumb_url,
@@ -226,8 +225,6 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
   const coursePrerequisites = !isEmpty(sanityPrerequisites)
     ? sanityPrerequisites
     : prerequisites
-
-  console.log({courseTopics}, {topics})
 
   const podcast = first(
     course?.items?.filter((item: any) => item.type === 'podcast'),

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -185,6 +185,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
     multiModuleLineheight,
   } = courseDependencies
 
+  console.log('course:', course)
   const {
     title,
     image_thumb_url,
@@ -200,12 +201,33 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
     collection_progress,
     favorited,
     updated_at,
+    prerequisites: sanityPrerequisites,
+    topics: sanityTopics,
+    freshness: sanityFreshness,
+    pairWithResources: sanityPairWithResources,
+    essentialQuestions: sanityEssentialQuestions,
     state,
     path,
     tags = [],
   } = course
 
   const ogImage = customOgImage ? customOgImage : ogImageUrl
+  const relatedResources = sanityPairWithResources
+    ? sanityPairWithResources
+    : pairWithResources
+
+  const courseFreshness = sanityFreshness ? sanityFreshness : freshness
+  const courseEssentialQuestions = !isEmpty(sanityEssentialQuestions)
+    ? transformSanityEssentialQuestions(sanityEssentialQuestions)
+    : essentialQuestions
+  const courseTopics = !isEmpty(sanityTopics)
+    ? transformSanityTopics(sanityTopics)
+    : topics
+  const coursePrerequisites = !isEmpty(sanityPrerequisites)
+    ? sanityPrerequisites
+    : prerequisites
+
+  console.log({courseTopics}, {topics})
 
   const podcast = first(
     course?.items?.filter((item: any) => item.type === 'podcast'),
@@ -500,7 +522,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 {description}
               </Markdown>
               <div className="pt-5 md:hidden block">
-                <Fresh freshness={freshness} />
+                <Fresh freshness={courseFreshness} />
 
                 <CourseProjectCard courseProject={courseProject} />
 
@@ -524,17 +546,19 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
               )}
               <div
                 className={`grid grid-cols-1 md:gap-x-5 ${
-                  prerequisites && topics ? 'md:grid-cols-2' : 'md:grid-cols-1'
+                  coursePrerequisites && courseTopics
+                    ? 'md:grid-cols-2'
+                    : 'md:grid-cols-1'
                 }`}
               >
-                {topics && (
+                {courseTopics && (
                   <div className="mt-8 border border-gray-100 dark:border-gray-700 rounded-md p-5">
                     <h2 className="text-lg font-semibold mb-3">
                       What you'll learn
                     </h2>
                     <div className="prose dark:prose-dark">
                       <ul className="grid grid-cols-1 md:gap-x-5">
-                        {topics?.map((topic: string) => (
+                        {courseTopics?.map((topic: string) => (
                           <li
                             key={topic}
                             className="text-gray-900 dark:text-gray-100 leading-6"
@@ -546,13 +570,13 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                     </div>
                   </div>
                 )}
-                {prerequisites && (
+                {coursePrerequisites && (
                   <div className="mt-8 border border-gray-100 dark:border-gray-700 rounded-md p-5">
                     <h2 className="text-lg font-semibold mb-3">
                       Prerequisites
                     </h2>
                     <div className="prose dark:prose-dark">
-                      <Prereqs prerequisites={prerequisites} />
+                      <Prereqs prerequisites={coursePrerequisites} />
                     </div>
                   </div>
                 )}
@@ -574,32 +598,34 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   </div>
                 </div>
               )}
-              {essentialQuestions && (
+              {courseEssentialQuestions && (
                 <div className="mt-8 border border-gray-100 dark:border-gray-700 rounded-md p-5">
                   <h2 className="text-lg font-semibold mb-3">
                     Questions to Reflect Upon:
                   </h2>
                   <div className="prose dark:prose-dark">
                     <ul className="grid grid-cols-1 md:gap-x-5">
-                      {essentialQuestions?.map((essentialQuestion: string) => (
-                        <li
-                          key={essentialQuestion}
-                          className="text-gray-900 dark:text-gray-100 leading-6"
-                        >
-                          {essentialQuestion}
-                        </li>
-                      ))}
+                      {courseEssentialQuestions?.map(
+                        (essentialQuestion: string) => (
+                          <li
+                            key={essentialQuestion}
+                            className="text-gray-900 dark:text-gray-100 leading-6"
+                          >
+                            {essentialQuestion}
+                          </li>
+                        ),
+                      )}
                     </ul>
                   </div>
                 </div>
               )}
               <LearnerRatings collection={course} />
-              {!isEmpty(pairWithResources) && (
+              {!isEmpty(relatedResources) && (
                 <div className="my-12 md:flex hidden flex-col space-y-2">
                   <h2 className="text-lg font-semibold mb-3">
                     You might also like these resources:
                   </h2>
-                  {pairWithResources.map((resource: any) => {
+                  {relatedResources.map((resource: any) => {
                     return (
                       <div key={resource.slug}>
                         <CardHorizontal
@@ -629,7 +655,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 <PlayButton lesson={nextLesson} />
               </div>
 
-              <Fresh freshness={freshness} />
+              <Fresh freshness={courseFreshness} />
 
               <CourseProjectCard courseProject={courseProject} />
 
@@ -1036,6 +1062,14 @@ const Prereqs = ({prerequisites}: any) => {
       )}
     </ul>
   )
+}
+
+const transformSanityEssentialQuestions = (essentialQuestions: any) => {
+  return essentialQuestions.map((question: any) => question.question)
+}
+
+const transformSanityTopics = (topics: any) => {
+  return topics.items
 }
 
 export default CollectionPageLayout

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -8,14 +8,13 @@ const courseQuery = groq`
   description,
   summary,
   essentialQuestions[]->{
-    question 
+    question
    },
   "pairWithResources": related[]->{
     name,
     title,
     byline,
-    description,
-    summary,
+    "description": summary,
     path,
     image,
     'instructor': collaborators[]->[role == 'instructor']{
@@ -25,7 +24,7 @@ const courseQuery = groq`
 	"freshness": staffReviews[0]{
     status,
     title,
-    summary
+    "text": summary
   },
 	"customOgImage": images[label == 'og-image'][0]{
     url
@@ -53,7 +52,7 @@ const courseQuery = groq`
     items[],
 		description
   },
-	"features": content[title == 'reatures'][0]{
+	"features": content[title == 'features'][0]{
     items[],
 		description
   },


### PR DESCRIPTION
We had an issue where we weren't actually using sanity data on the course page in `<CollectionPageLayout />`.

Another issue I identified was how we were creating the data on sanity that didn't match up to how we were loading it on the frontend.

Checked my work with the following course pages:
- [Accessible Cross-Browser CSS Form Styling](https://egghead.io/courses/accessible-cross-browser-css-form-styling-7297)
- [Develop Basic Web Apps with Vue.js](https://egghead.io/courses/develop-basic-web-apps-with-vue-js) 
- [Build Modern Layouts with CSS Grid](https://egghead.io/courses/build-modern-layouts-with-css-grid-d3f5) 
- [Create a Digital Garden CLI with Rust](https://egghead.io/courses/creating-a-digital-garden-cli-with-rust-34b8)


![Create a Digital Garden CLI with Rust  egghead io](https://user-images.githubusercontent.com/6188161/113787455-0dfb3980-9709-11eb-99e1-6251d79aaac4.png)


![](https://media4.giphy.com/media/hSjR6NPrfCVXDIPZX5/200.gif?cid=5a38a5a2t9moapzp1uyuw29idtvni0xotyw3hu7t84b7nkxl&rid=200.gif)

