### PR TITLE
Remove Managed Sub team check from header

### DIFF
--- a/src/components/app/header.tsx
+++ b/src/components/app/header.tsx
@@ -57,7 +57,7 @@ const Header: FunctionComponent = () => {
                 </a>
               </Link>
             )}
-            {(!isEmpty(viewer?.team) || !isEmpty(viewer?.team_accounts)) && (
+            {!isEmpty(viewer?.team_accounts) && (
               <Link href={`/team`}>
                 <a
                   onClick={() =>


### PR DESCRIPTION
The Team nav item should be shown when the user has team accounts (these
are Accounts that the user is an owner of). The `viewer.team` is an old
way of doing it that is being removed from the viewer payload.


![](https://media4.giphy.com/media/QVP7DawXZitKYg3AX5/200.gif?cid=5a38a5a2b88vp3qwv99vdih7cep56py39ci17osbfc4vdhx7&rid=200.gif)
