### PR TITLE
update digital garden query to original sanity feature

### DIFF
--- a/src/pages/learn/digital-gardening/index.tsx
+++ b/src/pages/learn/digital-gardening/index.tsx
@@ -108,7 +108,7 @@ const DigitalGardening: React.FC<any> = ({data}) => {
 
 export default DigitalGardening
 
-export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current == "digital-gardening-for-developers-v2"][0]{
+export const digitalGardeningQuery = groq`*[_type == 'resource' && slug.current == "digital-gardening-for-developers"][0]{
   title,
   description,
   path,


### PR DESCRIPTION
Switches this back to `Digital Gardening for Developers` feature in sanity so that the title remains the same