### PR TITLE
update digital garden feature to use named sanity resources

### DIFF
--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -151,16 +151,18 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
                 </header>
                 <div>
                   <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
-                    {featureDigitalGardening.resources.map((resource: any) => {
-                      return (
-                        <Card
-                          className="col-span-4 text-center"
-                          key={resource.path}
-                          resource={resource}
-                          location={location}
-                        />
-                      )
-                    })}
+                    {featureDigitalGardening.featured.courses.map(
+                      (resource: any) => {
+                        return (
+                          <Card
+                            className="col-span-4 text-center"
+                            key={resource.path}
+                            resource={resource}
+                            location={location}
+                          />
+                        )
+                      },
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/pages/learn/digital-gardening/index.tsx
+++ b/src/pages/learn/digital-gardening/index.tsx
@@ -142,18 +142,6 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
       image,
     },
   },
-  related[0]{
-    title,
-    description,
-    'cta': content[title == 'cta'][0]{
-      description
-    },
-    resources[]{
-      title,
-      'path': slug.current,
-      byline,
-      image,
-    },
   },
 }`
 

--- a/src/pages/learn/digital-gardening/index.tsx
+++ b/src/pages/learn/digital-gardening/index.tsx
@@ -8,6 +8,7 @@ import Card from 'components/pages/home/card'
 import {track} from 'utils/analytics'
 
 const DigitalGardening: React.FC<any> = ({data}) => {
+  console.log({courses: data.featured.courses})
   return (
     <div className="sm:-my-5 -my-3 -mx-5 p-5 dark:bg-gray-900 bg-gray-50">
       <div className="mx-auto max-w-screen-xl">
@@ -63,7 +64,7 @@ const DigitalGardening: React.FC<any> = ({data}) => {
 
         <div>
           <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
-            {data.resources.map((resource: any) => {
+            {data.featured.courses.map((resource: any) => {
               return (
                 <Card
                   className="col-span-4 text-center"
@@ -80,17 +81,17 @@ const DigitalGardening: React.FC<any> = ({data}) => {
             <div className="flex lg:flex-row flex-col items-center justify-center sm:space-x-10 sm:space-y-0 space-y-5 0 w-full xl:pr-16">
               <div className="mx-auto">
                 <h2 className="text-xs text-yellow-600 dark:yellow-green-300 uppercase font-semibold mb-2 text-center">
-                  {data.related.cta.description}
+                  {data.talks.cta}
                 </h2>
 
                 <h1 className="sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter">
-                  {data.related.title}
+                  {data.talks.title}
                 </h1>
               </div>
             </div>
           </div>
           <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
-            {data.related.resources.map((resource: any) => {
+            {data.talks.resources.map((resource: any) => {
               return (
                 <Card
                   className="col-span-3 text-center dark:bg-gray-800"
@@ -108,7 +109,7 @@ const DigitalGardening: React.FC<any> = ({data}) => {
 
 export default DigitalGardening
 
-export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current == "digital-gardening-for-developers"][0]{
+export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current == "digital-gardening-for-developers-v2"][0]{
   title,
   description,
   path,
@@ -122,12 +123,25 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
   'cta': content[title == 'cta'][0]{
     description
   },
-  resources[]{
+  'featured': resources[title == 'Featured digital gardening courses'][0]{
+ 		'courses': resources[]{
+    	title,
+    	byline,
+      'name': content[title == 'name'][0].description,
+    	'path': resources[]->[0].path,
+    	'image': resources[]->[0].image
+  	}
+  },
+	'talks': resources[title == 'Infrastructure for Digital Gardens'][0]{
     title,
-    byline,
-    'name': content[title == 'name'][0].description,
-    'path': resources[]->[0].path,
-    'image': resources[]->[0].image
+    description,
+    'cta': content[title == 'cta'][0].description,
+		resources[]{
+      title,
+      'path': slug.current,
+      byline,
+      image,
+    },
   },
   related[0]{
     title,
@@ -146,6 +160,8 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
 
 export async function getStaticProps() {
   const data = await sanityClient.fetch(digitalGardeningQuery)
+
+  console.log('from getstaticprops', data.featured.courses)
 
   return {
     props: {

--- a/src/pages/learn/digital-gardening/index.tsx
+++ b/src/pages/learn/digital-gardening/index.tsx
@@ -8,7 +8,6 @@ import Card from 'components/pages/home/card'
 import {track} from 'utils/analytics'
 
 const DigitalGardening: React.FC<any> = ({data}) => {
-  console.log({courses: data.featured.courses})
   return (
     <div className="sm:-my-5 -my-3 -mx-5 p-5 dark:bg-gray-900 bg-gray-50">
       <div className="mx-auto max-w-screen-xl">
@@ -160,8 +159,6 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
 
 export async function getStaticProps() {
   const data = await sanityClient.fetch(digitalGardeningQuery)
-
-  console.log('from getstaticprops', data.featured.courses)
 
   return {
     props: {

--- a/src/pages/learn/digital-gardening/index.tsx
+++ b/src/pages/learn/digital-gardening/index.tsx
@@ -142,7 +142,6 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
       image,
     },
   },
-  },
 }`
 
 export async function getStaticProps() {

--- a/src/pages/learn/digital-gardening/index.tsx
+++ b/src/pages/learn/digital-gardening/index.tsx
@@ -122,7 +122,7 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
   'cta': content[title == 'cta'][0]{
     description
   },
-  'featured': resources[title == 'Featured digital gardening courses'][0]{
+  'featured': resources[slug.current == 'featured-digital-gardening-courses'][0]{
  		'courses': resources[]{
     	title,
     	byline,
@@ -131,16 +131,16 @@ export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current 
     	'image': resources[]->[0].image
   	}
   },
-	'talks': resources[title == 'Infrastructure for Digital Gardens'][0]{
-    title,
-    description,
-    'cta': content[title == 'cta'][0].description,
-		resources[]{
+  'talks': resources[slug.current == 'infrastructure-for-digital-gardens'][0]{
       title,
-      'path': slug.current,
-      byline,
-      image,
-    },
+      description,
+      'cta': content[title == 'cta'][0].description,
+      resources[]{
+        title,
+        'path': slug.current,
+        byline,
+        image,
+      },
   },
 }`
 


### PR DESCRIPTION
This is using a restructured Sanity object where we are querying for the resource title so that we can add resources without breaking the front end.

One thing that I don't understand... `Create a digital garden CLI with Rust` course image and path aren't being returned from the API even though they are present in the query in sanity studio

![image](https://user-images.githubusercontent.com/6188161/115630293-c6aca580-a2d1-11eb-8024-8fbb7b699669.png)



![Build the portfolio you need to be a badass web developer   egghead io](https://user-images.githubusercontent.com/6188161/115630085-6ddd0d00-a2d1-11eb-82cb-d7b50dfa15e8.png)
![Build the portfolio you need to be a badass web developer   egghead io](https://user-images.githubusercontent.com/6188161/115630095-703f6700-a2d1-11eb-95ff-efd6779f26f9.png)


![](https://media2.giphy.com/media/kz6lK3nHNOoVVXpsYD/giphy.gif?cid=5a38a5a2zjwi5iwerffftwwez49fm1of5yut3qcfy15317hk&rid=giphy.gif&ct=g)

