### PR TITLE
add developer portfolio feature + portfolio clubs

### DIFF
--- a/src/components/pages/home/club-card/club-card.stories.mdx
+++ b/src/components/pages/home/club-card/club-card.stories.mdx
@@ -6,7 +6,6 @@ export const xStateClub = {
   title: 'Build an App with xState',
   subTitle: '6 weeks ・ Starting April 20th',
   path: '/clubs/xstate',
-  meta: true,
   image:
     'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/282/thumb/xstate.png',
 }
@@ -16,7 +15,6 @@ export const reduxClub = {
   title: 'Build an App with Redux',
   subTitle: '3 weeks ・ Start Anytime',
   path: '/clubs/redux',
-  meta: false,
   image:
     'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/386/thumb/redux.png',
 }

--- a/src/components/pages/home/club-card/club-card.stories.mdx
+++ b/src/components/pages/home/club-card/club-card.stories.mdx
@@ -1,0 +1,37 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks'
+import ClubCard from './'
+
+export const xStateClub = {
+  id: 'xstateClub',
+  title: 'Build an App with xState',
+  subTitle: '6 weeks ・ Starting April 20th',
+  path: '/clubs/xstate',
+  meta: true,
+  image:
+    'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/282/thumb/xstate.png',
+}
+
+export const reduxClub = {
+  id: 'reduxClub',
+  title: 'Build an App with Redux',
+  subTitle: '3 weeks ・ Start Anytime',
+  path: '/clubs/redux',
+  meta: false,
+  image:
+    'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/386/thumb/redux.png',
+}
+
+<Meta title="Components/Home/ClubCard" />
+
+# Club Card Component
+
+<Canvas>
+  <Story name="Default">
+    <div className="bg-gray-100 p-5">
+      <ClubCard resource={xStateClub} />
+    </div>
+    <div className="bg-gray-100 p-5">
+      <ClubCard resource={reduxClub} />
+    </div>
+  </Story>
+</Canvas>

--- a/src/components/pages/home/club-card/index.tsx
+++ b/src/components/pages/home/club-card/index.tsx
@@ -8,7 +8,6 @@ export type CardResource = {
   title: string
   subTitle: string
   path: string
-  meta: boolean
   image: string | {src: string; alt: string}
 }
 
