### PR TITLE
Add billing summary to team page

### DIFF
--- a/src/components/team/billing-section.tsx
+++ b/src/components/team/billing-section.tsx
@@ -5,6 +5,19 @@ import {format} from 'date-fns'
 import Link from 'next/link'
 import {track} from '../../utils/analytics'
 
+const formatAmountWithCurrency = (
+  amountInCents: number,
+  currency: string,
+): string => {
+  if (!amountInCents || !currency) return ''
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency,
+    minimumFractionDigits: 0,
+  }).format(amountInCents / 100)
+}
+
 const BillingSection = ({
   stripeCustomerId,
   slug,
@@ -17,31 +30,67 @@ const BillingSection = ({
     slug,
   })
 
-  const subscriptionUnitAmount = get(
-    subscriptionData,
-    'latestInvoice.amount_due',
-    subscriptionData?.price?.unit_amount,
-  )
   const currency = get(
     subscriptionData,
     'latestInvoice.currency',
     subscriptionData?.price?.unit_amount,
   )
-  const subscriptionPrice =
-    subscriptionUnitAmount &&
-    currency &&
-    new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency,
-      minimumFractionDigits: 0,
-    }).format(subscriptionUnitAmount / 100)
 
   const recurrence = recur(subscriptionData?.price)
 
+  let subscriptionName, subscriptionDescription
+
+  switch (recurrence) {
+    case 'year': {
+      subscriptionName = 'Annual egghead Team Subscription'
+      subscriptionDescription = 'Yearly Pro Membership'
+      break
+    }
+    case 'quarter': {
+      subscriptionName = 'Quarterly egghead Team Subscription'
+      subscriptionDescription = 'Quarterly Pro Membership'
+      break
+    }
+    case 'month': {
+      subscriptionName = 'Monthly egghead Team Subscription'
+      subscriptionDescription = 'Monthly Pro Membership'
+      break
+    }
+    default: {
+      subscriptionName = ''
+      subscriptionDescription = ''
+    }
+  }
+
+  const currentPeriodStart = new Date(
+    get(subscriptionData, 'subscription.current_period_start') * 1000,
+  )
+  const currentPeriodEnd = new Date(
+    get(subscriptionData, 'subscription.current_period_end') * 1000,
+  )
+
+  // const subscriptionStatus = get(subscriptionData, 'subscription.status')
+  const nextBillDate = new Date(
+    get(subscriptionData, 'upcomingInvoice.next_payment_attempt') * 1000,
+  )
+
   const quantity = get(subscriptionData, 'subscription.quantity', 1)
 
