### PR TITLE
pass CueBar as children of ProgressControl

### DIFF
--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -156,7 +156,6 @@ const VideoTest: React.FC<any> = ({videoResource}) => {
                   kind="metadata"
                   label="notes"
                 />
-                <CueBar order={6.0} />
                 <ControlBar disableDefaultControls>
                   <PlayToggle key="play-toggle" order={1} />
                   <ReplayControl key="replay-control" order={2} />
@@ -165,7 +164,9 @@ const VideoTest: React.FC<any> = ({videoResource}) => {
                   <CurrentTimeDisplay key="current-time-display" order={5} />
                   <TimeDivider key="time-divider" order={6} />
                   <DurationDisplay key="duration-display" order={7} />
-                  <ProgressControl key="progress-control" order={8} />
+                  <ProgressControl key="progress-control" order={8}>
+                    <CueBar key="cue-bar" />
+                  </ProgressControl>
                   <RemainingTimeDisplay
                     key="remaining-time-display"
                     order={9}

--- a/src/styles/cueplayer.css
+++ b/src/styles/cueplayer.css
@@ -1,0 +1,7 @@
+.cueplayer-react .cueplayer-react-cue-bar {
+  @apply bottom-0 h-8;
+}
+
+.cueplayer-react-cue-bar .cueplayer-react-cue-note {
+  @apply w-[4px];
+}


### PR DESCRIPTION
I think it's important having the cues placed on timeline so that it reflects actual position in time. There's a lot more going on in the mockups and in terms of proper interactions, but this is a first step towards that goal. 

before:
<img src="https://user-images.githubusercontent.com/25487857/121374203-fece7d00-c93f-11eb-8033-28da4d785118.png" width="700">

after: 
<img src="https://p-ZmFjNlQ.b3.n0.cdn.getcloudapp.com/items/p9uA7EXd/2f9ebf40-0494-4f66-af6d-ab2600f7eb93.gif?v=a432a8a794f542ed1ff4ca748df09520" width="700">

related PR for `cueplayer-react` library: https://github.com/joelhooks/cueplayer-react/pull/4

<img src="https://media.giphy.com/media/J26cCHEtf0YObuaIoy/giphy.gif" width="250">