@@ -24,36 +23,81 @@ const ClubCard: FunctionComponent<CardProps> = ({
   location = 'home',
   ...restProps
 }) => {
-  const {title, subTitle, path, meta, image} = resource || {}
+  const {title, subTitle, path, image} = resource || {}
 
   return (
     <div
-      className={`bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden sm:p-8 p-5 ${
+      className={`grid bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden sm:p-8 p-5 ${
         className ? className : ''
       }`}
       {...restProps}
     >
-      <div>
-        <div>
-          {meta ? (
-            <div className="flex items-center">
-              <span className="flex h-3 w-3 relative mr-3">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
-              </span>
-              <h2 className="uppercase font-semibold text-xs text-gray-700 dark:text-gray-300">
-                Live
-              </h2>
-            </div>
-          ) : (
-            <h2 className="uppercase font-semibold text-xs text-gray-700 dark:text-gray-300">
-              Self-paced
-            </h2>
-          )}
+      <div className="self-center">
+        {image && path && (
+          <Link href={path}>
+            <a
+              onClick={() => {
+                track('clicked home page resource', {
+                  resource: path,
+                  linkType: 'image',
+                  location,
+                })
+              }}
+              className="block flex-shrink-0 sm:w-auto w-20 mx-auto text-center mb-2"
+            >
+              <Image
+                src={get(image, 'src', image)}
+                width={100}
+                height={100}
+                alt={`illustration for ${title}`}
+                className="inline"
+              />
+            </a>
+          </Link>
+        )}
+        <div className="flex flex-col justify-center">
+          {title &&
+            (path ? (
+              <Link href={path}>
+                <a
+                  onClick={() => {
+                    track('clicked home page resource', {
+                      resource: path,
+                      linkType: 'text',
+                      location,
+                    })
+                  }}
+                  className="hover:text-blue-600 dark:hover:text-blue-300"
+                >
+                  <h2 className="uppercase font-semibold text-xs mb-1 text-gray-700 dark:text-gray-300 text-center">
+                    Portfolio Club
+                  </h2>
+                  <h3 className="text-xl font-bold tracking-tight leading-tight mb-2 text-center">
+                    {title}
+                  </h3>
+                </a>
+              </Link>
+            ) : (
+              <>
+                <h2 className="uppercase font-semibold text-xs mb-1 text-gray-700 dark:text-gray-300 text-center">
+                  Portfolio Club
+                </h2>
+                <h3 className="text-xl font-bold tracking-tight leading-tight mb-2 text-center">
+                  {title}
+                </h3>
+              </>
+            ))}
         </div>
+      </div>
 
-        <div className="my-4">
-          {image && path && (
+      <div className="grid grid-cols-3 border-t-2 border-gray-100 dark:border-gray-700 pt-5 self-end mt-4">
+        {subTitle && (
+          <div className="col-span-2 text-sm text-gray-600 dark:text-gray-300">
+            {subTitle}
+          </div>
+        )}
+        {path && (
+          <div className="justify-self-end">
             <Link href={path}>
               <a
                 onClick={() => {
@@ -63,69 +107,13 @@ const ClubCard: FunctionComponent<CardProps> = ({
                     location,
                   })
                 }}
-                className="block flex-shrink-0 sm:w-auto w-20 mx-auto text-center mb-8"
+                className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-2 px-6 rounded-md"
               >
-                <Image
-                  src={get(image, 'src', image)}
-                  width={100}
-                  height={100}
-                  alt={`illustration for ${title}`}
-                  className="inline"
-                />
+                Join
               </a>
             </Link>
-          )}
-          <div className="flex flex-col justify-center">
-            {title &&
-              (path ? (
-                <Link href={path}>
-                  <a
-                    onClick={() => {
-                      track('clicked home page resource', {
-                        resource: path,
-                        linkType: 'text',
-                        location,
-                      })
-                    }}
-                    className="hover:text-blue-600 dark:hover:text-blue-300"
-                  >
-                    <h3 className="text-xl font-bold tracking-tight leading-tight mb-2 text-center">
-                      {title}
-                    </h3>
-                  </a>
-                </Link>
-              ) : (
-                <h3 className="text-xl font-bold tracking-tight leading-tight mb-2 text-center">
-                  {title}
-                </h3>
-              ))}
           </div>
-        </div>
-        <div className="grid grid-cols-3 align-baseline border-t-2 border-gray-100 dark:border-gray-700 pt-5">
-          {subTitle && (
-            <div className="col-span-2 text-sm text-gray-600 dark:text-gray-300 mb-3">
-              {subTitle}
-            </div>
-          )}
-          {path && (
-            <div className="justify-self-end">
-              <Link href={path}>
-                <a
-                  onClick={() => {
-                    track('clicked home page resource', {
-                      resource: path,
-                      linkType: 'image',
-                      location,
-                    })
-                  }}
-                  className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
-                >
-                  Join
-                </a>
-              </Link>
-            </div>
-          )}
-        </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/pages/home/club-card/index.tsx
+++ b/src/components/pages/home/club-card/index.tsx
@@ -63,14 +63,14 @@ const ClubCard: FunctionComponent<CardProps> = ({
                     location,
                   })
                 }}
-                className="block flex-shrink-0 sm:w-auto w-20 mx-auto text-center"
+                className="block flex-shrink-0 sm:w-auto w-20 mx-auto text-center mb-8"
               >
                 <Image
                   src={get(image, 'src', image)}
-                  width={140}
-                  height={140}
+                  width={100}
+                  height={100}
                   alt={`illustration for ${title}`}
-                  className="inline mb-4"
+                  className="inline"
                 />
               </a>
             </Link>

--- a/src/components/pages/home/club-card/index.tsx
+++ b/src/components/pages/home/club-card/index.tsx
@@ -1,0 +1,134 @@
+import React, {FunctionComponent} from 'react'
+import Link from 'next/link'
+import {track} from 'utils/analytics'
+import Image from 'next/image'
+import {get} from 'lodash'
+
+export type CardResource = {
+  title: string
+  subTitle: string
+  path: string
+  meta: boolean
+  image: string | {src: string; alt: string}
+}
+
+type CardProps = {
+  resource?: CardResource
+  className?: string
+  location?: string
+}
+
+const ClubCard: FunctionComponent<CardProps> = ({
+  resource,
+  className,
+  location = 'home',
+  ...restProps
+}) => {
+  const {title, subTitle, path, meta, image} = resource || {}
+
+  return (
+    <div
+      className={`bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden sm:p-8 p-5 ${
+        className ? className : ''
+      }`}
+      {...restProps}
+    >
+      <div>
+        <div>
+          {meta ? (
+            <div className="flex items-center">
+              <span className="flex h-3 w-3 relative mr-3">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
+              </span>
+              <h2 className="uppercase font-semibold text-xs text-gray-700 dark:text-gray-300">
+                Live
+              </h2>
+            </div>
+          ) : (
+            <h2 className="uppercase font-semibold text-xs text-gray-700 dark:text-gray-300">
+              Self-paced
+            </h2>
+          )}
+        </div>
+
+        <div className="my-4">
+          {image && path && (
+            <Link href={path}>
+              <a
+                onClick={() => {
+                  track('clicked home page resource', {
+                    resource: path,
+                    linkType: 'image',
+                    location,
+                  })
+                }}
+                className="block flex-shrink-0 sm:w-auto w-20 mx-auto text-center"
+              >
+                <Image
+                  src={get(image, 'src', image)}
+                  width={140}
+                  height={140}
+                  alt={`illustration for ${title}`}
+                  className="inline mb-4"
+                />
+              </a>
+            </Link>
+          )}
+          <div className="flex flex-col justify-center">
+            {title &&
+              (path ? (
+                <Link href={path}>
+                  <a
+                    onClick={() => {
+                      track('clicked home page resource', {
+                        resource: path,
+                        linkType: 'text',
+                        location,
+                      })
+                    }}
+                    className="hover:text-blue-600 dark:hover:text-blue-300"
+                  >
+                    <h3 className="text-xl font-bold tracking-tight leading-tight mb-2 text-center">
+                      {title}
+                    </h3>
+                  </a>
+                </Link>
+              ) : (
+                <h3 className="text-xl font-bold tracking-tight leading-tight mb-2 text-center">
+                  {title}
+                </h3>
+              ))}
+          </div>
+        </div>
+        <div className="grid grid-cols-3 align-baseline border-t-2 border-gray-100 dark:border-gray-700 pt-5">
+          {subTitle && (
+            <div className="col-span-2 text-sm text-gray-600 dark:text-gray-300 mb-3">
+              {subTitle}
+            </div>
+          )}
+          {path && (
+            <div className="justify-self-end">
+              <Link href={path}>
+                <a
+                  onClick={() => {
+                    track('clicked home page resource', {
+                      resource: path,
+                      linkType: 'image',
+                      location,
+                    })
+                  }}
+                  className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 transform hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                >
+                  Join
+                </a>
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ClubCard

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -14,6 +14,7 @@ import {track} from 'utils/analytics'
 import Collection from './collection'
 import axios from 'utils/configured-axios'
 import Jumbotron from './jumbotron'
+import ClubCard from './club-card'
 
 const Home: FunctionComponent<any> = ({homePageData}) => {
   const location = 'home landing'
@@ -48,6 +49,10 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
   const featureDigitalGardening: any = get(
     homePageData,
     'featureDigitalGardening',
+  )
+  const featureDeveloperPortfolio: any = get(
+    homePageData,
+    'featureDeveloperPortfolio',
   )
 
   React.useEffect(() => {
@@ -113,6 +118,29 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
                 return <CardVerticalLarge key={resource.path} data={resource} />
               })}
             </div>
+
+            <section className="md:mt-20 mt-5 bg-gray-100 dark:bg-gray-700 rounded-lg p-5 grid md:grid-cols-6 sm:grid-cols-1 gap-4">
+              <div className="md:p-5 rounded-lg max-full col-span-3">
+                <div className="text-left">
+                  <Link href={featureDeveloperPortfolio.path}>
+                    <a className="font-bold hover:text-blue-600 dark:hover:text-blue-300">
+                      <h1 className="md:text-3xl text-2xl dark:text-gray-200 font-bold leading-tight">
+                        {featureDeveloperPortfolio.title}
+                      </h1>
+                    </a>
+                  </Link>
+                  <Markdown
+                    source={featureDeveloperPortfolio.cta}
+                    className="prose dark:prose-dark dark:prose-sm-dark prose-sm mt-4"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-rows-2 gap-4 col-span-3">
+                {featureDeveloperPortfolio.clubs.map((resource: any) => {
+                  return <ClubCard key={resource.slug} resource={resource} />
+                })}
+              </div>
+            </section>
 
             <CardHorizontal resource={modernLayoutsWithCSSGrid} />
 

--- a/src/pages/clubs/redux/index.tsx
+++ b/src/pages/clubs/redux/index.tsx
@@ -46,7 +46,7 @@ const reduxClub: React.FC<any> = ({data}) => {
             {data.redux.title}
           </h1>
           <p className="md:text-lg text-base font-semibold mt-4 text-gray-500">
-            Portfolio Project Club ・ {data.redux.subTitle}
+            Portfolio Club ・ {data.redux.subTitle}
           </p>
         </div>
         <Markdown className="prose dark:prose-dark dark:prose-lg-dark prose-lg">

--- a/src/pages/clubs/redux/index.tsx
+++ b/src/pages/clubs/redux/index.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import {sanityClient} from 'utils/sanity-client'
+import {reduxClubQuery} from '../../learn/developer-portfolio'
+import Markdown from 'react-markdown'
+import Image from 'next/image'
+import {NextSeo} from 'next-seo'
+
+const reduxClub: React.FC<any> = ({data}) => {
+  const defaultOgImage: string = `https://og-image-react-egghead.now.sh/article/${encodeURIComponent(
+    `Portfolio Club: ${data.redux.title}`,
+  )}?&theme=dark`
+
+  const ogImage = defaultOgImage
+
+  return (
+    <>
+      <NextSeo
+        title={`Portfolio Club: ${data.redux.title}`}
+        description={data.redux.summary}
+        openGraph={{
+          title: data.redux.title,
+          description: data.redux.summary,
+          images: [
+            {
+              url: ogImage,
+              alt: data.redux.title,
+            },
+          ],
+        }}
+        twitter={{
+          cardType: 'summary_large_image',
+          site: 'eggheadio',
+          handle: '',
+        }}
+      />
+      <div className="mx-auto mb-20 mt-10">
+        <div className="mb-12 lg:mb-20 text-center">
+          <Image
+            quality={100}
+            src={data.redux.image}
+            alt={`Tag image of ${data.redux.title} `}
+            width={100}
+            height={100}
+          />
+          <h1 className="max-w-screen-md lg:text-6xl md:text-5xl sm:text-4xl text-3xl w-full font-extrabold leading-tighter">
+            {data.redux.title}
+          </h1>
+          <p className="md:text-lg text-base font-semibold mt-4 text-gray-500">
+            {data.redux.subTitle}
+          </p>
+        </div>
+        <Markdown className="prose dark:prose-dark dark:prose-lg-dark prose-lg">
+          {data.redux.description}
+        </Markdown>
+      </div>
+    </>
+  )
+}
+
+export default reduxClub
+
+export async function getStaticProps() {
+  const data = await sanityClient.fetch(reduxClubQuery)
+
+  return {
+    props: {
+      data,
+    },
+  }
+}

--- a/src/pages/clubs/redux/index.tsx
+++ b/src/pages/clubs/redux/index.tsx
@@ -42,11 +42,11 @@ const reduxClub: React.FC<any> = ({data}) => {
             width={100}
             height={100}
           />
-          <h1 className="max-w-screen-md lg:text-6xl md:text-5xl sm:text-4xl text-3xl w-full font-extrabold leading-tighter">
+          <h1 className="max-w-screen-md lg:text-6xl md:text-5xl sm:text-4xl text-3xl w-full font-extrabold leading-tighter mt-8">
             {data.redux.title}
           </h1>
           <p className="md:text-lg text-base font-semibold mt-4 text-gray-500">
-            {data.redux.subTitle}
+            Portfolio Project Club ・ {data.redux.subTitle}
           </p>
         </div>
         <Markdown className="prose dark:prose-dark dark:prose-lg-dark prose-lg">

--- a/src/pages/clubs/xstate/index.tsx
+++ b/src/pages/clubs/xstate/index.tsx
@@ -42,11 +42,11 @@ const xStateClub: React.FC<any> = ({data}) => {
             width={100}
             height={100}
           />
-          <h1 className="max-w-screen-md lg:text-6xl md:text-5xl sm:text-4xl text-3xl w-full font-extrabold leading-tighter">
+          <h1 className="max-w-screen-md lg:text-6xl md:text-5xl sm:text-4xl text-3xl w-full font-extrabold leading-tighter mt-8">
             {data.xstate.title}
           </h1>
           <p className="md:text-lg text-base font-semibold mt-4 text-gray-500">
-            {data.xstate.subTitle}
+            Portfolio Project Club ・ {data.xstate.subTitle}
           </p>
         </div>
         <Markdown className="prose dark:prose-dark dark:prose-lg-dark prose-lg">

--- a/src/pages/clubs/xstate/index.tsx
+++ b/src/pages/clubs/xstate/index.tsx
@@ -46,7 +46,7 @@ const xStateClub: React.FC<any> = ({data}) => {
             {data.xstate.title}
           </h1>
           <p className="md:text-lg text-base font-semibold mt-4 text-gray-500">
-            Portfolio Project Club ・ {data.xstate.subTitle}
+            Portfolio Club ・ {data.xstate.subTitle}
           </p>
         </div>
         <Markdown className="prose dark:prose-dark dark:prose-lg-dark prose-lg">

--- a/src/pages/clubs/xstate/index.tsx
+++ b/src/pages/clubs/xstate/index.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import {sanityClient} from 'utils/sanity-client'
+import {xStateClubQuery} from '../../learn/developer-portfolio'
+import Markdown from 'react-markdown'
+import Image from 'next/image'
+import {NextSeo} from 'next-seo'
+
+const xStateClub: React.FC<any> = ({data}) => {
+  const defaultOgImage: string = `https://og-image-react-egghead.now.sh/article/${encodeURIComponent(
+    `Portfolio Club: ${data.xstate.title}`,
+  )}?&theme=dark`
+
+  const ogImage = defaultOgImage
+
+  return (
+    <>
+      <NextSeo
+        title={`Portfolio Club: ${data.xstate.title}`}
+        description={data.xstate.summary}
+        openGraph={{
+          title: data.xstate.title,
+          description: data.xstate.summary,
+          images: [
+            {
+              url: ogImage,
+              alt: data.xstate.title,
+            },
+          ],
+        }}
+        twitter={{
+          cardType: 'summary_large_image',
+          site: 'eggheadio',
+          handle: '',
+        }}
+      />
+      <div className="mx-auto mb-20 mt-10">
+        <div className="mb-12 lg:mb-20 text-center">
+          <Image
+            quality={100}
+            src={data.xstate.image}
+            alt={`Tag image of ${data.xstate.title} `}
+            width={100}
+            height={100}
+          />
+          <h1 className="max-w-screen-md lg:text-6xl md:text-5xl sm:text-4xl text-3xl w-full font-extrabold leading-tighter">
+            {data.xstate.title}
+          </h1>
+          <p className="md:text-lg text-base font-semibold mt-4 text-gray-500">
+            {data.xstate.subTitle}
+          </p>
+        </div>
+        <Markdown className="prose dark:prose-dark dark:prose-lg-dark prose-lg">
+          {data.xstate.description}
+        </Markdown>
+      </div>
+    </>
+  )
+}
+
+export default xStateClub
+
+export async function getStaticProps() {
+  const data = await sanityClient.fetch(xStateClubQuery)
+
+  return {
+    props: {
+      data,
+    },
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import groq from 'groq'
 import {sanityClient} from 'utils/sanity-client'
 import staticHomePageData from 'components/pages/home/homepage-data'
 import {digitalGardeningQuery} from './learn/digital-gardening'
+import {developerPortfolioQuery} from './learn/developer-portfolio'
 
 const IndexPage: FunctionComponent = ({homePageData}: any) => {
   return (
@@ -34,6 +35,7 @@ export default IndexPage
 const featureQuery = groq`
 {
   'featureDigitalGardening': ${digitalGardeningQuery},
+  'featureDeveloperPortfolio': ${developerPortfolioQuery}
 }
 `
 

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -54,7 +54,7 @@ const DeveloperPortfolio: React.FC<any> = ({data}) => {
             </div>
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-4 mt-5">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-5">
           {data.clubs.map((resource: any) => {
             return <ClubCard key={resource.slug} resource={resource} />
           })}

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -37,7 +37,7 @@ const DeveloperPortfolio: React.FC<any> = ({data}) => {
                 </div>
                 <div className="flex flex-col sm:items-start items-center w-full">
                   <h2 className="text-xs text-yellow-600 dark:text-yellow-300 uppercase font-semibold mb-2">
-                    Create a Developer Portfolio
+                    Craft a Portfolio that gets you hired
                   </h2>
 
                   <h1 className="sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter">
@@ -46,7 +46,7 @@ const DeveloperPortfolio: React.FC<any> = ({data}) => {
 
                   <Markdown
                     source={data.description}
-                    className="prose dark:prose-dark dark:prose-md-dark prose-md"
+                    className="prose dark:prose-dark dark:prose-md-dark prose-md mt-4"
                   />
                 </div>
               </div>

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -1,21 +1,77 @@
 import * as React from 'react'
 import groq from 'groq'
 import {sanityClient} from 'utils/sanity-client'
+import Image from 'next/image'
+import Link from 'next/link'
+import {track} from 'utils/analytics'
+import Markdown from 'react-markdown'
 
-const developerPortfolio: React.FC<any> = ({data}) => {
-  return <h1>{data.title}</h1>
+const DeveloperPortfolio: React.FC<any> = ({data}) => {
+  return (
+    <div className="sm:-my-5 -my-3 -mx-5 p-5 dark:bg-gray-900 bg-gray-50">
+      <div className="mx-auto max-w-screen-xl">
+        <div className="flex items-center justify-center bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-50 overflow-hidden rounded-lg shadow-sm">
+          <div className="px-5 sm:py-16 py-10 sm:text-left text-center">
+            <div className="space-y-5 mx-auto flex items-center justify-center lg:px-8 w-full">
+              <div className="flex lg:flex-row flex-col items-center justify-center sm:space-x-10 sm:space-y-0 space-y-5 0 w-full xl:pr-16">
+                <div className="flex-shrink-0">
+                  <Link href={data.path}>
+                    <a
+                      tabIndex={-1}
+                      onClick={() =>
+                        track('clicked jumbotron resource', {
+                          resource: data.path,
+                          linkType: 'image',
+                        })
+                      }
+                    >
+                      <Image
+                        quality={100}
+                        src={data.image}
+                        width={300}
+                        height={300}
+                        alt={data.title}
+                      />
+                    </a>
+                  </Link>
+                </div>
+                <div className="flex flex-col sm:items-start items-center w-full">
+                  <h2 className="text-xs text-yellow-600 dark:text-yellow-300 uppercase font-semibold mb-2">
+                    Create a Developer Portfolio
+                  </h2>
+
+                  <h1 className="sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter">
+                    {data.title}
+                  </h1>
+
+                  <Markdown
+                    source={data.description}
+                    className="prose dark:prose-dark dark:prose-md-dark prose-md"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
-export default developerPortfolio
+export default DeveloperPortfolio
 
 export const developerPortfolioQuery = groq`*[_type == 'resource' && slug.current == "build-business-oriented-portfolio"][0]{
   title,
   description,
- 	"slug": slug.current,
+  "cta": content[0].description,
+  path,
+  slug,
+  image,
   "clubs": resources[0].resources[]{
       title,
       subTitle,
       "slug": slug.current,
+      path,
       meta,
       image,
       summary,

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -72,7 +72,6 @@ export const developerPortfolioQuery = groq`*[_type == 'resource' && slug.curren
       subTitle,
       "slug": slug.current,
       path,
-      meta,
       image,
       summary,
 	}
@@ -84,7 +83,6 @@ export const reduxClubQuery = groq`*[_type == 'resource' && slug.current == "bui
       subTitle,
       description,
       "slug": slug.current,
-      meta,
       image,
       summary,
     }
@@ -96,7 +94,6 @@ export const xStateClubQuery = groq`*[_type == 'resource' && slug.current == "bu
       subTitle,
       description,
       "slug": slug.current,
-      meta,
       image,
       summary,
     }

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -17,7 +17,8 @@ export const developerPortfolioQuery = groq`*[_type == 'resource' && slug.curren
       subTitle,
       "slug": slug.current,
       meta,
-      image
+      image,
+      summary,
 	}
 }`
 
@@ -25,9 +26,11 @@ export const reduxClubQuery = groq`*[_type == 'resource' && slug.current == "bui
   "redux": resources[0].resources[slug.current == "redux"][0]{
       title,
       subTitle,
+      description,
       "slug": slug.current,
       meta,
-      image
+      image,
+      summary,
     }
 }`
 
@@ -35,9 +38,11 @@ export const xStateClubQuery = groq`*[_type == 'resource' && slug.current == "bu
   "xstate": resources[0].resources[slug.current == "xstate"][0]{
       title,
       subTitle,
+      description,
       "slug": slug.current,
       meta,
-      image
+      image,
+      summary,
     }
 }`
 

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import groq from 'groq'
+import {sanityClient} from 'utils/sanity-client'
+
+const developerPortfolio: React.FC<any> = ({data}) => {
+  return <h1>{data.title}</h1>
+}
+
+export default developerPortfolio
+
+export const developerPortfolioQuery = groq`*[_type == 'resource' && slug.current == "build-business-oriented-portfolio"][0]{
+  title,
+  description,
+ 	"slug": slug.current,
+  "clubs": resources[0].resources[]{
+      title,
+      subTitle,
+      "slug": slug.current,
+      meta,
+      image
+	}
+}`
+
+export const reduxClubQuery = groq`*[_type == 'resource' && slug.current == "build-business-oriented-portfolio"][0]{
+  "redux": resources[0].resources[slug.current == "redux"][0]{
+      title,
+      subTitle,
+      "slug": slug.current,
+      meta,
+      image
+    }
+}`
+
+export const xStateClubQuery = groq`*[_type == 'resource' && slug.current == "build-business-oriented-portfolio"][0]{
+  "xstate": resources[0].resources[slug.current == "xstate"][0]{
+      title,
+      subTitle,
+      "slug": slug.current,
+      meta,
+      image
+    }
+}`
+
+export async function getStaticProps() {
+  const data = await sanityClient.fetch(developerPortfolioQuery)
+
+  return {
+    props: {
+      data,
+    },
+  }
+}

--- a/src/pages/learn/developer-portfolio/index.tsx
+++ b/src/pages/learn/developer-portfolio/index.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import {track} from 'utils/analytics'
 import Markdown from 'react-markdown'
+import ClubCard from 'components/pages/home/club-card'
 
 const DeveloperPortfolio: React.FC<any> = ({data}) => {
   return (
@@ -52,6 +53,11 @@ const DeveloperPortfolio: React.FC<any> = ({data}) => {
               </div>
             </div>
           </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4 mt-5">
+          {data.clubs.map((resource: any) => {
+            return <ClubCard key={resource.slug} resource={resource} />
+          })}
         </div>
       </div>
     </div>

--- a/studio/schemas/documents/resource.js
+++ b/studio/schemas/documents/resource.js
@@ -118,6 +118,10 @@ export default {
             title: 'portfolio',
             value: 'portfolio',
           },
+          {
+            title: 'club',
+            value: 'club',
+          },
         ],
       },
     },


### PR DESCRIPTION
We needed a landing page for portfolio clubs and cards that could serve as CTAs to drive sign-ups. Instead of creating portfolio club data in isolation, this PR leverages the established pattern for creating features. 

The `Craft a Business Oriented Developer Portfolio` feature contains a `Portfolio Clubs` resource, and inside of that, `Clubs` are structured as resources.

**Note:** the developer portfolio feature page still needs further curation, but that's probably a separate PR. 

### club card component
![image](https://user-images.githubusercontent.com/57044804/115784776-6b32f400-a373-11eb-8c18-9592ebd56a2c.png)

### club landing page
![image](https://user-images.githubusercontent.com/57044804/115784347-d6c89180-a372-11eb-90ca-d6f54dcc272a.png)

### developer portfolio feature
![image](https://user-images.githubusercontent.com/57044804/115783943-56a22c00-a372-11eb-96c6-861f01a8ead0.png)

### developer portfolio page
![image](https://user-images.githubusercontent.com/57044804/115784516-12fbf200-a373-11eb-875f-0ad607a8d815.png)

![](https://i.giphy.com/media/9fuvOqZ8tbZOU/giphy.webp)