-  const nextBillDate = new Date(
-    get(subscriptionData, 'subscription.current_period_end') * 1000,
+  const tiers = get(subscriptionData, 'subscription.plan.tiers', [])
+  const matchingTier = tiers.find((tier: {up_to: number}) => {
+    if (quantity <= tier.up_to || tier.up_to === null) return true
+
+    return false
+  })
+  const subscriptionUnitPrice = formatAmountWithCurrency(
+    matchingTier?.unit_amount,
+    currency,
+  )
+
+  const totalAmountInCents = get(subscriptionData, 'upcomingInvoice.amount_due')
+  const subscriptionTotalPrice = formatAmountWithCurrency(
+    totalAmountInCents,
+    currency,
   )
 
   return (
@@ -61,35 +110,70 @@ const BillingSection = ({
       </div>
       {!loading && (
         <div className="flex flex-col space-y-2 border border-gray-300 mt-4 p-2">
-          <div className="flex flex-row justify-between">
-            <span>egghead team annual</span>
-            <span>
-              Next Bill Date:{' '}
-              <span className="font-semibold">
-                {format(nextBillDate, 'yyyy/MM/dd')}
+          <div className="flex flex-col space-y-3">
+            <div className="flex flex-col space-y-4 justify-start md:space-y-0 md:flex-row md:justify-between mt-2">
+              <div className="text-lg">{subscriptionName}</div>
+              <div className="">
+                {subscriptionData?.portalUrl && (
+                  <Link href={subscriptionData.portalUrl}>
+                    <a
+                      onClick={() => {
+                        track(`clicked manage team membership`)
+                      }}
+                      className="mt-4 text-center transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                    >
+                      Manage Your Team Membership
+                    </a>
+                  </Link>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col space-y-0.5">
+              <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                Current Billing Period
               </span>
-            </span>
-          </div>
-          <div>
-            <span>
-              <span className="font-bold text-lg">{subscriptionPrice}</span> per{' '}
-              {recurrence} for <span className="font-semibold">{quantity}</span>{' '}
-              {quantity !== 1 ? 'learners' : 'learner'}
-            </span>
-          </div>
-          <div className="flex flex-row-reverse">
-            {subscriptionData?.portalUrl && (
-              <Link href={subscriptionData.portalUrl}>
-                <a
-                  onClick={() => {
-                    track(`clicked manage team membership`)
-                  }}
-                  className="mt-4 text-center transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
-                >
-                  Manage Your Team Membership
-                </a>
-              </Link>
-            )}
+              <span className="">
+                {format(currentPeriodStart, 'yyyy/MM/dd')} -{' '}
+                {format(currentPeriodEnd, 'yyyy/MM/dd')}
+              </span>
+            </div>
+            <div className="flex flex-col space-y-0.5">
+              <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                Next Billing Date
+              </span>
+              <span className="">
+                {nextBillDate ? format(nextBillDate, 'yyyy/MM/dd') : 'N/A'}
+              </span>
+            </div>
+            <div className="flex flex-row space-x-8">
+              <div className="flex flex-col space-y-0.5">
+                <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                  Description
+                </span>
+                <span className="">{subscriptionDescription}</span>
+              </div>
+
+              <div className="flex flex-col space-y-0.5">
+                <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                  Seats
+                </span>
+                <span className="">{quantity}</span>
+              </div>
+
+              <div className="flex flex-col space-y-0.5">
+                <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                  Unit Price
+                </span>
+                <span className="">{subscriptionUnitPrice}</span>
+              </div>
+
+              <div className="flex flex-col space-y-0.5">
+                <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                  Total Amount
+                </span>
+                <span className="">{subscriptionTotalPrice}</span>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/team/billing-section.tsx
+++ b/src/components/team/billing-section.tsx
@@ -69,10 +69,17 @@ const BillingSection = ({
     get(subscriptionData, 'subscription.current_period_end') * 1000,
   )
 
-  // const subscriptionStatus = get(subscriptionData, 'subscription.status')
-  const nextBillDate = new Date(
-    get(subscriptionData, 'upcomingInvoice.next_payment_attempt') * 1000,
-  )
+  const activeSubscription =
+    get(subscriptionData, 'subscription.status') === 'active' &&
+    !get(subscriptionData, 'subscription.canceled_at')
+  const nextBillDate: string | undefined = activeSubscription
+    ? format(
+        new Date(
+          get(subscriptionData, 'upcomingInvoice.next_payment_attempt') * 1000,
+        ),
+        'yyyy/MM/dd',
+      )
+    : undefined
 
   const quantity = get(subscriptionData, 'subscription.quantity', 1)
 
@@ -87,7 +94,11 @@ const BillingSection = ({
     currency,
   )
 
-  const totalAmountInCents = get(subscriptionData, 'upcomingInvoice.amount_due')
+  const totalAmountInCents = get(
+    subscriptionData,
+    'upcomingInvoice.amount_due',
+    get(subscriptionData, 'latestInvoice.amount_due'),
+  )
   const subscriptionTotalPrice = formatAmountWithCurrency(
     totalAmountInCents,
     currency,
@@ -141,9 +152,7 @@ const BillingSection = ({
               <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
                 Next Billing Date
               </span>
-              <span className="">
-                {nextBillDate ? format(nextBillDate, 'yyyy/MM/dd') : 'N/A'}
-              </span>
+              <span className="">{nextBillDate || 'Canceled'}</span>
             </div>
             <div className="flex flex-row space-x-8">
               <div className="flex flex-col space-y-0.5">

--- a/src/components/team/billing-section.tsx
+++ b/src/components/team/billing-section.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react'
+import useSubscriptionDetails from 'hooks/use-subscription-data'
+import get from 'lodash/get'
+import {format} from 'date-fns'
+import Link from 'next/link'
+import {track} from '../../utils/analytics'
+
+const BillingSection = ({
+  stripeCustomerId,
+  slug,
+}: {
+  stripeCustomerId: string
+  slug: string
+}) => {
+  const {subscriptionData, recur, loading} = useSubscriptionDetails({
+    stripeCustomerId,
+    slug,
+  })
+
+  const subscriptionUnitAmount = get(
+    subscriptionData,
+    'latestInvoice.amount_due',
+    subscriptionData?.price?.unit_amount,
+  )
+  const currency = get(
+    subscriptionData,
+    'latestInvoice.currency',
+    subscriptionData?.price?.unit_amount,
+  )
+  const subscriptionPrice =
+    subscriptionUnitAmount &&
+    currency &&
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+      minimumFractionDigits: 0,
+    }).format(subscriptionUnitAmount / 100)
+
+  const recurrence = recur(subscriptionData?.price)
+
+  const quantity = get(subscriptionData, 'subscription.quantity', 1)
+
+  const nextBillDate = new Date(
+    get(subscriptionData, 'subscription.current_period_end') * 1000,
+  )
+
+  return (
+    <>
+      <h2 className="font-semibold text-xl mt-16">Team Billing</h2>
+      <div className="flex flex-row justify-between mt-4">
+        <h3 className="font-semibold text-lg">Your Team Membership</h3>
+        <span>
+          Need Help?{' '}
+          <a
+            className="font-semibold text-blue-500 hover:text-blue-600"
+            href="mailto:support@egghead.io"
+          >
+            support@egghead.io
+          </a>
+        </span>
+      </div>
+      {!loading && (
+        <div className="flex flex-col space-y-2 border border-gray-300 mt-4 p-2">
+          <div className="flex flex-row justify-between">
+            <span>egghead team annual</span>
+            <span>
+              Next Bill Date:{' '}
+              <span className="font-semibold">
+                {format(nextBillDate, 'yyyy/MM/dd')}
+              </span>
+            </span>
+          </div>
+          <div>
+            <span>
+              <span className="font-bold text-lg">{subscriptionPrice}</span> per{' '}
+              {recurrence} for <span className="font-semibold">{quantity}</span>{' '}
+              {quantity !== 1 ? 'learners' : 'learner'}
+            </span>
+          </div>
+          <div className="flex flex-row-reverse">
+            {subscriptionData?.portalUrl && (
+              <Link href={subscriptionData.portalUrl}>
+                <a
+                  onClick={() => {
+                    track(`clicked manage team membership`)
+                  }}
+                  className="mt-4 text-center transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                >
+                  Manage Your Team Membership
+                </a>
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default BillingSection

--- a/src/components/users/subscription-details.tsx
+++ b/src/components/users/subscription-details.tsx
@@ -10,11 +10,10 @@ type SubscriptionDetailsProps = {
   slug: string
 }
 
-const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = ({
+const useSubscriptionDetails = ({
   stripeCustomerId,
   slug,
-}) => {
-  const {viewer} = useViewer()
+}: SubscriptionDetailsProps) => {
   const [subscriptionData, setSubscriptionData] = React.useState<any>()
   const recur = (price: any) => {
     const {
@@ -43,6 +42,19 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = (
         })
     }
   }, [stripeCustomerId, slug])
+
+  return [subscriptionData, recur]
+}
+
+const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = ({
+  stripeCustomerId,
+  slug,
+}) => {
+  const {viewer} = useViewer()
+  const [subscriptionData, recur] = useSubscriptionDetails({
+    stripeCustomerId,
+    slug,
+  })
 
   const subscriptionName = subscriptionData && subscriptionData.product?.name
   const subscriptionUnitAmount = get(

--- a/src/components/users/subscription-details.tsx
+++ b/src/components/users/subscription-details.tsx
@@ -15,7 +15,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = (
   slug,
 }) => {
   const {viewer} = useViewer()
-  const [subscriptionData, recur] = useSubscriptionDetails({
+  const {subscriptionData, recur, loading} = useSubscriptionDetails({
     stripeCustomerId,
     slug,
   })
@@ -43,7 +43,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = (
   return (
     <>
       {/* Payment details */}
-      {subscriptionData && (
+      {!loading && subscriptionData && (
         <div className="sm:px-6 lg:px-0 lg:col-span-9">
           <section className="mb-32">
             <div className="p-4 w-full">

--- a/src/components/users/subscription-details.tsx
+++ b/src/components/users/subscription-details.tsx
@@ -1,49 +1,13 @@
 import React from 'react'
-import axios from 'axios'
 import Link from 'next/link'
 import {track} from '../../utils/analytics'
 import {useViewer} from 'context/viewer-context'
 import get from 'lodash/get'
+import useSubscriptionDetails from 'hooks/use-subscription-data'
 
 type SubscriptionDetailsProps = {
   stripeCustomerId: string
   slug: string
-}
-
-const useSubscriptionDetails = ({
-  stripeCustomerId,
-  slug,
-}: SubscriptionDetailsProps) => {
-  const [subscriptionData, setSubscriptionData] = React.useState<any>()
-  const recur = (price: any) => {
-    const {
-      recurring: {interval, interval_count},
-    } = price
-
-    if (interval === 'month' && interval_count === 3) return 'quarter'
-    if (interval === 'month' && interval_count === 6) return '6-months'
-    if (interval === 'month' && interval_count === 1) return 'month'
-    if (interval === 'year' && interval_count === 1) return 'year'
-  }
-
-  React.useEffect(() => {
-    if (stripeCustomerId) {
-      axios
-        .get(`/api/stripe/billing/session`, {
-          params: {
-            customer_id: stripeCustomerId,
-            account_slug: slug,
-          },
-        })
-        .then(({data}) => {
-          if (data) {
-            setSubscriptionData(data)
-          }
-        })
-    }
-  }, [stripeCustomerId, slug])
-
-  return [subscriptionData, recur]
 }
 
 const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> = ({

--- a/src/hooks/use-subscription-data.tsx
+++ b/src/hooks/use-subscription-data.tsx
@@ -8,8 +8,11 @@ const useSubscriptionDetails = ({
   stripeCustomerId: string
   slug: string
 }) => {
+  const [loading, setLoading] = React.useState<boolean>(true)
   const [subscriptionData, setSubscriptionData] = React.useState<any>()
   const recur = (price: any) => {
+    if (price === undefined) return ''
+
     const {
       recurring: {interval, interval_count},
     } = price
@@ -22,6 +25,8 @@ const useSubscriptionDetails = ({
 
   React.useEffect(() => {
     if (stripeCustomerId) {
+      setLoading(true)
+
       axios
         .get(`/api/stripe/billing/session`, {
           params: {
@@ -34,10 +39,13 @@ const useSubscriptionDetails = ({
             setSubscriptionData(data)
           }
         })
+        .finally(() => {
+          setLoading(false)
+        })
     }
   }, [stripeCustomerId, slug])
 
-  return [subscriptionData, recur]
+  return {subscriptionData, recur, loading}
 }
 
 export default useSubscriptionDetails

--- a/src/hooks/use-subscription-data.tsx
+++ b/src/hooks/use-subscription-data.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import axios from 'axios'
+
+const useSubscriptionDetails = ({
+  stripeCustomerId,
+  slug,
+}: {
+  stripeCustomerId: string
+  slug: string
+}) => {
+  const [subscriptionData, setSubscriptionData] = React.useState<any>()
+  const recur = (price: any) => {
+    const {
+      recurring: {interval, interval_count},
+    } = price
+
+    if (interval === 'month' && interval_count === 3) return 'quarter'
+    if (interval === 'month' && interval_count === 6) return '6-months'
+    if (interval === 'month' && interval_count === 1) return 'month'
+    if (interval === 'year' && interval_count === 1) return 'year'
+  }
+
+  React.useEffect(() => {
+    if (stripeCustomerId) {
+      axios
+        .get(`/api/stripe/billing/session`, {
+          params: {
+            customer_id: stripeCustomerId,
+            account_slug: slug,
+          },
+        })
+        .then(({data}) => {
+          if (data) {
+            setSubscriptionData(data)
+          }
+        })
+    }
+  }, [stripeCustomerId, slug])
+
+  return [subscriptionData, recur]
+}
+
+export default useSubscriptionDetails

--- a/src/pages/api/stripe/billing/session.ts
+++ b/src/pages/api/stripe/billing/session.ts
@@ -1,5 +1,6 @@
 import {first, get} from 'lodash'
 import {NextApiRequest, NextApiResponse} from 'next'
+import isEmpty from 'lodash/isEmpty'
 
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY)
 
@@ -23,9 +24,6 @@ const StripeCheckoutSession = async (
       const customer = await stripe.customers.retrieve(customer_id, {
         expand: ['default_source', 'subscriptions.data.latest_invoice'],
       })
-      const upcomingInvoice = await stripe.invoices.retrieveUpcoming({
-        customer: customer_id,
-      })
 
       const subscription = customer.subscriptions?.data[0]
 
@@ -36,6 +34,16 @@ const StripeCheckoutSession = async (
         const {product: product_id} = price
 
         const product = await stripe.products.retrieve(product_id)
+
+        // Try fetching the upcoming invoice
+        let upcomingInvoice = {}
+        if (!isEmpty(subscription.canceled_at)) {
+          // Only retrieve it if the subscription hasn't been cancelled,
+          // otherwise it will result in a StripeInvalidRequestError.
+          upcomingInvoice = await stripe.invoices.retrieveUpcoming({
+            customer: customer_id,
+          })
+        }
 
         res.status(200).json({
           portalUrl: session.url,

--- a/src/pages/api/stripe/billing/session.ts
+++ b/src/pages/api/stripe/billing/session.ts
@@ -23,6 +23,9 @@ const StripeCheckoutSession = async (
       const customer = await stripe.customers.retrieve(customer_id, {
         expand: ['default_source', 'subscriptions.data.latest_invoice'],
       })
+      const upcomingInvoice = await stripe.invoices.retrieveUpcoming({
+        customer: customer_id,
+      })
 
       const subscription = customer.subscriptions?.data[0]
 
@@ -40,6 +43,7 @@ const StripeCheckoutSession = async (
           price,
           product,
           latestInvoice,
+          upcomingInvoice,
         })
       } else {
         res.status(200).json({portalUrl: session.url, customer})

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -10,6 +10,8 @@ import {loadTeams} from 'lib/teams'
 import TeamName from '../../components/team/team-name'
 import {getTokenFromCookieHeaders} from 'utils/auth'
 import isEmpty from 'lodash/isEmpty'
+import SubscriptionDetails from 'components/users/subscription-details'
+import BillingSection from 'components/team/billing-section'
 
 export type TeamData = {
   accountId: number
@@ -19,8 +21,8 @@ export type TeamData = {
   numberOfMembers: number
   capacity: number
   isFull: boolean
-  accountSlug: string | undefined
-  stripeCustomerId: string | undefined
+  accountSlug: string
+  stripeCustomerId: string
 }
 
 const TeamComposition = ({teamData}: {teamData: TeamData}) => {
@@ -192,6 +194,10 @@ const Team = ({team: teamData}: TeamPageProps) => {
               )
             })}
           </table>
+          <BillingSection
+            stripeCustomerId={teamData.stripeCustomerId}
+            slug={teamData.accountSlug}
+          />
         </div>
       )}
     </LoginRequired>


### PR DESCRIPTION
Add Billing Summary details to the team page so that a team owner can see what their plan looks like, what they are paying, and click through to the Stripe Billing Portal to manage it all.

Here is what it looks like:

![CleanShot 2021-04-15 at 10 50 24@2x](https://user-images.githubusercontent.com/694063/114899295-75d01500-9dd8-11eb-853a-96a14ca6c3b4.png)

Here is the original mock up. Note that I didn't match the details from this mock up exactly. I started with a simpler approach that puts the core information on the screen.

Depending on what details are important, we can take a second pass on this to include any or all of:
- Discount information
- Computed monthly breakdown for each learner

(Invoices, also pictured in this mock up, are coming up next.)

![image](https://user-images.githubusercontent.com/694063/114907246-7f5d7b00-9de0-11eb-8653-099741019c6f.png)



![](https://media1.giphy.com/media/UTRSC9VGMMG8tHRxcr/200.gif?cid=5a38a5a29lvpwbgt2lczkksu7imyol3gx05bsl2ax8xp2p1k&rid=200.gif&ct=g)