### PR TITLE
update sanity query to be consistent with rails

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -132,8 +132,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
         byline: 'Colby Fayock・1h 4m・Course',
         image:
           'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/412/781/thumb/ecommerce-stripe-next.png',
-        path:
-          '/playlists/create-an-ecommerce-store-with-next-js-and-stripe-checkout-562c',
+        path: '/playlists/create-an-ecommerce-store-with-next-js-and-stripe-checkout-562c',
         slug: 'create-an-ecommerce-store-with-next-js-and-stripe-checkout-562c',
         description: `This is a practical project based look at building a working e-commerce store
         using modern tools and APIs. Excellent for a weekend side-project for your [developer project portfolio](https://joelhooks.com/developer-portfolio)`,
@@ -257,8 +256,13 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
     [],
   ).map((lesson: LessonResource) => lesson.slug)
 
-  const {name, avatar_url, url: instructor_slug, bio_short, twitter} =
-    instructor || {}
+  const {
+    full_name: name,
+    avatar_url,
+    slug,
+    bio_short,
+    twitter,
+  } = instructor || {}
 
   const image_url = square_cover_480_url || image_thumb_url
 
@@ -420,7 +424,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   <InstructorProfile
                     name={name}
                     avatar_url={avatar_url}
-                    url={instructor_slug}
+                    url={slug}
                     bio_short={bio_short}
                     twitter={twitter}
                   />
@@ -790,9 +794,8 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                             <ul className="ml-8">
                               {playlist?.lessons?.map(
                                 (lesson: LessonResource, index: number) => {
-                                  const isComplete = completedLessonSlugs.includes(
-                                    lesson.slug,
-                                  )
+                                  const isComplete =
+                                    completedLessonSlugs.includes(lesson.slug)
                                   return (
                                     <li
                                       key={`${playlist.slug}::${lesson.slug}`}

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -1,4 +1,5 @@
 import {sanityClient} from 'utils/sanity-client'
+import {pickBy, identity} from 'lodash'
 import groq from 'groq'
 
 const courseQuery = groq`
@@ -34,9 +35,9 @@ const courseQuery = groq`
     'image': person->image.url
   },
 	'instructor': collaborators[]->[role == 'instructor'][0]{
-    'name': person->name,
+    'full_name': person->name,
     'avatar_url': person->image.url,
-    'url': person->slug.current
+    'slug': person->slug.current
   },
 	'dependencies': softwareLibraries[]{
     version,


### PR DESCRIPTION
The sanity data coming in was different than the rails attribute so when the course data wasn't set in sanity, no instructor name would be shown. I converted the sanity data to be consistent with the rails data so now the objects merge instead of having separate `slug` and `url` attributes. We were only checking for `url` on the front end.

While making a sanity object for a course is a lot easier now, this shouldn't ever be an issue or something we should have to check

![tweak](https://media3.giphy.com/media/lOyrQ8OiSazc17xKvo/giphy.gif?cid=74e95743cvfrm89u90zci3axjittf0veb53etti2gd1dwbob&rid=giphy.gif&ct=g)