### PR TITLE
Check if subscription uses tiered pricing

### DIFF
--- a/src/components/team/billing-section.tsx
+++ b/src/components/team/billing-section.tsx
@@ -103,16 +103,25 @@ const BillingSection = ({
 
   const quantity = get(subscriptionData, 'subscription.quantity', 1)
 
-  const tiers = get(subscriptionData, 'subscription.plan.tiers', [])
-  const matchingTier = tiers.find((tier: {up_to: number}) => {
-    if (quantity <= tier.up_to || tier.up_to === null) return true
+  let subscriptionUnitPrice
 
-    return false
-  })
-  const subscriptionUnitPrice = formatAmountWithCurrency(
-    matchingTier?.unit_amount,
-    currency,
-  )
+  if (get(subscriptionData, 'subscription.plan.billing_scheme') === 'tiered') {
+    // if the user/account is on tiered pricing...
+    const tiers = get(subscriptionData, 'subscription.plan.tiers', [])
+    const matchingTier = tiers.find((tier: {up_to: number}) => {
+      if (quantity <= tier.up_to || tier.up_to === null) return true
+
+      return false
+    })
+    subscriptionUnitPrice = formatAmountWithCurrency(
+      matchingTier?.unit_amount,
+      currency,
+    )
+  } else {
+    // otherwise, they are on legacy pricing...
+    const unitAmount = get(subscriptionData, 'subscription.plan.amount')
+    subscriptionUnitPrice = formatAmountWithCurrency(unitAmount, currency)
+  }
 
   const totalAmountInCents = get(
     subscriptionData,


### PR DESCRIPTION
If it doesn't, fetch the amount right off the subscription rather than
looking in the tiers.

Is there a non-tiered team account in Stripe Test Mode that I can use to verify this? (Marking this as No Merge until I can verify it)

![](https://media0.giphy.com/media/1BFGiTkzVBkwPLsLZ7/200w.gif?cid=5a38a5a21960byyvdra4xo68fvezo1kspxk9y1jirmk3z4gd&rid=200w.gif&ct=g)