### PR TITLE
Load Digital Gardening Section From Sanity

### DIFF
--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -1,36 +1,5 @@
 const homepageData = [
   {
-    id: 'digital-gardening-featured',
-    title: 'Featured',
-    resources: [
-      {
-        name: 'Content Authoring',
-        title: 'Creating a Digital Garden CLI with Rust',
-        byline: 'Chris Biscardi・1h 10m',
-        image:
-          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/429/801/full/rust-garden-cli_424_2x.png',
-        path: '/courses/creating-a-digital-garden-cli-with-rust-34b8',
-      },
-      {
-        name: 'Start a Blog',
-        title: 'Build a Developer Blog with Gatsby',
-        byline: 'Laurie Barth・35m',
-        image:
-          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/425/621/full/developer_blog_1000_2x.png',
-        path: '/courses/build-a-developer-blog-with-gatsby-bd96',
-      },
-      {
-        name: 'Create a Portfolio',
-        title: 'Build a site from scratch with Next.js',
-        byline: 'Tomasz Łakomy・37m',
-        image:
-          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/387/163/square_480/netlify-ts.png',
-        path:
-          '/playlists/build-a-blog-with-next-js-typescript-emotion-and-netlify-adcc',
-      },
-    ],
-  },
-  {
     id: 'jumbotron',
     title: 'Create a Digital Garden CLI with Rust',
     byline: 'new course',

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -19,7 +19,7 @@ import Jumbotron from './jumbotron'
 import LevelUpCTA from '../../survey/level-up-cta'
 
 const Home: FunctionComponent<any> = ({sections}) => {
-  const {digitalGardeningFeature} = sections
+  const [featureCallOut] = sections
 
   const location = 'home landing'
   const {viewer, loading} = useViewer()
@@ -158,7 +158,7 @@ const Home: FunctionComponent<any> = ({sections}) => {
                 </header>
                 <div>
                   <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
-                    {digitalGardeningFeature.resources.map((resource: any) => {
+                    {featureCallOut.resources.map((resource: any) => {
                       return (
                         <Card
                           className="col-span-4 text-center"

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -18,7 +18,9 @@ import InProgressCollection from './in-progress-collection'
 import Jumbotron from './jumbotron'
 import LevelUpCTA from '../../survey/level-up-cta'
 
-const Home: FunctionComponent = () => {
+const Home: FunctionComponent<any> = ({sections}) => {
+  const {digitalGardeningFeature} = sections
+
   const location = 'home landing'
   const {viewer, loading} = useViewer()
   const [currentCourse, setCurrentCourse] = React.useState<CardResource>()
@@ -60,9 +62,6 @@ const Home: FunctionComponent = () => {
   const topics: any = find(homepageData, {id: 'topics'})
   const swag: any = find(homepageData, {id: 'swag'})
   const ecommerce: any = find(homepageData, {id: 'ecommerce'})
-  const digitalGardeningFeatured: any = find(homepageData, {
-    id: 'digital-gardening-featured',
-  })
 
   React.useEffect(() => {
     if (currentCourseUrl) {
@@ -159,7 +158,7 @@ const Home: FunctionComponent = () => {
                 </header>
                 <div>
                   <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
-                    {digitalGardeningFeatured.resources.map((resource: any) => {
+                    {digitalGardeningFeature.resources.map((resource: any) => {
                       return (
                         <Card
                           className="col-span-4 text-center"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,11 @@
 import React, {FunctionComponent} from 'react'
 import {NextSeo} from 'next-seo'
 import Home from 'components/pages/home'
+import groq from 'groq'
+import {sanityClient} from 'utils/sanity-client'
+import InstructorsIndex from 'components/search/instructors'
 
-const IndexPage: FunctionComponent = () => {
+const IndexPage: FunctionComponent = ({sections}: any) => {
   return (
     <>
       <NextSeo
@@ -18,7 +21,7 @@ const IndexPage: FunctionComponent = () => {
       />
       <main className="bg-gray-50 dark:bg-gray-900 sm:-my-5 -my-3 -mx-5 p-5">
         <div className="max-w-screen-xl mx-auto">
-          <Home />
+          <Home sections={sections} />
         </div>
       </main>
     </>
@@ -26,3 +29,36 @@ const IndexPage: FunctionComponent = () => {
 }
 
 export default IndexPage
+
+const digitalGardeningQuery = groq`
+*[_type == 'resource' && slug.current == "digital-gardening-for-developers"][0]{
+  title,
+  description,
+  'illustration': images[label == 'eggo'][0]{
+    url,
+    alt
+  },
+  'quote': content[title == 'quote'][0]{
+    description
+  },
+  resources[]{
+    title,
+    byline,
+    'name': content[title == 'name'][0].description,
+    'path': resources[]->[0].path,
+    'image': resources[]->[0].image
+  }
+}
+`
+
+export async function getStaticProps() {
+  const digitalGardeningFeature = await sanityClient.fetch(
+    digitalGardeningQuery,
+  )
+
+  return {
+    props: {
+      sections: {digitalGardeningFeature},
+    },
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -58,7 +58,7 @@ export async function getStaticProps() {
 
   return {
     props: {
-      sections: {digitalGardeningFeature},
+      sections: [digitalGardeningFeature],
     },
   }
 }


### PR DESCRIPTION
@laurosilvacom, @theianjones, @MaggieAppleton, @dealingwith got on a call to structure the `Digital Gardening for Developers` section data on the home page in Sanity and subsequently load that data.

It should look exactly like it does in production.
![Build the portfolio you need to be a badass web developer   egghead io](https://user-images.githubusercontent.com/6188161/114228921-25266b00-9945-11eb-8410-655ec1c557be.png)



![](https://media2.giphy.com/media/kyhrWIYkR52EyU9zuF/200.gif?cid=5a38a5a2ubdid8rore1g1098e9tisz9f1fkofbhg9y17gcss&rid=200.gif)
