### PR TITLE
use optional chaining to safely look up properties

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -241,7 +241,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
 
   const courseTags = tags.map((tag: any) => {
     const ogVersion = get(dependencies, tag.name)
-    const sanityTag = find(sanityDependencies, {name: tag.name}).version
+    const sanityTag = find(sanityDependencies, {name: tag.name})?.version
 
     const version = !isEmpty(sanityTag) ? sanityTag : ogVersion
 


### PR DESCRIPTION
If dependencies aren't set in sanity, the course page won't render due to trying to look up a property on undefined.

![its broken](https://media2.giphy.com/media/vPFVmgFd5bjqfZS9ZD/giphy.gif?cid=74e957438xnxde4to0suewhcv21nrn6dt34r0qxfhn4o4pnm&rid=giphy.gif&ct=g)