### PR TITLE
Add light mode to homepage feature cards

### DIFF
--- a/src/components/pages/home/card/index.tsx
+++ b/src/components/pages/home/card/index.tsx
@@ -17,6 +17,8 @@ export type CardResource = {
   instructor?: any
   background?: string
   lightBackground?: string
+  featureCardBackground?: string
+  lightFeatureCardBackground?: string
 }
 
 type CardProps = {

--- a/src/components/pages/home/card/index.tsx
+++ b/src/components/pages/home/card/index.tsx
@@ -16,6 +16,7 @@ export type CardResource = {
   resources?: CardResource[]
   instructor?: any
   background?: string
+  lightBackground?: string
 }
 
 type CardProps = {

--- a/src/components/pages/home/jumbotron/index.tsx
+++ b/src/components/pages/home/jumbotron/index.tsx
@@ -3,7 +3,6 @@ import {CardResource} from 'components/pages/home/card'
 import Markdown from 'react-markdown'
 import Link from 'next/link'
 import Image from 'next/image'
-import {useTheme} from 'next-themes'
 import {get} from 'lodash'
 import {bpMinMD} from 'utils/breakpoints'
 import {track} from 'utils/analytics'
@@ -11,26 +10,15 @@ import {track} from 'utils/analytics'
 type JumbotronProps = {
   resource: CardResource
   textColor?: String
+  background?: String
 }
 
 const Jumbotron: FunctionComponent<JumbotronProps> = ({
   resource,
   textColor,
+  background,
 }) => {
-  const {theme} = useTheme()
-  const {
-    path,
-    image,
-    title,
-    byline,
-    instructor,
-    background,
-    lightBackground,
-    description,
-  } = resource
-
-  console.log(theme)
-  const themedBackground = theme === 'dark' ? background : lightBackground
+  const {path, image, title, byline, instructor, description} = resource
 
   return (
     <div
@@ -74,7 +62,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
               </h2>
               <Link href={path}>
                 <a
-                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-gray-900 dark:text-white hover:text-yellow-500`}
+                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-gray-900 dark:text-white `}
                   onClick={() =>
                     track('clicked jumbotron resource', {
                       resource: path,
@@ -119,7 +107,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
       </div>
       <UniqueBackground
         className="absolute left-0 top-0 w-full h-full z-0 object-cover"
-        background={themedBackground}
+        background={background}
       />
     </div>
   )

--- a/src/components/pages/home/jumbotron/index.tsx
+++ b/src/components/pages/home/jumbotron/index.tsx
@@ -9,13 +9,11 @@ import {track} from 'utils/analytics'
 
 type JumbotronProps = {
   resource: CardResource
-  textColor?: String
   background?: String
 }
 
 const Jumbotron: FunctionComponent<JumbotronProps> = ({
   resource,
-  textColor,
   background,
 }) => {
   const {path, image, title, byline, instructor, description} = resource
@@ -62,7 +60,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
               </h2>
               <Link href={path}>
                 <a
-                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-gray-900 dark:text-white `}
+                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-300`}
                   onClick={() =>
                     track('clicked jumbotron resource', {
                       resource: path,
@@ -73,27 +71,18 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
                   <h1>{title}</h1>
                 </a>
               </Link>
-              <Link href={instructor.path}>
-                <a
-                  className="mt-4 flex items-center space-x-2 text-base group"
-                  onClick={() =>
-                    track('clicked instructor in jumbotron', {
-                      instructor: instructor.slug,
-                    })
-                  }
-                >
-                  <Image
-                    src={instructor.image}
-                    width={40}
-                    height={40}
-                    className="rounded-full"
-                    alt={instructor.name}
-                  />
-                  <span className="group-hover:text-orange-200 text-gray-900 dark:text-white">
-                    {instructor.name}
-                  </span>
-                </a>
-              </Link>
+              <div className="mt-4 flex items-center space-x-2 text-base group">
+                <Image
+                  src={instructor.image}
+                  width={40}
+                  height={40}
+                  className="rounded-full"
+                  alt={instructor.name}
+                />
+                <span className="text-gray-900 dark:text-white">
+                  {instructor.name}
+                </span>
+              </div>
               {description && (
                 <Markdown
                   source={description}

--- a/src/components/pages/home/jumbotron/index.tsx
+++ b/src/components/pages/home/jumbotron/index.tsx
@@ -3,6 +3,7 @@ import {CardResource} from 'components/pages/home/card'
 import Markdown from 'react-markdown'
 import Link from 'next/link'
 import Image from 'next/image'
+import {useTheme} from 'next-themes'
 import {get} from 'lodash'
 import {bpMinMD} from 'utils/breakpoints'
 import {track} from 'utils/analytics'
@@ -16,6 +17,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
   resource,
   textColor,
 }) => {
+  const {theme} = useTheme()
   const {
     path,
     image,
@@ -23,8 +25,13 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
     byline,
     instructor,
     background,
+    lightBackground,
     description,
   } = resource
+
+  console.log(theme)
+  const themedBackground = theme === 'dark' ? background : lightBackground
+
   return (
     <div
       className="relative flex items-center justify-center bg-gray-900 dark:bg-gray-800 text-white overflow-hidden rounded-lg shadow-sm"
@@ -67,7 +74,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
               </h2>
               <Link href={path}>
                 <a
-                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter hover:text-yellow-500`}
+                  className={`sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-gray-900 dark:text-white hover:text-yellow-500`}
                   onClick={() =>
                     track('clicked jumbotron resource', {
                       resource: path,
@@ -94,7 +101,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
                     className="rounded-full"
                     alt={instructor.name}
                   />
-                  <span className="group-hover:text-orange-200">
+                  <span className="group-hover:text-orange-200 text-gray-900 dark:text-white">
                     {instructor.name}
                   </span>
                 </a>
@@ -103,7 +110,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
                 <Markdown
                   source={description}
                   allowDangerousHtml={true}
-                  className="mt-4 text-gray-200 text-base max-w-screen-sm"
+                  className="mt-4 prose dark:prose-dark text-base max-w-screen-sm"
                 />
               )}
             </div>
@@ -112,7 +119,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
       </div>
       <UniqueBackground
         className="absolute left-0 top-0 w-full h-full z-0 object-cover"
-        background={background}
+        background={themedBackground}
       />
     </div>
   )

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -37,11 +37,7 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
       <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
         What's New
       </h2>
-      <Jumbotron
-        resource={jumbotron}
-        background={themedBackground}
-        textColor="text-green-400"
-      />
+      <Jumbotron resource={jumbotron} background={themedBackground} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
         <div className="h-full grid gap-4">
           <CourseFeatureCard
@@ -163,7 +159,7 @@ const CourseFeatureCard = ({
           <div className="relative z-10 flex flex-col h-full justify-between  items-center sm:p-8 p-5">
             <div className="flex flex-col items-center">
               <Image src={image} width={200} height={200} alt={title} />
-              <h2 className="text-xl font-bold min-w-full mt-4 sm:mt-14 mb-2 leading-tighter group-hover:underline">
+              <h2 className="text-xl font-bold min-w-full mt-4 sm:mt-14 mb-2 leading-tighter group-hover:text-blue-600 dark:group-hover:text-blue-300">
                 {title}
               </h2>
               <span className="text-sm opacity-80">{name}</span>

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -10,7 +10,7 @@ import Card, {CardResource} from 'components/pages/home/card'
 import Jumbotron from 'components/pages/home/jumbotron'
 import {useTheme} from 'next-themes'
 
-const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
+const WhatsNewPage: FunctionComponent<WhatsNewResource> = ({resource}) => {
   const [mounted, setMounted] = React.useState(false)
   const {theme} = useTheme()
 
@@ -43,7 +43,7 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
           <CourseFeatureCard
             className="h-auto row-span-2 w-full"
             resource={secondPrimary}
-            featureCardBackground={themedFeatureCardBackground}
+            featureCardBackground={themedFeatureCardBackground!}
           />
           <CardHorizontal className="w-full" resource={thirdPrimary} />
         </div>
@@ -135,11 +135,17 @@ export const CardHorizontal: FunctionComponent<{
   )
 }
 
+type CourseFeatureCardProps = {
+  resource: CardResource
+  featureCardBackground: string
+  className?: string
+}
+
 const CourseFeatureCard = ({
   resource,
   featureCardBackground,
   className,
-}: any) => {
+}: CourseFeatureCardProps) => {
   const {
     title,
     image,
@@ -158,7 +164,14 @@ const CourseFeatureCard = ({
         <div className="flex flex-col items-center h-full">
           <div className="relative z-10 flex flex-col h-full justify-between  items-center sm:p-8 p-5">
             <div className="flex flex-col items-center">
-              <Image src={image} width={200} height={200} alt={title} />
+              {image && (
+                <Image
+                  src={get(image, 'src', image)}
+                  width={200}
+                  height={200}
+                  alt={title}
+                />
+              )}
               <h2 className="text-xl font-bold min-w-full mt-4 sm:mt-14 mb-2 leading-tighter group-hover:text-blue-600 dark:group-hover:text-blue-300">
                 {title}
               </h2>
@@ -175,6 +188,14 @@ const CourseFeatureCard = ({
       </a>
     </Link>
   )
+}
+
+type WhatsNewResource = {
+  resource: {
+    title: string
+    primary: {resources: CardResource[]}
+    secondary: {resources: CardResource[]}
+  }
 }
 
 export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "whats-new"][0]{

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -11,6 +11,12 @@ import Jumbotron from 'components/pages/home/jumbotron'
 import {useTheme} from 'next-themes'
 
 const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
+  const [mounted, setMounted] = React.useState(false)
+  const {theme} = useTheme()
+
+  React.useEffect(() => setMounted(true), [])
+  if (!mounted) return null
+
   const {primary, secondary} = resource
   const [jumbotron, secondPrimary, thirdPrimary] = primary.resources
   const [
@@ -19,17 +25,29 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
     thirdSecondaryResource,
   ] = secondary.resources
 
+  const {background, lightBackground} = jumbotron
+  const {lightFeatureCardBackground, featureCardBackground} = secondPrimary
+
+  const themedBackground = theme === 'light' ? lightBackground : background
+  const themedFeatureCardBackground =
+    theme === 'light' ? lightFeatureCardBackground : featureCardBackground
+
   return (
     <section className="sm:-my-5 -my-3 mx-auto max-w-screen-xl">
       <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
         What's New
       </h2>
-      <Jumbotron resource={jumbotron} textColor="text-green-400" />
+      <Jumbotron
+        resource={jumbotron}
+        background={themedBackground}
+        textColor="text-green-400"
+      />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
         <div className="h-full grid gap-4">
           <CourseFeatureCard
             className="h-auto row-span-2 w-full"
             resource={secondPrimary}
+            featureCardBackground={themedFeatureCardBackground}
           />
           <CardHorizontal className="w-full" resource={thirdPrimary} />
         </div>
@@ -121,20 +139,18 @@ export const CardHorizontal: FunctionComponent<{
   )
 }
 
-const CourseFeatureCard = ({resource, className}: any) => {
-  const {theme} = useTheme()
+const CourseFeatureCard = ({
+  resource,
+  featureCardBackground,
+  className,
+}: any) => {
   const {
     title,
     image,
     path,
     description,
-    featureCardBackground,
-    lightFeatureCardBackground,
     instructor: {name},
   } = resource
-
-  const themedFeatureCardBackground =
-    theme === 'light' ? lightFeatureCardBackground : featureCardBackground
 
   return (
     <Link href={path}>
@@ -156,7 +172,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
           </div>
           <img
             className="absolute top-0 left-0 z-0 w-full"
-            src={themedFeatureCardBackground}
+            src={featureCardBackground}
             alt=""
           />
         </div>

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -10,9 +10,13 @@ import Card, {CardResource} from 'components/pages/home/card'
 import Jumbotron from 'components/pages/home/jumbotron'
 
 const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
-  const {primary, side} = resource
+  const {primary, secondary} = resource
   const [jumbotron, secondPrimary, thirdPrimary] = primary.resources
-  const [firstSide, secondSide, thirdSide] = side.resources
+  const [
+    firstSecondaryResource,
+    secondSecondaryResource,
+    thirdSecondaryResource,
+  ] = secondary.resources
 
   return (
     <section className="sm:-my-5 -my-3 p-5 mx-auto max-w-screen-xl">
@@ -29,9 +33,18 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
           <CardHorizontal className="w-full" resource={thirdPrimary} />
         </div>
         <div className="grid gap-4">
-          <CardHorizontal className="h-auto flex" resource={firstSide} />
-          <CardHorizontal className="w-full flex" resource={secondSide} />
-          <CardHorizontal className="w-full flex" resource={thirdSide} />
+          <CardHorizontal
+            className="h-auto flex"
+            resource={firstSecondaryResource}
+          />
+          <CardHorizontal
+            className="w-full flex"
+            resource={secondSecondaryResource}
+          />
+          <CardHorizontal
+            className="w-full flex"
+            resource={thirdSecondaryResource}
+          />
         </div>
       </div>
     </section>
@@ -147,7 +160,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
 
 export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "whats-new"][0]{
   title,
-	'primary': resources[slug.current == 'primary-resources'][0]{
+	'primary': resources[slug.current == 'new-page-primary-resource-collection'][0]{
  		resources[]->{
       title,
       'name': type,
@@ -166,7 +179,7 @@ export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "what
   		},
     }
   },
-	'side': resources[slug.current == 'side-resources'][0]{
+	'secondary': resources[slug.current == 'new-page-secondary-resource-collection'][0]{
     resources[]{
       'name': type,
       title,

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -19,7 +19,7 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
   ] = secondary.resources
 
   return (
-    <section className="sm:-my-5 -my-3 p-5 mx-auto max-w-screen-xl">
+    <section className="sm:-my-5 -my-3">
       <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
         What's New
       </h2>

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -8,6 +8,7 @@ import Markdown from 'react-markdown'
 import {track} from 'utils/analytics'
 import Card, {CardResource} from 'components/pages/home/card'
 import Jumbotron from 'components/pages/home/jumbotron'
+import {useTheme} from 'next-themes'
 
 const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
   const {primary, secondary} = resource
@@ -121,14 +122,20 @@ export const CardHorizontal: FunctionComponent<{
 }
 
 const CourseFeatureCard = ({resource, className}: any) => {
+  const {theme} = useTheme()
   const {
     title,
     image,
     path,
     description,
     featureCardBackground,
+    lightFeatureCardBackground,
     instructor: {name},
   } = resource
+
+  const themedFeatureCardBackground =
+    theme === 'light' ? lightFeatureCardBackground : featureCardBackground
+
   return (
     <Link href={path}>
       <a
@@ -149,7 +156,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
           </div>
           <img
             className="absolute top-0 left-0 z-0 w-full"
-            src={featureCardBackground}
+            src={themedFeatureCardBackground}
             alt=""
           />
         </div>
@@ -168,7 +175,9 @@ export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "what
     	path,
     	image,
       'background': images[label == 'banner-image-blank'][0].url,
+      'lightBackground': images[label == 'light-banner-image-blank'][0].url,
       'featureCardBackground': images[label == 'feature-card-background'][0].url,
+      'lightFeatureCardBackground': images[label == 'light-feature-card-background'][0].url,
       'instructor': collaborators[]->[role == 'instructor'][0]{
         title,
         'slug': person->slug.current,

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -19,7 +19,7 @@ const WhatsNewPage: FunctionComponent<any> = ({resource}) => {
   ] = secondary.resources
 
   return (
-    <section className="sm:-my-5 -my-3">
+    <section className="sm:-my-5 -my-3 mx-auto max-w-screen-xl">
       <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
         What's New
       </h2>


### PR DESCRIPTION
We support light and dark modes for the site so our custom CTA's should support that as well

This attempts to solve that issue by loading two different themed backgrounds based on the current theme set in the app.

One thing I'm not handling here is the case where an asset is missing. So if we didn't have a light background set, none would show for that.

I am thinking about turning this functionality into a hook for reuse elsewhere. I can see this being useful for our curated and instructor page CTA cards.

![](https://media2.giphy.com/media/3ohzdFHDBEG32PmWJO/giphy.gif?cid=5a38a5a219tci1rbo4jo8fwop2kt2e5s0g0gato8gd966yeg&rid=giphy.gif&ct=g)

Light:
![light mode](https://user-images.githubusercontent.com/6188161/116426181-e3386880-a810-11eb-982b-fafad0613bca.png)

Dark:
![dark mode](https://user-images.githubusercontent.com/6188161/116426190-e5022c00-a810-11eb-86b3-17aaa07cde7b.png)

