### PR TITLE
Add What's New Section to homepage + UX improvements

### DIFF
--- a/src/components/pages/home/homepage-data.ts
+++ b/src/components/pages/home/homepage-data.ts
@@ -40,6 +40,46 @@ const homepageData = {
         'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/458/medium/IMG_20190627_100655_466.jpg',
     },
   },
+  'react-concurrent-react-from-scratch': {
+    id: 'react-concurrent-react-from-scratch',
+    title: 'Concurrent React from Scratch',
+    name: 'Mental Models for concurrent React',
+    byline: 'Shawn Wang・36m',
+    description: `In this talk, we’ll create an effective mental model of Concurrent React by building a tiny clone of React! We will start with a blank JS file and learn about how React renders components, schedules Time-Slicing updates with a Work Loop, and more!`,
+    image:
+      'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/211/original/download.jpeg',
+    path: '/courses/build-modern-layouts-with-css-grid-d3f5',
+    slug: 'build-modern-layouts-with-css-grid-d3f5',
+    instructor: {
+      name: 'Shawn Wang',
+      slug: 'shawn-wang',
+      path: '/q/resources-by-shawn-wang',
+      twitter: 'swyx',
+      image:
+        'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/211/original/download.jpeg',
+    },
+  },
+  'drawing-the-invisible-react-explained-in-five-visual-metaphors': {
+    id: 'drawing-the-invisible-react-explained-in-five-visual-metaphors',
+    title: 'Drawing the Invisible: React Explained ',
+    name: 'Visualize React through Metaphor',
+    byline: 'Maggie Appleton・36m',
+    description: `A guide to the fundamentals of React explained through five visual metaphors. From component trees to state, Maggie explains the analogies and metaphorical comparisons that helped her "get" React for the first time.`,
+    image:
+      'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/053/original/profile_photo_big_2.png',
+    path:
+      '/talks/javascript-drawing-the-invisible-react-explained-in-five-visual-metaphors',
+    slug:
+      'javascript-drawing-the-invisible-react-explained-in-five-visual-metaphors',
+    instructor: {
+      name: 'Maggie Appleton',
+      slug: 'maggie-appleton',
+      path: '/q/resources-by-maggie-appleton',
+      twitter: 'mappletons',
+      image:
+        'https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/053/original/profile_photo_big_2.png',
+    },
+  },
   video: {
     id: 'video',
     name: 'Optimize your Learning',

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -14,6 +14,7 @@ import Collection from './collection'
 import axios from 'utils/configured-axios'
 import Jumbotron from './jumbotron'
 import VideoCard from 'components/pages/home/video-card'
+import WhatsNew from '../../../pages/new'
 
 const Home: FunctionComponent<any> = ({homePageData}) => {
   const location = 'home landing'
@@ -49,6 +50,7 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
     homePageData,
     'featureDigitalGardening',
   )
+  const featureWhatsNew: any = get(homePageData, 'featureWhatsNew')
 
   React.useEffect(() => {
     if (viewer) {
@@ -95,193 +97,219 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
           />
         )}
       </div> */}
-      <div className="lg:space-y-6 space-y-4">
-        <Jumbotron resource={jumbotron} />
-        <section className="">
+      <div className="mt-12">
+        <WhatsNew resource={featureWhatsNew} />
+
+        <section className="mt-32">
+          <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white text-center">
+            Our Curated Guides
+          </h2>
           <TopicsList topics={topics} />
         </section>
-        <section className="grid lg:grid-cols-8 grid-cols-1 lg:gap-6 gap-4">
-          <VideoCard className="lg:col-span-6" resource={video} />
-          <EventSchedule />
-        </section>
-        <section className="grid lg:grid-cols-12 grid-cols-1 lg:gap-6 gap-4">
-          <div className="lg:col-span-8 lg:space-y-6 space-y-4">
-            <div
-              className={`grid sm:grid-cols-${featured.length} grid-cols-2 sm:gap-5 gap-3`}
-            >
-              {map(featured, (resource) => {
-                return <CardVerticalLarge key={resource.path} data={resource} />
-              })}
-            </div>
 
-            <CardHorizontal resource={modernLayoutsWithCSSGrid} />
-
-            <section className="md:mt-20 mt-5 grid lg:grid-cols-12 grid-cols-1 gap-5 md:bg-gray-100 dark:bg-gray-700 rounded-lg md:p-5">
-              <div className="col-span-12 space-y-5">
-                <header className="py-5 md:px-8 px-5 rounded-md flex md:flex-row flex-col md:text-left text-center md:space-y-0 space-y-3 md:items-start items-center justify-center md:space-x-5 space-x-0">
-                  <div className="flex-shrink-0">
-                    <Image
-                      src={
-                        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1617475003/egghead-next-pages/home-page/eggo-gardening.png'
-                      }
-                      alt="illustration for Digital Gardening for Developers "
-                      width={222}
-                      height={273}
-                      quality={100}
-                    />
-                  </div>
-                  <div className="max-w-screen-sm space-y-3">
-                    <Link href={featureDigitalGardening.path}>
-                      <a className="font-bold hover:text-blue-600 dark:hover:text-blue-300">
-                        <h1 className="md:text-3xl text-2xl dark:text-gray-200 font-bold leading-tight">
-                          {featureDigitalGardening.title}
-                        </h1>
-                      </a>
-                    </Link>
-
-                    <div className="prose dark:prose-dark leading-relaxed text-gray-700 dark:text-gray-50 space-y-3 ">
-                      <Markdown className="prose dark:prose-dark dark:prose-sm-dark prose-sm mt-4">
-                        {featureDigitalGardening.description}
-                      </Markdown>
-                      <Markdown className="prose dark:prose-dark dark:prose-sm-dark prose-sm mt-4">
-                        {featureDigitalGardening.quote.description}
-                      </Markdown>
-                    </div>
-                  </div>
-                </header>
-                <div>
-                  <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
-                    {featureDigitalGardening.featured.courses.map(
-                      (resource: any) => {
-                        return (
-                          <Card
-                            className="col-span-4 text-center"
-                            key={resource.path}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
-                      },
-                    )}
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <CardHorizontal resource={ecommerce} />
-            <div className="grid xl:grid-cols-2 lg:grid-cols-1 md:grid-cols-2 grid-cols-1 lg:gap-6 gap-4">
-              <CardVerticalWithStack data={aws} />
-              <CardVerticalWithStack
-                data={freeCourses}
-                memberTitle="Must Watch"
-              />
-            </div>
-
-            <div className="grid md:grid-cols-2 grid-cols-1 lg:gap-6 gap-4 items-start mt-8">
-              <Card resource={accessibleApps} className="h-full text-center">
-                <Collection />
-              </Card>
-              <Card
-                resource={accessibleReactApps}
-                className="h-full text-center"
-              >
-                <Collection />
-              </Card>
-            </div>
-
-            <CardHorizontal resource={projectFeatureCardVideoApp} />
-
-            <CardHorizontal resource={wordpressWithGraphql} />
-
-            <CardHorizontal resource={portfolioProject} />
+        <section className="mt-32">
+          <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
+            egghead Talks and Events
+          </h2>
+          <div className="grid lg:grid-cols-8 grid-cols-1 lg:gap-6 gap-4">
+            <VideoCard className="lg:col-span-6" resource={video} />
+            <EventSchedule />
+            <CardHorizontal
+              className="col-span-4"
+              resource={modernLayoutsWithCSSGrid}
+            />
+            <CardHorizontal
+              className="col-span-4"
+              resource={modernLayoutsWithCSSGrid}
+            />
           </div>
-          <aside className="lg:col-span-4 lg:space-y-6 space-y-4">
-            <CardVerticalWithStack className="sm:py-3 py-2" data={getStarted} />
-            <ReactStateManagement />
-            <CardVerticalWithStack data={devEssentials} />
+        </section>
 
-            <Card resource={tailwind} className="text-center">
-              <ol className="text-left">
-                {tailwind.resources.map((resource: any, index: any) => {
+        <section className="mt-32">
+          <div className="grid lg:grid-cols-12 grid-cols-1 lg:gap-6 gap-4">
+            <div className="lg:col-span-8 lg:space-y-6 space-y-4">
+              <div
+                className={`grid sm:grid-cols-${featured.length} grid-cols-2 sm:gap-5 gap-3`}
+              >
+                {map(featured, (resource) => {
                   return (
-                    <li key={resource.path} className="flex space-x-2 my-2">
-                      <span>{index + 1}</span>
-                      <Link href={resource.path}>
-                        <a className="font-bold hover:text-blue-600 dark:hover:text-blue-300">
-                          {resource.title}
-                        </a>
-                      </Link>
-                    </li>
+                    <CardVerticalLarge key={resource.path} data={resource} />
                   )
                 })}
-              </ol>
-            </Card>
+              </div>
 
-            <Card>
-              <>
-                <Link href={swag.path}>
-                  <a className="inline-block hover:text-blue-600">
-                    <h2 className="uppercase font-semibold text-xs text-gray-600 dark:text-gray-300">
-                      {swag.name}
-                    </h2>
-                  </a>
-                </Link>
-                <Link href={swag.path}>
-                  <a className="inline-block hover:text-blue-600">
-                    <h3 className="text-lg tracking-tight font-bold leading-tight mb-1">
-                      {swag.title}
-                    </h3>
-                  </a>
-                </Link>
-                <ul className="grid grid-cols-2 gap-3 mt-3">
-                  {map(get(swag, 'resources'), (resource) => (
-                    <li
-                      className="py-1 flex flex-col items-center text-center  text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-300"
-                      key={resource.path}
-                    >
-                      {resource.image && (
-                        <div className="flex-shrink-0">
-                          <Link href={resource.path}>
-                            <a
-                              onClick={() => {
-                                track('clicked home page swag', {
-                                  resource: resource.path,
-                                  linkType: 'image',
-                                })
-                              }}
-                              tabIndex={-1}
-                            >
-                              <Image
-                                className="rounded-lg"
-                                src={resource.image}
-                                alt={resource.title}
-                                width={205}
-                                height={205}
-                              />
-                            </a>
-                          </Link>
-                        </div>
-                      )}
-                      <Link href={resource.path}>
-                        <a
-                          onClick={() => {
-                            track('clicked home page swag', {
-                              resource: resource.path,
-                              linkType: 'text',
-                            })
-                          }}
-                          className="text-xs leading-tight"
-                        >
-                          {resource.title}
+              <CardHorizontal resource={modernLayoutsWithCSSGrid} />
+
+              <section className="md:mt-20 mt-5 grid lg:grid-cols-12 grid-cols-1 gap-5 md:bg-gray-100 dark:bg-gray-700 rounded-lg md:p-5">
+                <div className="col-span-12 space-y-5">
+                  <header className="py-5 md:px-8 px-5 rounded-md flex md:flex-row flex-col md:text-left text-center md:space-y-0 space-y-3 md:items-start items-center justify-center md:space-x-5 space-x-0">
+                    <div className="flex-shrink-0">
+                      <Image
+                        src={
+                          'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1617475003/egghead-next-pages/home-page/eggo-gardening.png'
+                        }
+                        alt="illustration for Digital Gardening for Developers "
+                        width={222}
+                        height={273}
+                        quality={100}
+                      />
+                    </div>
+                    <div className="max-w-screen-sm space-y-3">
+                      <Link href={featureDigitalGardening.path}>
+                        <a className="font-bold hover:text-blue-600 dark:hover:text-blue-300">
+                          <h1 className="md:text-3xl text-2xl dark:text-gray-200 font-bold leading-tight">
+                            {featureDigitalGardening.title}
+                          </h1>
                         </a>
                       </Link>
-                    </li>
-                  ))}
-                </ul>
-              </>
-            </Card>
-            <CardVerticalWithStack data={workflows} />
-          </aside>
+
+                      <div className="prose dark:prose-dark leading-relaxed text-gray-700 dark:text-gray-50 space-y-3 ">
+                        <Markdown className="prose dark:prose-dark dark:prose-sm-dark prose-sm mt-4">
+                          {featureDigitalGardening.description}
+                        </Markdown>
+                        <Markdown className="prose dark:prose-dark dark:prose-sm-dark prose-sm mt-4">
+                          {featureDigitalGardening.quote.description}
+                        </Markdown>
+                      </div>
+                    </div>
+                  </header>
+                  <div>
+                    <div className="grid lg:grid-cols-12 grid-cols-1 gap-5 mt-5">
+                      {featureDigitalGardening.featured.courses.map(
+                        (resource: any) => {
+                          return (
+                            <Card
+                              className="col-span-4 text-center"
+                              key={resource.path}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                        },
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <CardHorizontal resource={ecommerce} />
+              <div className="grid xl:grid-cols-2 lg:grid-cols-1 md:grid-cols-2 grid-cols-1 lg:gap-6 gap-4">
+                <CardVerticalWithStack data={aws} />
+                <CardVerticalWithStack
+                  data={freeCourses}
+                  memberTitle="Must Watch"
+                />
+              </div>
+
+              <div className="grid md:grid-cols-2 grid-cols-1 lg:gap-6 gap-4 items-start mt-8">
+                <Card resource={accessibleApps} className="h-full text-center">
+                  <Collection />
+                </Card>
+                <Card
+                  resource={accessibleReactApps}
+                  className="h-full text-center"
+                >
+                  <Collection />
+                </Card>
+              </div>
+
+              <CardHorizontal resource={projectFeatureCardVideoApp} />
+
+              <CardHorizontal resource={wordpressWithGraphql} />
+
+              <CardHorizontal resource={portfolioProject} />
+            </div>
+            <aside className="lg:col-span-4 lg:space-y-6 space-y-4">
+              <CardVerticalWithStack
+                className="sm:py-3 py-2"
+                data={getStarted}
+              />
+              <ReactStateManagement />
+              <CardVerticalWithStack data={devEssentials} />
+
+              <Card resource={tailwind} className="text-center">
+                <ol className="text-left">
+                  {tailwind.resources.map((resource: any, index: any) => {
+                    return (
+                      <li key={resource.path} className="flex space-x-2 my-2">
+                        <span>{index + 1}</span>
+                        <Link href={resource.path}>
+                          <a className="font-bold hover:text-blue-600 dark:hover:text-blue-300">
+                            {resource.title}
+                          </a>
+                        </Link>
+                      </li>
+                    )
+                  })}
+                </ol>
+              </Card>
+
+              <Card>
+                <>
+                  <Link href={swag.path}>
+                    <a className="inline-block hover:text-blue-600">
+                      <h2 className="uppercase font-semibold text-xs text-gray-600 dark:text-gray-300">
+                        {swag.name}
+                      </h2>
+                    </a>
+                  </Link>
+                  <Link href={swag.path}>
+                    <a className="inline-block hover:text-blue-600">
+                      <h3 className="text-lg tracking-tight font-bold leading-tight mb-1">
+                        {swag.title}
+                      </h3>
+                    </a>
+                  </Link>
+                  <ul className="grid grid-cols-2 gap-3 mt-3">
+                    {map(get(swag, 'resources'), (resource) => (
+                      <li
+                        className="py-1 flex flex-col items-center text-center  text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-300"
+                        key={resource.path}
+                      >
+                        {resource.image && (
+                          <div className="flex-shrink-0">
+                            <Link href={resource.path}>
+                              <a
+                                onClick={() => {
+                                  track('clicked home page swag', {
+                                    resource: resource.path,
+                                    linkType: 'image',
+                                  })
+                                }}
+                                tabIndex={-1}
+                              >
+                                <Image
+                                  className="rounded-lg"
+                                  src={resource.image}
+                                  alt={resource.title}
+                                  width={205}
+                                  height={205}
+                                />
+                              </a>
+                            </Link>
+                          </div>
+                        )}
+                        <Link href={resource.path}>
+                          <a
+                            onClick={() => {
+                              track('clicked home page swag', {
+                                resource: resource.path,
+                                linkType: 'text',
+                              })
+                            }}
+                            className="text-xs leading-tight"
+                          >
+                            {resource.title}
+                          </a>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              </Card>
+              <CardVerticalWithStack data={workflows} />
+            </aside>
+          </div>
         </section>
       </div>
     </>

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -51,6 +51,14 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
     'featureDigitalGardening',
   )
   const featureWhatsNew: any = get(homePageData, 'featureWhatsNew')
+  const concurrentReactTalk: any = get(
+    homePageData,
+    'react-concurrent-react-from-scratch',
+  )
+  const reactMetaphorTalk: any = get(
+    homePageData,
+    'drawing-the-invisible-react-explained-in-five-visual-metaphors',
+  )
 
   React.useEffect(() => {
     if (viewer) {
@@ -116,11 +124,11 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
             <EventSchedule />
             <CardHorizontal
               className="col-span-4"
-              resource={modernLayoutsWithCSSGrid}
+              resource={concurrentReactTalk}
             />
             <CardHorizontal
               className="col-span-4"
-              resource={modernLayoutsWithCSSGrid}
+              resource={reactMetaphorTalk}
             />
           </div>
         </section>
@@ -463,6 +471,8 @@ export const CardHorizontal: FunctionComponent<{
                   src={get(resource.image, 'src', resource.image)}
                   width={160}
                   height={160}
+                  layout="fixed"
+                  className="object-cover rounded-md"
                   alt={`illustration for ${resource.title}`}
                 />
               </a>

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -119,17 +119,21 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
           <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
             egghead Talks and Events
           </h2>
-          <div className="grid lg:grid-cols-8 grid-cols-1 lg:gap-6 gap-4">
-            <VideoCard className="lg:col-span-6" resource={video} />
-            <EventSchedule />
-            <CardHorizontal
-              className="col-span-4"
-              resource={concurrentReactTalk}
-            />
-            <CardHorizontal
-              className="col-span-4"
-              resource={reactMetaphorTalk}
-            />
+          <div className="">
+            <div className="grid lg:grid-cols-8 grid-cols-1 col-span-8 gap-4">
+              <VideoCard className="lg:col-span-6" resource={video} />
+              <EventSchedule />
+            </div>
+            <div className="grid lg:grid-cols-2 grid-cols-1 gap-4">
+              <CardHorizontal
+                resource={concurrentReactTalk}
+                className="m-0 mt-4"
+              />
+              <CardHorizontal
+                resource={reactMetaphorTalk}
+                className="m-0 lg:mt-4"
+              />
+            </div>
           </div>
         </section>
 

--- a/src/components/pages/home/jumbotron/index.tsx
+++ b/src/components/pages/home/jumbotron/index.tsx
@@ -67,7 +67,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
               </h2>
               <Link href={path}>
                 <a
-                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter`}
+                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter hover:text-yellow-500`}
                   onClick={() =>
                     track('clicked jumbotron resource', {
                       resource: path,

--- a/src/components/pages/home/jumbotron/index.tsx
+++ b/src/components/pages/home/jumbotron/index.tsx
@@ -9,9 +9,13 @@ import {track} from 'utils/analytics'
 
 type JumbotronProps = {
   resource: CardResource
+  textColor?: String
 }
 
-const Jumbotron: FunctionComponent<JumbotronProps> = ({resource}) => {
+const Jumbotron: FunctionComponent<JumbotronProps> = ({
+  resource,
+  textColor,
+}) => {
   const {
     path,
     image,
@@ -56,12 +60,14 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({resource}) => {
               </Link>
             </div>
             <div className="flex flex-col sm:items-start items-center w-full">
-              <h2 className="text-xs text-yellow-500 uppercase font-semibold mb-2">
+              <h2
+                className={`text-xs text-yellow-500 uppercase font-semibold mb-2`}
+              >
                 {byline}
               </h2>
               <Link href={path}>
                 <a
-                  className="sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter hover:text-yellow-500"
+                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter`}
                   onClick={() =>
                     track('clicked jumbotron resource', {
                       resource: path,

--- a/src/components/pages/home/video-card/index.tsx
+++ b/src/components/pages/home/video-card/index.tsx
@@ -76,7 +76,7 @@ const VideoCard: React.FC<{
             </Markdown>
           </div>
         </div>
-        <div className="flex-shrink-0 flex items-center">
+        <div className="flex-shrink-0 flex items-center self-center">
           <Link href={path}>
             <a
               onClick={() => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import groq from 'groq'
 import {sanityClient} from 'utils/sanity-client'
 import staticHomePageData from 'components/pages/home/homepage-data'
 import {digitalGardeningQuery} from './learn/digital-gardening'
+import {whatsNewQuery} from './new'
 
 const IndexPage: FunctionComponent = ({homePageData}: any) => {
   return (
@@ -34,6 +35,7 @@ export default IndexPage
 const featureQuery = groq`
 {
   'featureDigitalGardening': ${digitalGardeningQuery},
+  'featureWhatsNew': ${whatsNewQuery},
 }
 `
 

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -178,11 +178,11 @@ export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "what
 }`
 
 export async function getStaticProps() {
-  const data = await sanityClient.fetch(whatsNewQuery)
+  const resource = await sanityClient.fetch(whatsNewQuery)
 
   return {
     props: {
-      data,
+      resource,
     },
   }
 }

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -113,7 +113,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
     image,
     path,
     description,
-    fancyCardBackground,
+    featureCardBackground,
     instructor: {name},
   } = resource
   return (
@@ -136,7 +136,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
           </div>
           <img
             className="absolute top-0 left-0 z-0 w-full"
-            src={fancyCardBackground}
+            src={featureCardBackground}
             alt=""
           />
         </div>
@@ -155,7 +155,7 @@ export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "what
     	path,
     	image,
       'background': images[label == 'banner-image-blank'][0].url,
-      'fancyCardBackground': images[label == 'fancy-card'][0].url,
+      'featureCardBackground': images[label == 'feature-card-background'][0].url,
       'instructor': collaborators[]->[role == 'instructor'][0]{
         title,
         'slug': person->slug.current,

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -1,0 +1,191 @@
+import groq from 'groq'
+import {sanityClient} from 'utils/sanity-client'
+import Image from 'next/image'
+import Link from 'next/link'
+import {get} from 'lodash'
+import React, {FunctionComponent} from 'react'
+import Markdown from 'react-markdown'
+import {track} from 'utils/analytics'
+import Card, {CardResource} from 'components/pages/home/card'
+import Jumbotron from 'components/pages/home/jumbotron'
+
+const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
+  const {primary, side} = resource
+  const [jumbotron, secondPrimary, thirdPrimary] = primary.resources
+  const [firstSide, secondSide, thirdSide] = side.resources
+
+  return (
+    <section className="sm:-my-5 -my-3 p-5 mx-auto max-w-screen-xl">
+      <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
+        What's New
+      </h2>
+      <Jumbotron resource={jumbotron} textColor="text-green-400" />
+      <div className="grid grid-cols-12 grid-rows-2 gap-4 mt-4">
+        <CourseFeatureCard
+          className="h-auto row-span-2 w-full col-span-6"
+          resource={secondPrimary}
+        />
+        <CardHorizontal className="h-auto col-span-6" resource={firstSide} />
+        <CardHorizontal
+          className="w-full row-span-1 col-span-6"
+          resource={secondSide}
+        />
+        <CardHorizontal
+          className="w-full row-span-1 col-span-6"
+          resource={thirdPrimary}
+        />
+        <CardHorizontal
+          className="w-full row-span-1 col-span-6"
+          resource={thirdSide}
+        />
+      </div>
+    </section>
+  )
+}
+
+export default WhatsNewPage
+
+export const CardHorizontal: FunctionComponent<{
+  resource: CardResource
+  className?: string
+  location?: string
+}> = ({resource, className = 'border-none my-4', location = 'home'}) => {
+  return (
+    <Card className={className}>
+      <>
+        <div className="flex sm:flex-row flex-col sm:space-x-5 space-x-0 sm:space-y-0 space-y-5 items-center sm:text-left text-center">
+          {resource?.image && (
+            <Link href={resource.path}>
+              <a
+                onClick={() => {
+                  track('whats new homepage resource', {
+                    resource: resource.path,
+                    linkType: 'image',
+                    location,
+                  })
+                }}
+                className="block flex-shrink-0 sm:w-auto m:w-24 w-36"
+                tabIndex={-1}
+              >
+                <Image
+                  src={get(resource.image, 'src', resource.image)}
+                  width={160}
+                  height={160}
+                  alt={`illustration for ${resource?.title}`}
+                />
+              </a>
+            </Link>
+          )}
+          <div className="flex flex-col justify-center sm:items-start items-center">
+            <h2 className=" uppercase font-semibold text-xs tracking-tight text-gray-700 dark:text-gray-300 mb-1">
+              {resource?.name}
+            </h2>
+            <Link href={resource?.path}>
+              <a
+                onClick={() => {
+                  track('clicked resource', {
+                    resource: resource?.path,
+                    linkType: 'text',
+                    location,
+                  })
+                }}
+                className="hover:text-blue-600 dark:hover:text-blue-300"
+              >
+                <h3 className="text-xl font-bold leading-tighter">
+                  {resource?.title}
+                </h3>
+              </a>
+            </Link>
+            <div className="text-xs text-gray-600 dark:text-gray-300 mb-2 mt-1">
+              {resource?.byline}
+            </div>
+            <Markdown
+              source={resource?.description || ''}
+              className="prose dark:prose-dark dark:prose-dark-sm prose-sm max-w-none"
+            />
+          </div>
+        </div>
+      </>
+    </Card>
+  )
+}
+
+const CourseFeatureCard = ({resource, className}: any) => {
+  const {
+    title,
+    image,
+    path,
+    description,
+    fancyCardBackground,
+    instructor: {name},
+  } = resource
+  return (
+    <Link href={path}>
+      <a
+        className={`relative dark:bg-gray-800 bg-white group block rounded-md w-full h-full overflow-hidden text-center shadow-sm dark:text-white ${
+          className ? className : ''
+        }`}
+      >
+        <div className="flex flex-col items-center h-full">
+          <div className="relative z-10 flex flex-col h-full justify-between p-2 items-center">
+            <div className="flex flex-col items-center mt-14">
+              <Image src={image} width={200} height={200} alt={title} />
+              <h2 className="text-xl font-bold min-w-full mt-10 mb-2 leading-tighter group-hover:underline">
+                {title}
+              </h2>
+              <span className="text-sm opacity-80">{name}</span>
+              <p className="text-sm mt-4">{description}</p>
+            </div>
+          </div>
+          <img
+            className="absolute top-0 left-0 z-0 w-full"
+            src={fancyCardBackground}
+            alt=""
+          />
+        </div>
+      </a>
+    </Link>
+  )
+}
+
+export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "whats-new"][0]{
+  title,
+	'primary': resources[slug.current == 'primary-resources'][0]{
+ 		resources[]->{
+      title,
+      'name': type,
+      'description': summary,
+    	path,
+    	image,
+      'background': images[label == 'banner-image-blank'][0].url,
+      'fancyCardBackground': images[label == 'fancy-card'][0].url,
+      'instructor': collaborators[]->[role == 'instructor'][0]{
+        title,
+        'slug': person->slug.current,
+        'name': person->name,
+        'path': person->website,
+        'twitter': person->twitter,
+        'image': person->image.url
+  		},
+    }
+  },
+	'side': resources[slug.current == 'side-resources'][0]{
+    resources[]{
+      'name': type,
+      title,
+      path,
+      byline,
+      image,
+    }
+  },
+}`
+
+export async function getStaticProps() {
+  const data = await sanityClient.fetch(whatsNewQuery)
+
+  return {
+    props: {
+      data,
+    },
+  }
+}

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -71,6 +71,8 @@ export const CardHorizontal: FunctionComponent<{
                   src={get(resource.image, 'src', resource.image)}
                   width={160}
                   height={160}
+                  layout="fixed"
+                  className="object-cover rounded-md"
                   alt={`illustration for ${resource?.title}`}
                 />
               </a>

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -127,7 +127,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
           <div className="relative z-10 flex flex-col h-full justify-between  items-center sm:p-8 p-5">
             <div className="flex flex-col items-center">
               <Image src={image} width={200} height={200} alt={title} />
-              <h2 className="text-xl font-bold min-w-full mt-10 mb-2 leading-tighter group-hover:underline">
+              <h2 className="text-xl font-bold min-w-full mt-4 sm:mt-14 mb-2 leading-tighter group-hover:underline">
                 {title}
               </h2>
               <span className="text-sm opacity-80">{name}</span>

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -20,24 +20,19 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
         What's New
       </h2>
       <Jumbotron resource={jumbotron} textColor="text-green-400" />
-      <div className="grid grid-cols-12 grid-rows-2 gap-4 mt-4">
-        <CourseFeatureCard
-          className="h-auto row-span-2 w-full col-span-6"
-          resource={secondPrimary}
-        />
-        <CardHorizontal className="h-auto col-span-6" resource={firstSide} />
-        <CardHorizontal
-          className="w-full row-span-1 col-span-6"
-          resource={secondSide}
-        />
-        <CardHorizontal
-          className="w-full row-span-1 col-span-6"
-          resource={thirdPrimary}
-        />
-        <CardHorizontal
-          className="w-full row-span-1 col-span-6"
-          resource={thirdSide}
-        />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
+        <div className="h-full grid gap-4">
+          <CourseFeatureCard
+            className="h-auto row-span-2 w-full"
+            resource={secondPrimary}
+          />
+          <CardHorizontal className="w-full" resource={thirdPrimary} />
+        </div>
+        <div className="grid gap-4">
+          <CardHorizontal className="h-auto flex" resource={firstSide} />
+          <CardHorizontal className="w-full flex" resource={secondSide} />
+          <CardHorizontal className="w-full flex" resource={thirdSide} />
+        </div>
       </div>
     </section>
   )
@@ -69,8 +64,8 @@ export const CardHorizontal: FunctionComponent<{
               >
                 <Image
                   src={get(resource.image, 'src', resource.image)}
-                  width={160}
-                  height={160}
+                  width={130}
+                  height={130}
                   layout="fixed"
                   className="object-cover rounded-md"
                   alt={`illustration for ${resource?.title}`}
@@ -129,8 +124,8 @@ const CourseFeatureCard = ({resource, className}: any) => {
         }`}
       >
         <div className="flex flex-col items-center h-full">
-          <div className="relative z-10 flex flex-col h-full justify-between p-2 items-center">
-            <div className="flex flex-col items-center mt-14">
+          <div className="relative z-10 flex flex-col h-full justify-between  items-center sm:p-8 p-5">
+            <div className="flex flex-col items-center">
               <Image src={image} width={200} height={200} alt={title} />
               <h2 className="text-xl font-bold min-w-full mt-10 mb-2 leading-tighter group-hover:underline">
                 {title}


### PR DESCRIPTION
We are scrapping the changes made in #584 because they were building on top of the 'new' card components that we want to properly plan out better before committing to a structure and digging ourselves into a hole.

Also updated the page route to egghead.io/new which we can curate further. 

![](https://media1.giphy.com/media/3ov9k9AyzTiUCfsZrO/200.gif?cid=5a38a5a29oldtjvzlz0ocrcyknhifvq100rzwtxbbwz7pkci&rid=200.gif&ct=g)

![Build the portfolio you need to be a badass web developer   egghead io](https://user-images.githubusercontent.com/6188161/116134523-fd056e80-a69d-11eb-9a88-26fcd1a0282c.png)
