### PR TITLE
Updated the course title on a course card

### DIFF
--- a/src/components/search/instructors/dan-abramov/dan-abramov-page-data.ts
+++ b/src/components/search/instructors/dan-abramov/dan-abramov-page-data.ts
@@ -23,8 +23,8 @@ He started using React for front-end development when he was working with a U.S-
     name: 'Just starting out with JavaScript',
     resources: [
       {
-        title: 'Getting Started with Redux',
-        path: '/courses/getting-started-with-redux',
+        title: 'Fundamentals of Redux Course from Dan Abramov',
+        path: '/courses/fundamentals-of-redux-course-from-dan-abramov-bd5cc867',
         image:
           'https://d2eip9sf3oo6c2.cloudfront.net/series/square_covers/000/000/025/full/EGH_Redux-New.png',
         byline: 'Dan Abramov',


### PR DESCRIPTION
The title for `Getting Started with Redux` changed to `Fundamentals of Redux Course from Dan Abramov`. 

OLD
<img width="619" alt="Screen Shot 2021-06-09 at 11 53 51 AM" src="https://user-images.githubusercontent.com/26470581/121415475-a043d780-c91c-11eb-9cec-93ec9162fda2.png">

NEW
<img width="524" alt="Screen Shot 2021-06-09 at 12 13 13 PM" src="https://user-images.githubusercontent.com/26470581/121415502-a8037c00-c91c-11eb-85a0-dfa7a453d31f.png">

The course cards are hardcoded in `src/components/search/instructors/` so I updated that in this PR.

![](https://media2.giphy.com/media/enrlWbD943ZZi9ZszN/200.gif?cid=5a38a5a2dj3q1jkkh0b4dkr34qoj960ie53r8hpzupbubpbk&rid=200.gif&ct=g)