### PR TITLE
Cueplayer tweaks

### DIFF
--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import classNames from 'classnames'
 import Tippy from '@tippyjs/react'
+import {scroller} from 'react-scroll'
 import {useEggheadPlayerPrefs} from 'components/EggheadPlayer/use-egghead-player'
 
 const CueBar: React.FC<any> = ({
@@ -8,7 +9,6 @@ const CueBar: React.FC<any> = ({
   disableCompletely,
   player,
   actions,
-  scroller,
 }) => {
   const {duration, activeMetadataTracks} = player
 
@@ -30,7 +30,6 @@ const CueBar: React.FC<any> = ({
             duration={duration}
             player={player}
             actions={actions}
-            scroller={scroller}
           />
         )
       })}
@@ -79,7 +78,6 @@ const NoteCue: React.FC<any> = ({
   className,
   actions,
   player,
-  scroller,
 }) => {
   const playerPrefs = useEggheadPlayerPrefs()
   const setVisible = useCue(cue, actions)

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -103,7 +103,7 @@ const NoteCue: React.FC<any> = ({
       playerPrefs.setPlayerPrefs({sideBar: {activeTab: 0}})
       scroller.scrollTo('active-note', {
         duration: 0,
-        delay: 1,
+        delay: 0,
         offset: -12,
         containerId: 'notes-tab-scroll-container',
       })

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -103,7 +103,7 @@ const NoteCue: React.FC<any> = ({
       playerPrefs.setPlayerPrefs({sideBar: {activeTab: 0}})
       scroller.scrollTo('active-note', {
         duration: 0,
-        delay: 0,
+        delay: 1,
         offset: -12,
         containerId: 'notes-tab-scroll-container',
       })

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -28,7 +28,7 @@ import ReactMarkdown from 'react-markdown'
 import CueBar from 'components/player/cue-bar'
 import ControlBarDivider from 'components/player/control-bar-divider'
 import {useEggheadPlayerPrefs} from 'components/EggheadPlayer/use-egghead-player'
-import {Element, scroller} from 'react-scroll'
+import {Element} from 'react-scroll'
 import {VideoResource} from '../types'
 import {loadBasicLesson} from '../lib/lessons'
 import {loadNotesFromUrl} from './api/github-load-notes'
@@ -83,7 +83,7 @@ const EggheadPlayer: React.FC<{
                 default
               />
               <track id="notes" src={notesUrl} kind="metadata" label="notes" />
-              <CueBar key="cue-bar" order={6.0} scroller={scroller} />
+              <CueBar key="cue-bar" order={6.0} />
 
               <ControlBar disableDefaultControls autoHide={false}>
                 <PlayToggle key="play-toggle" order={1} />

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -20,6 +20,7 @@ import {
   PlayerProvider,
   usePlayer,
 } from 'cueplayer-react'
+import SimpleBar from 'simplebar-react'
 import HLSSource from 'components/player/hls-source'
 import classNames from 'classnames'
 import {Tabs, TabList, Tab, TabPanels, TabPanel} from '@reach/tabs'
@@ -127,17 +128,14 @@ const EggheadPlayer: React.FC<{
                   {!isEmpty(cues) && <Tab>Notes</Tab>}
                   <Tab>Lessons</Tab>
                 </TabList>
-                <TabPanels
-                  id="notes-tab-scroll-container"
-                  className="flex-grow overflow-y-auto"
-                >
-                  <div>
+                <TabPanels className="flex-grow relative">
+                  <div className="absolute" css={{inset: 0}}>
                     {!isEmpty(cues) && (
-                      <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000">
+                      <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000 w-full h-full">
                         <NotesTabContent cues={cues} />
                       </TabPanel>
                     )}
-                    <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000">
+                    <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000 w-full h-full">
                       <div>This will be a list of lessons.</div>
                     </TabPanel>
                   </div>
@@ -154,9 +152,18 @@ const EggheadPlayer: React.FC<{
 const NotesTabContent: React.FC<{cues: VTTCue[]}> = ({cues}) => {
   const {player} = usePlayer()
   const disabled: boolean = isEmpty(cues)
+  const scrollableNodeRef: any = React.createRef()
 
   return disabled ? null : (
-    <div>
+    <SimpleBar
+      forceVisible="y"
+      autoHide={false}
+      scrollableNodeProps={{
+        ref: scrollableNodeRef,
+        id: 'notes-tab-scroll-container',
+      }}
+      className="h-full overscroll-contain"
+    >
       {cues.map((cue: VTTCue) => {
         const note = cue.text
         const active = player.activeMetadataTrackCues.includes(cue)
@@ -188,7 +195,7 @@ const NotesTabContent: React.FC<{cues: VTTCue[]}> = ({cues}) => {
           </div>
         )
       })}
-    </div>
+    </SimpleBar>
   )
 }
 

--- a/src/styles/cueplayer.css
+++ b/src/styles/cueplayer.css
@@ -22,11 +22,13 @@
 /* progress bar */
 .video-test .cueplayer-react .cueplayer-react-progress-control {
   @apply transform translate-y-6 bottom-0 w-full h-6 absolute bg-gray-1000;
+  transform: translateY(1.5rem);
 }
 
 /* cue bar */
 .video-test .cueplayer-react .cueplayer-react-cue-bar {
   @apply transform translate-y-10 bottom-0 h-4 flex bg-gray-1000 z-10;
+  transform: translateY(2.5rem);
 }
 
 /* control bar */


### PR DESCRIPTION
What was done:
- fixed styles to prevent collision in build
- add SimpleBar (for nice scroll bars) to the Notes list

What I failed with:
- auto scroll to active note while video plays. It scrolls on click on Cue though, but it works weird (I suspect it is because we have multiple active cues, can't figure out exactly where the state is leaking).

https://share.getcloudapp.com/12u4Ax1p