### PR TITLE
Few tweaks for Cueplayer

### DIFF
--- a/src/components/pages/lessons/collection-lessons-list.tsx
+++ b/src/components/pages/lessons/collection-lessons-list.tsx
@@ -36,7 +36,7 @@ const CollectionLessonsList: FunctionComponent<NextUpListProps> = ({
 
   return lessons ? (
     <div className="h-full overflow-hidden">
-      <div className="overflow-hidden bg-white dark:bg-gray-900 dark:border-gray-800 border-gray-100 h-96 lg:h-full rounded-md lg:rounded-none border lg:border-none">
+      <div className="overflow-hidden dark:bg-gray-900 dark:border-gray-800 border-gray-100 h-96 lg:h-full rounded-md lg:rounded-none border lg:border-none">
         <SimpleBar
           autoHide={false}
           className="h-full"

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -126,7 +126,7 @@ const NoteCue: React.FC<any> = ({
       interactive={true}
       content={
         <div className="p-2">
-          <div className="line-clamp-6 prose-sm prose">
+          <div className="line-clamp-6 prose-sm prose leading-normal">
             <ReactMarkdown>{note}</ReactMarkdown>
           </div>
         </div>

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import classNames from 'classnames'
+import {isEmpty} from 'lodash'
 import Tippy from '@tippyjs/react'
 import {scroller} from 'react-scroll'
 import {useEggheadPlayerPrefs} from 'components/EggheadPlayer/use-egghead-player'
@@ -21,7 +22,7 @@ const CueBar: React.FC<any> = ({
     return [...acc, ...Array.from(track.cues || [])]
   }, [])
 
-  return disableCompletely ? null : (
+  return disableCompletely || isEmpty(noteCues) ? null : (
     <div className={classNames('cueplayer-react-cue-bar', className)}>
       {noteCues.map((noteCue: any) => {
         return (

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -37,9 +37,8 @@ import {loadNotesFromUrl} from './api/github-load-notes'
 
 const EggheadPlayer: React.FC<{
   videoResource: VideoResource
-  currentLessonSlug: string
   notesUrl: string
-}> = ({videoResource, currentLessonSlug, notesUrl}) => {
+}> = ({videoResource, notesUrl}) => {
   const playerContainer = React.useRef<any>()
   const playerPrefs = useEggheadPlayerPrefs()
   const {player} = usePlayer()
@@ -135,7 +134,7 @@ const EggheadPlayer: React.FC<{
                       <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000 w-full h-full">
                         <CollectionLessonsList
                           course={videoResource?.collection}
-                          currentLessonSlug={currentLessonSlug}
+                          currentLessonSlug={videoResource?.slug}
                           progress={[]}
                         />
                       </TabPanel>
@@ -248,16 +247,11 @@ const PlayerContainer: React.ForwardRefExoticComponent<any> = React.forwardRef<
 
 const VideoTest: React.FC<{
   videoResource: VideoResource
-  currentLessonSlug: string
   notesUrl: string
-}> = ({videoResource, currentLessonSlug, notesUrl}) => {
+}> = ({videoResource, notesUrl}) => {
   return (
     <PlayerProvider>
-      <EggheadPlayer
-        videoResource={videoResource}
-        currentLessonSlug={currentLessonSlug}
-        notesUrl={notesUrl}
-      />
+      <EggheadPlayer videoResource={videoResource} notesUrl={notesUrl} />
     </PlayerProvider>
   )
 }
@@ -282,7 +276,6 @@ export const getServerSideProps: GetServerSideProps = async function ({
   return {
     props: {
       videoResource,
-      currentLessonSlug: lesson,
       notesUrl: `/api/github-load-notes?url=${lessonNotes[lesson]}`,
     },
   }

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -131,7 +131,7 @@ const EggheadPlayer: React.FC<{
                 <TabPanels className="flex-grow relative">
                   <div className="lg:absolute" css={{inset: 0}}>
                     {videoResource?.collection && (
-                      <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000 w-full h-full">
+                      <TabPanel className="bg-gray-100 dark:bg-gray-1000 w-full h-full">
                         <CollectionLessonsList
                           course={videoResource?.collection}
                           currentLessonSlug={videoResource?.slug}
@@ -140,7 +140,7 @@ const EggheadPlayer: React.FC<{
                       </TabPanel>
                     )}
                     {!isEmpty(cues) && (
-                      <TabPanel className="p-4 bg-gray-100 dark:bg-gray-1000 w-full h-full">
+                      <TabPanel className="bg-gray-100 dark:bg-gray-1000 w-full h-full">
                         <NotesTabContent cues={cues} />
                       </TabPanel>
                     )}
@@ -169,7 +169,7 @@ const NotesTabContent: React.FC<{cues: VTTCue[]}> = ({cues}) => {
         ref: scrollableNodeRef,
         id: 'notes-tab-scroll-container',
       }}
-      className="h-full overscroll-contain"
+      className="h-full overscroll-contain p-4"
     >
       <div className="space-y-3">
         {cues.map((cue: VTTCue) => {

--- a/src/pages/video-test.tsx
+++ b/src/pages/video-test.tsx
@@ -64,9 +64,9 @@ const EggheadPlayer: React.FC<{
           className="relative grid grid-cols-1 lg:grid-cols-12 font-sans text-base"
         >
           <div
-            className={`relative z-10 pb-[4.5rem] ${
-              player.isFullscreen ? 'lg:col-span-12' : 'lg:col-span-9'
-            }`}
+            className={`relative z-10 ${
+              isEmpty(cues) ? 'pb-14' : 'pb-[4.5rem]'
+            } ${player.isFullscreen ? 'lg:col-span-12' : 'lg:col-span-9'}`}
           >
             <Player
               muted
@@ -86,7 +86,13 @@ const EggheadPlayer: React.FC<{
               />
               <track id="notes" src={notesUrl} kind="metadata" label="notes" />
               <CueBar key="cue-bar" order={6.0} />
-              <ControlBar disableDefaultControls autoHide={false}>
+              <ControlBar
+                disableDefaultControls
+                autoHide={false}
+                className={`transform ${
+                  isEmpty(cues) ? 'translate-y-14' : 'translate-y-[4.5rem]'
+                }`}
+              >
                 <PlayToggle key="play-toggle" order={1} />
                 <ReplayControl key="replay-control" order={2} />
                 <ForwardControl key="forward-control" order={3} />

--- a/src/styles/cueplayer.css
+++ b/src/styles/cueplayer.css
@@ -1,5 +1,8 @@
 /* side-bar */
 /* tabs */
+.side-bar {
+  @apply select-text;
+}
 .side-bar [data-reach-tabs] [data-reach-tab-list] {
   @apply space-x-0 bg-transparent rounded-none bg-white dark:bg-gray-900;
 }

--- a/src/styles/cueplayer.css
+++ b/src/styles/cueplayer.css
@@ -36,7 +36,7 @@
 
 /* control bar */
 .video-test .cueplayer-react .cueplayer-react-control-bar {
-  @apply transform translate-y-[4.5rem] flex bg-gray-1000;
+  @apply flex bg-gray-1000;
 }
 
 .video-test .cueplayer-react .cueplayer-react-fullscreen {
@@ -49,7 +49,6 @@
 }
 
 .cueplayer-react .cueplayer-react-cue-bar {
-  display: none;
   width: 100%;
   position: absolute;
   bottom: 32px;
@@ -57,8 +56,6 @@
   right: 0;
   height: 16px;
   background-color: #2b333f90;
-
-  animation-timing-function: cubic-bezier(0.28, 0.84, 0.42, 1);
 }
 
 .cueplayer-react-has-started.cueplayer-react-user-inactive.cueplayer-react-playing

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
               },
               code: {color: theme('colors.blue.600')},
             },
-            'strong > a': {
+            'strong > a, a > strong': {
               color: theme('colors.blue.600'),
             },
             code: {
@@ -83,7 +83,7 @@ module.exports = {
                 },
               },
             },
-            'strong > a': {
+            'strong > a, a > strong': {
               color: theme('colors.blue.400'),
             },
             blockquote: {


### PR DESCRIPTION
1. fix `prose` styles for cue popups
2. text in side bar could be selected now
3. content of tabs is stretched now
![Image 2021-06-23 at 4 14 33 PM](https://user-images.githubusercontent.com/1519448/123102887-29d7c700-d43e-11eb-9af9-f846d2697480.jpg)
4. styles for no cues state
![no-cues](https://user-images.githubusercontent.com/1519448/123102728-07de4480-d43e-11eb-8be8-730433ee5e19.jpg)


https://media3.giphy.com/media/IgjAo7ZmCmoOiHy5dU/giphy.gif?cid=5a38a5a2tkzensfsjhhmkekzmxecyd0etbcl4m6csgw6k817&rid=giphy.gif&ct=g