### PR TITLE
Replacing the Bitmovin player

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "browser-cookies": "^1.2.0",
     "client-oauth2": "^4.3.3",
     "cookie": "^0.4.1",
-    "cueplayer-react": "^0.0.7",
+    "cueplayer-react": "^0.0.8",
     "date-fns": "^2.19.0",
     "discord.js": "^12.5.3",
     "facepaint": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "browser-cookies": "^1.2.0",
     "client-oauth2": "^4.3.3",
     "cookie": "^0.4.1",
-    "cueplayer-react": "^0.0.6",
+    "cueplayer-react": "^0.0.7",
     "date-fns": "^2.19.0",
     "discord.js": "^12.5.3",
     "facepaint": "^1.2.1",

--- a/src/components/EggheadPlayer/use-egghead-player.ts
+++ b/src/components/EggheadPlayer/use-egghead-player.ts
@@ -221,7 +221,7 @@ const defaultPlayerPreferences = {
     id: null,
     kind: null,
     label: 'off',
-    lang: null,
+    language: null,
   },
   muted: false,
   theater: false,

--- a/src/machines/lesson-player-machine.ts
+++ b/src/machines/lesson-player-machine.ts
@@ -105,6 +105,7 @@ export const playerMachine = Machine<
         on: {
           PLAY: 'playing',
           LOAD: 'loading',
+          COMPLETE: 'completed',
         },
       },
 

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, SyntheticEvent} from 'react'
 import {GetServerSideProps} from 'next'
 import {useRouter} from 'next/router'
 import {isEmpty, get, first, isFunction, filter} from 'lodash'
@@ -47,6 +47,24 @@ import useCio from 'hooks/use-cio'
 import LevelUpCTA from '../../components/survey/level-up-cta'
 import Comments from '../../components/pages/lessons/comments/comments'
 import Spinner from 'components/spinner'
+import {
+  BigPlayButton,
+  ClosedCaptionButton,
+  ControlBar,
+  CurrentTimeDisplay,
+  DurationDisplay,
+  ForwardControl,
+  FullscreenToggle,
+  HLSSource,
+  PlaybackRateMenuButton,
+  Player,
+  PlayToggle,
+  ProgressControl,
+  RemainingTimeDisplay,
+  ReplayControl,
+  TimeDivider,
+  VolumeMenuButton,
+} from 'cueplayer-react'
 
 const tracer = getTracer('lesson-page')
 
@@ -99,7 +117,13 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
   const router = useRouter()
   const {subscriber, cioIdentify} = useCio()
   const {viewer} = useViewer()
-  const {setPlayerPrefs, playbackRate, defaultView} = useEggheadPlayerPrefs()
+  const {
+    setPlayerPrefs,
+    playbackRate,
+    defaultView,
+    volumeRate,
+    subtitle,
+  } = useEggheadPlayerPrefs()
 
   const {md} = useBreakpoint()
 
