### PR TITLE
Use specific error messages from server when Ownership Transfer Invite cannot be sent

### DIFF
--- a/src/components/team/account-ownership-transfer.tsx
+++ b/src/components/team/account-ownership-transfer.tsx
@@ -88,13 +88,13 @@ const AccountOwnershipTransfer = ({accountId}: {accountId: number}) => {
                   error: data.error,
                 })
 
-                toast.error(
-                  'There was an issue sending the ownership transfer invite. Please contact support@egghead.io if the issue persists.',
-                  {
-                    duration: 6000,
-                    icon: '❌',
-                  },
-                )
+                const defaultMessage =
+                  'There was an issue sending the ownership transfer invite. Please contact support@egghead.io if the issue persists.'
+
+                toast.error(data.error || defaultMessage, {
+                  duration: 6000,
+                  icon: '❌',
+                })
               } finally {
                 setLoading(false)
               }


### PR DESCRIPTION
There are different ways that sending an Account Ownership Transfer
Invitation can fail. There are user-friendly messages coming from the
server explaining what went wrong. This commit wires those up to the
toast that displays on error.


https://user-images.githubusercontent.com/694063/123320811-dfb31c00-d4f7-11eb-9054-5099d30ce46f.mp4


![](https://media2.giphy.com/media/RSoaNlvZ2xgt2/giphy.gif?cid=5a38a5a2z39x92spccpcrkz40xdqduu2pr8bh2slino57cad&rid=giphy.gif&ct=g)

