### PR TITLE
add typescript course CTA on curated typescript page

### DIFF
--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -70,7 +70,7 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
           ],
         }}
       />
-      <div className="md:grid md:grid-cols-12 grid-cols-1 sm:gap-8 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
+      <div className="md:grid md:grid-cols-12 grid-cols-1 gap-5 items-start space-y-5 md:space-y-0 dark:bg-gray-900">
         <Topic
           className="col-span-8"
           title={topic.label}

--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -84,7 +84,7 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
         {CTAComponent ? <CTAComponent /> : <DefaultCTA location={location} />}
       </div>
       {beginner && intermediate && advanced && (
-        <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start sm:mt-5 mt-3">
+        <div className="grid md:grid-cols-3 grid-cols-1 gap-5 items-start mt-5">
           <Card resource={beginner} location={location}>
             <Collection />
           </Card>

--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -48,7 +48,7 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
   const advanced: any = find(pageData, {id: 'advanced'})
 
   return (
-    <div className="sm:pb-8 pb-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+    <div className="sm:pb-8 pb-5 max-w-screen-xl lg:mx-auto mx-5 dark:bg-gray-900">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/typescript/index.tsx
+++ b/src/components/search/curated/typescript/index.tsx
@@ -35,7 +35,7 @@ Love them or hate them, static types are here to stay, and at the very least an 
       pageData={typescriptPageData}
       CTAComponent={CourseFeatureCard}
     >
-      <div className="mb-10 pb-10 xl:px-0 max-w-screen-xl mx-auto">
+      <div className="mb-10 pb-10 xl:px-0 max-w-screen-xl mx-2">
         {/* Featured Section */}
         <section className="grid lg:grid-cols-12 grid-cols-1 items-start mt-12 ">
           <div className="md:col-span-8 mr-0 md:mr-5">
@@ -51,7 +51,7 @@ Love them or hate them, static types are here to stay, and at the very least an 
             </Card>
           </div>
           <Card
-            className="col-span-4 h-full"
+            className="mt-5 col-span-4 h-full"
             resource={algorithms}
             location={location}
           >
@@ -109,8 +109,8 @@ const CourseFeatureCard = ({resource, className}: any) => {
             </div>
           </div>
           <img
-            className="absolute top-0 left-0 z-0 w-full"
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1619807045/next.egghead.io/resources/advanced-typescript-fundamentals/background-feature-card.svg"
+            className="absolute top-0 left-0 z-0 w-full object-fit"
+            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1619808981/next.egghead.io/resources/advanced-typescript-fundamentals/background-feature-card-v2.svg"
             alt=""
           />
         </div>

--- a/src/components/search/curated/typescript/index.tsx
+++ b/src/components/search/curated/typescript/index.tsx
@@ -81,7 +81,7 @@ const CourseFeatureCard = ({resource, className}: any) => {
           className ? className : ''
         }`}
       >
-        <div className="items-center h-full w-full block">
+        <div className="items-center h-full w-full block bg-white dark:bg-gray-800">
           <div
             className="relative z-10 flex flex-col h-full justify-between  items-center sm:p-8 p-5"
             css={{

--- a/src/components/search/curated/typescript/index.tsx
+++ b/src/components/search/curated/typescript/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
 import typescriptPageData from './typescript-page-data'
 import SearchCuratedEssential from '../curated-essential'
+import {bpMinMD} from 'utils/breakpoints'
 import Card from 'components/pages/home/card'
 import Collection from 'components/pages/home/collection'
 import {find} from 'lodash'
@@ -30,6 +33,7 @@ Love them or hate them, static types are here to stay, and at the very least an 
         `,
       }}
       pageData={typescriptPageData}
+      CTAComponent={CourseFeatureCard}
     >
       <div className="mb-10 pb-10 xl:px-0 max-w-screen-xl mx-auto">
         {/* Featured Section */}
@@ -66,6 +70,52 @@ Love them or hate them, static types are here to stay, and at the very least an 
         </section>
       </div>
     </SearchCuratedEssential>
+  )
+}
+
+const CourseFeatureCard = ({resource, className}: any) => {
+  return (
+    <Link href="/courses/advanced-typescript-fundamentals-579c174f">
+      <a
+        className={`block md:col-span-4 rounded-md w-full h-full overflow-hidden border-0 border-gray-100 relative text-center ${
+          className ? className : ''
+        }`}
+      >
+        <div className="items-center h-full w-full block">
+          <div
+            className="relative z-10 flex flex-col h-full justify-between  items-center sm:p-8 p-5"
+            css={{
+              [bpMinMD]: {
+                minHeight: 477,
+              },
+            }}
+          >
+            <div className="flex flex-col items-center">
+              <Image
+                src="https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/433/579/full/typescript.png"
+                width={200}
+                height={200}
+                alt="Advanced TypeScript Fundamentals"
+              />
+              <h2 className="text-xl font-bold min-w-full mt-4 sm:mt-14 mb-2 leading-tighter group-hover:underline">
+                Advanced TypeScript Fundamentals
+              </h2>
+              <span className="text-sm opacity-80">Marius Schulz</span>
+              <p className="text-sm mt-4">
+                Learn the newest language features TypeScript has to offer.
+                Learn how to use optional chaining, const assertions,
+                conditional types, and more!
+              </p>
+            </div>
+          </div>
+          <img
+            className="absolute top-0 left-0 z-0 w-full"
+            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1619807045/next.egghead.io/resources/advanced-typescript-fundamentals/background-feature-card.svg"
+            alt=""
+          />
+        </div>
+      </a>
+    </Link>
   )
 }
 

--- a/src/components/search/curated/typescript/index.tsx
+++ b/src/components/search/curated/typescript/index.tsx
@@ -51,7 +51,7 @@ Love them or hate them, static types are here to stay, and at the very least an 
             </Card>
           </div>
           <Card
-            className="mt-5 col-span-4 h-full"
+            className="sm:mt-0 mt-5 col-span-4 h-full"
             resource={algorithms}
             location={location}
           >

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -196,9 +196,13 @@ export const getServerSideProps: GetServerSideProps = async function ({
 
   if (selectedTopics?.length === 1 && !selectedTopics.includes('undefined')) {
     const topic = first<string>(selectedTopics)
+
+    console.log({selectedTopics})
     try {
       if (topic) {
         initialTopic = await loadTag(topic)
+
+        console.log({topic})
       }
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
Adds latest typescript course to TypeScript curated page.

Tweaked some margin/spacing on cards for consistency


![](https://media1.giphy.com/media/JqKNbaYKsdSve/200w.gif?cid=5a38a5a2yigo8sgygnmmt34pylmz3xdvzfpxb1pz37bzhw7n&rid=200w.gif&ct=g)


![In-Depth TypeScript Tutorials for 2021  egghead io](https://user-images.githubusercontent.com/6188161/116742541-7f0ad580-a9c5-11eb-86c5-76ef481cccec.png)
![In-Depth TypeScript Tutorials for 2021  egghead io](https://user-images.githubusercontent.com/6188161/116742545-80d49900-a9c5-11eb-920f-c16a14e50663.png)
![In-Depth TypeScript Tutorials for 2021  egghead io](https://user-images.githubusercontent.com/6188161/116742552-8205c600-a9c5-11eb-8e70-981c1c46387c.png)
![In-Depth TypeScript Tutorials for 2021  egghead io](https://user-images.githubusercontent.com/6188161/116742556-83cf8980-a9c5-11eb-8b9c-bf4173b8bd79.png)