@@ -403,47 +427,91 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                     playerVisible ? 'block' : 'hidden'
                   } w-full lg:block absolute top-0 left-0 right-0 bottom-0`}
                 >
-                  <EggheadPlayer
+                  {/*<EggheadPlayer*/}
+                  {/*  id="egghead-player"*/}
+                  {/*  ref={playerRef}*/}
+                  {/*  hidden={playerState.matches('LOADING')}*/}
+                  {/*  resource={lesson}*/}
+                  {/*  poster={lesson?.thumb_url}*/}
+                  {/*  hls_url={lesson?.hls_url}*/}
+                  {/*  dash_url={lesson?.dash_url}*/}
+                  {/*  playing={playerState.matches('playing')}*/}
+                  {/*  playbackRate={playbackRate}*/}
+                  {/*  width="100%"*/}
+                  {/*  height="auto"*/}
+                  {/*  pip="true"*/}
+                  {/*  controls*/}
+                  {/*  onPlay={() => send('PLAY')}*/}
+                  {/*  onViewModeChanged={({to}: {to: string}) => {*/}
+                  {/*    if (to === 'fullscreen') {*/}
+                  {/*      track('entered fullscreen video', {*/}
+                  {/*        video: lesson.slug,*/}
+                  {/*      })*/}
+
+                  {/*      setIsFullscreen(true)*/}
+                  {/*    } else {*/}
+                  {/*      setIsFullscreen(false)*/}
+                  {/*    }*/}
+                  {/*  }}*/}
+                  {/*  onReady={(player: any) => {*/}
+                  {/*    actualPlayerRef.current = player*/}
+                  {/*    console.debug(`player ready [autoplay:${autoplay}]`)*/}
+                  {/*    const isDifferent = lastAutoPlayed.current !== lesson.slug*/}
+                  {/*    if (autoplay && isDifferent && isFunction(player.play)) {*/}
+                  {/*      console.debug(`autoplaying`)*/}
+                  {/*      lastAutoPlayed.current = lesson.slug*/}
+                  {/*      player.play()*/}
+                  {/*    }*/}
+                  {/*  }}*/}
+                  {/*  onPause={() => {*/}
+                  {/*    send('PAUSE')*/}
+                  {/*  }}*/}
+                  {/*  onProgress={({...progress}) => {*/}
+                  {/*    onProgress(progress, lesson).then((lessonView: any) => {*/}
+                  {/*      if (lessonView) {*/}
+                  {/*        console.debug('progress recorded', {*/}
+                  {/*          progress: lessonView,*/}
+                  {/*        })*/}
+                  {/*        setLessonView(lessonView)*/}
+                  {/*      }*/}
+                  {/*    })*/}
+                  {/*  }}*/}
+                  {/*  onEnded={() => {*/}
+                  {/*    console.debug(`received ended event from player`)*/}
+                  {/*    send('COMPLETE')*/}
+                  {/*  }}*/}
+                  {/*  subtitlesUrl={get(lesson, 'subtitles_url')}*/}
+                  {/*/>*/}
+                  <Player
                     id="egghead-player"
                     ref={playerRef}
-                    hidden={playerState.matches('LOADING')}
-                    resource={lesson}
+                    crossOrigin="anonymous"
+                    className="font-sans"
                     poster={lesson?.thumb_url}
-                    hls_url={lesson?.hls_url}
-                    dash_url={lesson?.dash_url}
-                    playing={playerState.matches('playing')}
-                    playbackRate={playbackRate}
-                    width="100%"
-                    height="auto"
-                    pip="true"
-                    controls
-                    onPlay={() => send('PLAY')}
-                    onViewModeChanged={({to}: {to: string}) => {
-                      if (to === 'fullscreen') {
-                        track('entered fullscreen video', {
-                          video: lesson.slug,
-                        })
-
-                        setIsFullscreen(true)
-                      } else {
-                        setIsFullscreen(false)
-                      }
-                    }}
-                    onReady={(player: any) => {
-                      actualPlayerRef.current = player
+                    volume={0.2}
+                    onCanPlay={(event: SyntheticEvent) => {
                       console.debug(`player ready [autoplay:${autoplay}]`)
-                      const isDifferent = lastAutoPlayed.current !== lesson.slug
+                      const player: HTMLVideoElement = event.target as HTMLVideoElement
+                      player.volume = volumeRate / 100
+                      player.playbackRate = playbackRate
+                      actualPlayerRef.current = player
+                      const isDifferent =
+                        lastAutoPlayed.current !== lesson?.hls_url
                       if (autoplay && isDifferent && isFunction(player.play)) {
                         console.debug(`autoplaying`)
-                        lastAutoPlayed.current = lesson.slug
+                        lastAutoPlayed.current = lesson?.hls_url
                         player.play()
                       }
                     }}
                     onPause={() => {
                       send('PAUSE')
                     }}
-                    onProgress={({...progress}) => {
-                      onProgress(progress, lesson).then((lessonView: any) => {
+                    onPlay={() => send('PLAY')}
+                    onTimeUpdate={(event: any) => {
+                      onProgress(
+                        {playedSeconds: event.target.currentTime},
+                        lesson,
+                      ).then((lessonView: any) => {
                         if (lessonView) {
                           console.debug('progress recorded', {
                             progress: lessonView,
@@ -456,8 +524,72 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                       console.debug(`received ended event from player`)
                       send('COMPLETE')
                     }}
-                    subtitlesUrl={get(lesson, 'subtitles_url')}
-                  />
+                    onVolumeChange={(event: SyntheticEvent) => {
+                      const player: HTMLVideoElement = event.target as HTMLVideoElement
+                      setPlayerPrefs({volumeRate: player.volume * 100})
+                    }}
+                  >
+                    {lesson?.hls_url && (
+                      <HLSSource
+                        key={lesson?.hls_url}
+                        isVideoChild
+                        src={lesson?.hls_url}
+                      />
+                    )}
+                    <track
+                      key={lesson?.subtitles_url}
+                      src={lesson?.subtitles_url}
+                      kind="subtitles"
+                      srcLang="en"
+                      label="English"
+                      default={subtitle?.language === 'en'}
+                    />
+                    <BigPlayButton position="center" />
+                    <ControlBar disableDefaultControls>
+                      <PlayToggle key="play-toggle" order={1} />
+                      <ReplayControl key="replay-control" order={2} />
+                      <ForwardControl key="forward-control" order={3} />
+                      <VolumeMenuButton key="volume-menu-button" order={4} />
+                      <CurrentTimeDisplay
+                        key="current-time-display"
+                        order={5}
+                      />
+                      <TimeDivider key="time-divider" order={6} />
+                      <DurationDisplay key="duration-display" order={7} />
+                      <ProgressControl key="progress-control" order={8} />
+                      <RemainingTimeDisplay
+                        key="remaining-time-display"
+                        order={9}
+                      />
+                      <PlaybackRateMenuButton
+                        rates={[1, 1.25, 1.5, 2]}
+                        key="playback-rate"
+                        order={10}
+                        selected={playbackRate}
+                        onChange={(playbackRate: number) => {
+                          setPlayerPrefs({playbackRate})
+                        }}
+                      />
+                      {lesson?.subtitles_url && (
+                        <ClosedCaptionButton
+                          key={lesson?.subtitles_url}
+                          order={11}
+                          selected={subtitle}
+                          onChange={(track: TextTrack) => {
+                            setPlayerPrefs({
+                              subtitle: {
+                                id: track.id,
+                                kind: track.kind,
+                                label: track.label,
+                                language: track.language,
+                              },
+                            })
+                          }}
+                        />
+                      )}
+                      <FullscreenToggle key="fullscreen-toggle" order={12} />
+                    </ControlBar>
+                  </Player>
                 </div>
 
                 {spinnerVisible && (

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -125,7 +125,7 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
     subtitle,
   } = useEggheadPlayerPrefs()
 
-  const {md} = useBreakpoint()
+  const {sm, md} = useBreakpoint()
 
   const [isFullscreen, setIsFullscreen] = React.useState(false)
 
@@ -545,50 +545,55 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                       default={subtitle?.language === 'en'}
                     />
                     <BigPlayButton position="center" />
-                    <ControlBar disableDefaultControls>
-                      <PlayToggle key="play-toggle" order={1} />
-                      <ReplayControl key="replay-control" order={2} />
-                      <ForwardControl key="forward-control" order={3} />
-                      <VolumeMenuButton key="volume-menu-button" order={4} />
-                      <CurrentTimeDisplay
-                        key="current-time-display"
-                        order={5}
-                      />
-                      <TimeDivider key="time-divider" order={6} />
-                      <DurationDisplay key="duration-display" order={7} />
-                      <ProgressControl key="progress-control" order={8} />
-                      <RemainingTimeDisplay
-                        key="remaining-time-display"
-                        order={9}
-                      />
-                      <PlaybackRateMenuButton
-                        rates={[1, 1.25, 1.5, 2]}
-                        key="playback-rate"
-                        order={10}
-                        selected={playbackRate}
-                        onChange={(playbackRate: number) => {
-                          setPlayerPrefs({playbackRate})
-                        }}
-                      />
-                      {lesson?.subtitles_url && (
-                        <ClosedCaptionButton
-                          key={lesson?.subtitles_url}
-                          order={11}
-                          selected={subtitle}
-                          onChange={(track: TextTrack) => {
-                            setPlayerPrefs({
-                              subtitle: {
-                                id: track.id,
-                                kind: track.kind,
-                                label: track.label,
-                                language: track.language,
-                              },
-                            })
+                    {!sm && (
+                      <ControlBar disableDefaultControls>
+                        <PlayToggle key="play-toggle" order={1} />
+
+                        <ProgressControl key="progress-control" order={8} />
+                        <RemainingTimeDisplay
+                          key="remaining-time-display"
+                          order={9}
+                        />
+                        <ReplayControl key="replay-control" order={2} />
+                        <ForwardControl key="forward-control" order={3} />
+                        <VolumeMenuButton key="volume-menu-button" order={4} />
+                        <CurrentTimeDisplay
+                          key="current-time-display"
+                          order={5}
+                        />
+                        <TimeDivider key="time-divider" order={6} />
+                        <DurationDisplay key="duration-display" order={7} />
+                        <PlaybackRateMenuButton
+                          rates={[1, 1.25, 1.5, 2]}
+                          className="hidden"
+                          key="playback-rate"
+                          order={10}
+                          selected={playbackRate}
+                          onChange={(playbackRate: number) => {
+                            setPlayerPrefs({playbackRate})
                           }}
                         />
-                      )}
-                      <FullscreenToggle key="fullscreen-toggle" order={12} />
-                    </ControlBar>
+                        {lesson?.subtitles_url && (
+                          <ClosedCaptionButton
+                            key={lesson?.subtitles_url}
+                            className="hidden"
+                            order={11}
+                            selected={subtitle}
+                            onChange={(track: TextTrack) => {
+                              setPlayerPrefs({
+                                subtitle: {
+                                  id: track.id,
+                                  kind: track.kind,
+                                  label: track.label,
+                                  language: track.language,
+                                },
+                              })
+                            }}
+                          />
+                        )}
+                        <FullscreenToggle key="fullscreen-toggle" order={12} />
+                      </ControlBar>
+                    )}
                   </Player>
                 </div>
 
@@ -679,15 +684,6 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                     onDark={true}
                     player={actualPlayerRef.current}
                   />
-                  {playbackRate && (
-                    <PlaybackSpeedSelect
-                      playbackRate={playbackRate}
-                      changePlaybackRate={(rate: number) =>
-                        setPlayerPrefs({playbackRate: rate})
-                      }
-                      video={slug}
-                    />
-                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -19,6 +19,99 @@ import {
   PlaybackRateMenuButton,
   FullscreenToggle,
 } from 'cueplayer-react'
+import {SyntheticEvent} from 'react'
+import {isFunction} from 'lodash'
+
+export const getServerSideProps: GetServerSideProps = async function ({query}) {
+  const videoResource = pickVideoResource(query.v)
+
+  return {
+    props: {
+      videoResource,
+    },
+  }
+}
+
+const VideoTest: React.FC<any> = ({videoResource}) => {
+  const actualPlayerRef = React.useRef<any>()
+
+  //autoplay
+  const lastAutoPlayed = React.useRef()
+  const [autoplay, setAutoplay] = React.useState(true)
+
+  const send = (message) => {
+    console.debug(message)
+  }
+
+  const onProgress = () => {
+    console.log('progress happened')
+  }
+
+  return (
+    <div>
+      {videoResource.hls_url && (
+        <Player
+          ref={(test: any) => {
+            console.log(test.manager.store.getState())
+          }}
+          crossOrigin="anonymous"
+          className="font-sans"
+          poster={videoResource.poster}
+          onCanPlay={(event: SyntheticEvent) => {
+            console.debug(`player ready [autoplay:${autoplay}]`)
+            const player: HTMLVideoElement = event.target as HTMLVideoElement
+            actualPlayerRef.current = player
+            const isDifferent = lastAutoPlayed.current !== videoResource.hls_url
+            if (autoplay && isDifferent && isFunction(player.play)) {
+              console.debug(`autoplaying`)
+              lastAutoPlayed.current = videoResource.hls_url
+              player.play()
+            }
+          }}
+          onPause={() => {
+            send('PAUSE')
+          }}
+          onPlay={() => send('PLAY')}
+          onTimeUpdate={() => {
+            onProgress()
+          }}
+          onEnded={() => {
+            console.debug(`received ended event from player`)
+            send('COMPLETE')
+          }}
+        >
+          <BigPlayButton position="center" />
+          <HLSSource isVideoChild src={videoResource.hls_url} />
+          <track
+            src={videoResource.subtitlesUrl}
+            kind="subtitles"
+            srcLang="en"
+            label="English"
+            default
+          />
+          <ControlBar disableDefaultControls>
+            <PlayToggle key="play-toggle" order={1} />
+            <ReplayControl key="replay-control" order={2} />
+            <ForwardControl key="forward-control" order={3} />
+            <VolumeMenuButton key="volume-menu-button" order={4} />
+            <CurrentTimeDisplay key="current-time-display" order={5} />
+            <TimeDivider key="time-divider" order={6} />
+            <DurationDisplay key="duration-display" order={7} />
+            <ProgressControl key="progress-control" order={8} />
+            <RemainingTimeDisplay key="remaining-time-display" order={9} />
+            <PlaybackRateMenuButton
+              rates={[1, 1.25, 1.5, 2]}
+              key="playback-rate"
+              order={10}
+            />
+            <ClosedCaptionButton order={11} />
+            <FullscreenToggle key="fullscreen-toggle" order={12} />
+          </ControlBar>
+        </Player>
+      )}
+    </div>
+  )
+}
 
 const videoResources = {
   testingjavascript: {
@@ -115,60 +208,6 @@ const pickVideoResource = (query: any) => {
     default:
       return videoResources.defaultVideo
   }
-}
-
-export const getServerSideProps: GetServerSideProps = async function ({query}) {
-  const videoResource = pickVideoResource(query.v)
-
-  return {
-    props: {
-      videoResource,
-    },
-  }
-}
-const VideoTest: React.FC<any> = ({videoResource}) => {
-  return (
-    <div>
-      {videoResource.hls_url && (
-        <Player
-          ref={(test: any) => {
-            console.log(test)
-          }}
-          crossOrigin="anonymous"
-          className="font-sans"
-          poster={videoResource.poster}
-        >
-          <BigPlayButton position="center" />
-          <HLSSource isVideoChild src={videoResource.hls_url} />
-          <track
-            src={videoResource.subtitlesUrl}
-            kind="subtitles"
-            srcLang="en"
-            label="English"
-            default
-          />
-          <ControlBar disableDefaultControls>
-            <PlayToggle key="play-toggle" order={1} />
-            <ReplayControl key="replay-control" order={2} />
-            <ForwardControl key="forward-control" order={3} />
-            <VolumeMenuButton key="volume-menu-button" order={4} />
-            <CurrentTimeDisplay key="current-time-display" order={5} />
-            <TimeDivider key="time-divider" order={6} />
-            <DurationDisplay key="duration-display" order={7} />
-            <ProgressControl key="progress-control" order={8} />
-            <RemainingTimeDisplay key="remaining-time-display" order={9} />
-            <PlaybackRateMenuButton
-              rates={[1, 1.25, 1.5, 2]}
-              key="playback-rate"
-              order={10}
-            />
-            <ClosedCaptionButton order={11} />
-            <FullscreenToggle key="fullscreen-toggle" order={12} />
-          </ControlBar>
-        </Player>
-      )}
-    </div>
-  )
 }
 
 export default VideoTest

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -39,7 +39,7 @@ const VideoTest: React.FC<any> = ({videoResource}) => {
   const lastAutoPlayed = React.useRef()
   const [autoplay, setAutoplay] = React.useState(true)
 
-  const send = (message) => {
+  const send = (message:any) => {
     console.debug(message)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9392,10 +9392,10 @@ csstype@^3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
   integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
 
-cueplayer-react@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/cueplayer-react/-/cueplayer-react-0.0.7.tgz#fa2f3c57b5326867bd9f7f1b0e2f43c0fb3d6789"
-  integrity sha512-AfPI9/sQSC88a5uG8SGwKNq8ftCjqePy3NNfRnn4CnNDZ2yQ/R+5E6kA58M9UvMUPMtdxW2aPamPXCsJ6WidcQ==
+cueplayer-react@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/cueplayer-react/-/cueplayer-react-0.0.8.tgz#f62c70c11121a4e1c3ca44c2857447b266c31990"
+  integrity sha512-IZrGVOuPbdiLleckVjQO9v7NybYw81dhfOmZK55b6u84PoVVVHp+lu2350GxRbWiDlomMaWDDptpJAZQmnvXyQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
     classnames "^2.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9392,10 +9392,10 @@ csstype@^3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
   integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
 
-cueplayer-react@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/cueplayer-react/-/cueplayer-react-0.0.6.tgz#e11c553407df8c0824376ccaa5e41a7b98e6ea90"
-  integrity sha512-ZGyhvTj2pJCpHlcjkl9Ax9pJxmxvcf017TcWJKGGohjtH7Y1ZHBMCoUctugvhG5NVeVkstJyZMD/s26E0Q2vqw==
+cueplayer-react@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/cueplayer-react/-/cueplayer-react-0.0.7.tgz#fa2f3c57b5326867bd9f7f1b0e2f43c0fb3d6789"
+  integrity sha512-AfPI9/sQSC88a5uG8SGwKNq8ftCjqePy3NNfRnn4CnNDZ2yQ/R+5E6kA58M9UvMUPMtdxW2aPamPXCsJ6WidcQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
     classnames "^2.2.6"


### PR DESCRIPTION
This replaces the Bitmovin player on video resource (lesson) pages.

I tested it fairly well, but could use some additional help!

![image](https://user-images.githubusercontent.com/86834/115937866-d224db80-a44d-11eb-85f2-006f608180db.png)


![](https://media.giphy.com/media/pWsz9pgd1X1Re/giphy.gif)