### PR TITLE
Use styles for team table that stack on mobile

### DIFF
--- a/src/components/team/member-table.tsx
+++ b/src/components/team/member-table.tsx
@@ -1,0 +1,60 @@
+import {format} from 'date-fns'
+
+const MemberTable = ({members}: {members: any[]}) => {
+  return (
+    <div className="bg-white shadow overflow-hidden sm:rounded-md">
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        {members.map((member: any, i: number) => {
+          const {id, name, email, roles, date_added} = member
+
+          return (
+            <li
+              key={id}
+              className={
+                i % 2 === 0
+                  ? 'bg-gray-100 dark:bg-gray-800'
+                  : 'bg-white dark:bg-gray-900'
+              }
+            >
+              <div className="px-4 py-4 sm:px-6">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium truncate">
+                    {name ? (
+                      <span>
+                        {name} ({email})
+                      </span>
+                    ) : (
+                      <span>{email}</span>
+                    )}
+                  </p>
+                  <div className="ml-2 flex-shrink-0 flex">
+                    <p className="cursor-pointer px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 dark:bg-red-700 text-red-800 dark:text-red-100 hover:shadow">
+                      Remove
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-2 sm:flex sm:justify-between">
+                  <div className="sm:flex">
+                    <p className="flex items-center text-sm text-gray-500 dark:text-gray-300">
+                      {roles.join(', ')}
+                    </p>
+                  </div>
+                  <div className="mt-2 flex items-center text-sm text-gray-500 dark:text-gray-300 sm:mt-0">
+                    <p>
+                      Joined on{' '}
+                      <time dateTime={date_added}>
+                        {format(new Date(date_added), 'yyyy/MM/dd')}
+                      </time>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default MemberTable

--- a/src/components/team/member-table.tsx
+++ b/src/components/team/member-table.tsx
@@ -2,7 +2,7 @@ import {format} from 'date-fns'
 
 const MemberTable = ({members}: {members: any[]}) => {
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-md">
+    <div className="bg-white shadow overflow-hidden sm:rounded-md mt-2">
       <ul className="divide-y divide-gray-200 dark:divide-gray-700">
         {members.map((member: any, i: number) => {
           const {id, name, email, roles, date_added} = member

--- a/src/components/team/member-table.tsx
+++ b/src/components/team/member-table.tsx
@@ -28,9 +28,9 @@ const MemberTable = ({members}: {members: any[]}) => {
                     )}
                   </p>
                   <div className="ml-2 flex-shrink-0 flex">
-                    <p className="cursor-pointer px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 dark:bg-red-700 text-red-800 dark:text-red-100 hover:shadow">
-                      Remove
-                    </p>
+                    {/* <p className="cursor-pointer px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 dark:bg-red-700 text-red-800 dark:text-red-100 hover:shadow"> */}
+                    {/*   Remove */}
+                    {/* </p> */}
                   </div>
                 </div>
                 <div className="mt-2 sm:flex sm:justify-between">

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -10,8 +10,8 @@ import {loadTeams} from 'lib/teams'
 import TeamName from '../../components/team/team-name'
 import {getTokenFromCookieHeaders} from 'utils/auth'
 import isEmpty from 'lodash/isEmpty'
-import SubscriptionDetails from 'components/users/subscription-details'
 import BillingSection from 'components/team/billing-section'
+import MemberTable from 'components/team/member-table'
 
 export type TeamData = {
   accountId: number
@@ -162,42 +162,7 @@ const Team = ({team: teamData}: TeamPageProps) => {
           <h2 className="font-semibold text-xl mt-16">
             Current Team Members <TeamComposition teamData={teamData} />
           </h2>
-          <table
-            className="w-full mt-6 text-left text-lg"
-            css={{
-              td: {
-                padding: '0.5rem 0.75rem',
-              },
-            }}
-          >
-            <tr>
-              <th>Name</th>
-              <th>Email</th>
-              <th>Role(s)</th>
-              <th>Date Added</th>
-            </tr>
-            {teamData.members.map((member: any, i: number) => {
-              return (
-                <tr
-                  key={member.id || member.email}
-                  className={
-                    i % 2 === 0
-                      ? 'bg-gray-100 dark:bg-gray-800'
-                      : 'bg-white dark:bg-gray-900'
-                  }
-                >
-                  <td>{member.name}</td>
-                  <td>{member.email}</td>
-                  <td>{member.roles.join(', ')}</td>
-                  <td>{member.date_added}</td>
-                </tr>
-              )
-            })}
-          </table>
-          <BillingSection
-            stripeCustomerId={teamData.stripeCustomerId}
-            slug={teamData.accountSlug}
-          />
+          <MemberTable members={teamData.members} />
         </div>
       )}
     </LoginRequired>


### PR DESCRIPTION
Joel mentioned that we have Tailwind UI for this project, so I swapped out my kludgy table for a Tailwind UI [_stacked list_](https://tailwindui.com/components/application-ui/lists/stacked-lists) that looks better on desktop and collapses cleanly on mobile.

The `Remove` button that is displayed in these screenshots is commented out for now until that gets implemented.

Desktop:

<img width="1011" alt="CleanShot 2021-04-16 at 13 02 14@2x" src="https://user-images.githubusercontent.com/694063/115066114-b1d8a800-9eb4-11eb-9874-9d83a02a10c5.png">

Mobile:

<img width="488" alt="CleanShot 2021-04-16 at 13 02 40@2x" src="https://user-images.githubusercontent.com/694063/115066134-b735f280-9eb4-11eb-8690-cbce72b95f61.png">

![](https://media1.giphy.com/media/X83Y7r03T6uty/200.gif?cid=5a38a5a2wwfs1xf09gpjnvr6fuwdw7timbh7i8d02q7btpde&rid=200.gif&ct=g)