### PR TITLE
Pass ref and href to anchor from next/link

### DIFF
--- a/src/components/pages/lessons/collection-lessons-list.tsx
+++ b/src/components/pages/lessons/collection-lessons-list.tsx
@@ -84,6 +84,29 @@ const CollectionLessonsList: FunctionComponent<NextUpListProps> = ({
   ) : null
 }
 
+interface WrappedLinkProps extends React.HTMLProps<HTMLAnchorElement> {
+  lesson: any
+}
+
+const WrappedAnchor = React.forwardRef<HTMLAnchorElement, WrappedLinkProps>(
+  ({onClick = () => {}, href, lesson, children}, ref) => {
+    return (
+      <a
+        href={href}
+        onClick={(e) => {
+          track(`clicked next up lesson`, {
+            lesson: lesson.slug,
+          })
+          onClick(e)
+        }}
+        ref={ref}
+      >
+        {children}
+      </a>
+    )
+  },
+)
+
 const Item: FunctionComponent<{
   lesson: any
   active: boolean
@@ -91,7 +114,7 @@ const Item: FunctionComponent<{
   index: number
   completed: boolean
 }> = ({lesson, className, index, completed, active = false, ...props}) => {
-  const Item = () => (
+  const InnerItem = () => (
     <div
       className={`group flex p-3 ${
         active
@@ -126,19 +149,12 @@ const Item: FunctionComponent<{
     </div>
   )
   return active ? (
-    <Item />
+    <InnerItem />
   ) : (
-    <Link href={lesson.path}>
-      <a
-        onClick={() => {
-          track(`clicked next up lesson`, {
-            lesson: lesson.slug,
-          })
-        }}
-        className="font-semibold"
-      >
-        <Item />
-      </a>
+    <Link href={lesson.path} passHref>
+      <WrappedAnchor lesson={lesson}>
+        <InnerItem />
+      </WrappedAnchor>
     </Link>
   )
 }


### PR DESCRIPTION
Since we have an onClick in our inner `<a/>` we need to pass the
ref, Link.onClick, and href to the `<a/>`.

[next link docs](https://nextjs.org/docs/api-reference/next/link)

![link](https://media0.giphy.com/media/NVBR6cLvUjV9C/giphy.gif?cid=74e95743n7wwkin77eycc46ywcqfa9f0tyshfnife2ad8obi&rid=giphy.gif&ct=g)