### PR TITLE
revert epic react banners to default

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -358,7 +358,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
   }
 
   const EpicReactBanner = ({
-    image = 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226638/epic-react/summer-sale-2021/banner-course-page_2x.jpg',
+    image = 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1626109728/epic-react/default-banners/banner-course-page_2x.jpg',
     width = 1416,
     height = 508,
   }) => {
@@ -944,7 +944,10 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   You might also like these resources:
                 </h2>
                 <EpicReactBanner
-                  image="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226676/epic-react/summer-sale-2021/banner-react-page_2x.jpg"
+                  // 25% off
+                  // image="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226676/epic-react/summer-sale-2021/banner-react-page_2x.jpg"
+                  // default
+                  image="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1626109728/epic-react/default-banners/banner-react-page_2x.jpg"
                   width={916 / 2}
                   height={1024 / 2}
                 />

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -270,7 +270,9 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
             >
               <div className="overflow-hidden flex items-center justify-center rounded-lg">
                 <Image
-                  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625229239/epic-react/summer-sale-2021/banner-home_2x.jpg"
+                  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1626109728/epic-react/default-banners/banner-home_2x.jpg"
+                  // 25% off
+                  // src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625229239/epic-react/summer-sale-2021/banner-home_2x.jpg"
                   alt="Get Really Good at React on EpicReact.dev by Kent C. Dodds"
                   width={704}
                   height={836}

--- a/src/components/search/curated/default-cta.tsx
+++ b/src/components/search/curated/default-cta.tsx
@@ -19,10 +19,9 @@ const DefaultCTA: React.FC<{location: string}> = ({location}) => {
         height={463}
         className="rounded-lg"
         alt="Get Really Good at React on EpicReact.dev by Kent C. Dodds"
-        // default
-        // src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
+        src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1626109728/epic-react/default-banners/banner-react-page_2x.jpg"
         // 25% off
-        src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226676/epic-react/summer-sale-2021/banner-react-page_2x.jpg"
+        // src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226676/epic-react/summer-sale-2021/banner-react-page_2x.jpg"
       />
     </ExternalTrackedLink>
   )

--- a/src/components/search/curated/react/index.tsx
+++ b/src/components/search/curated/react/index.tsx
@@ -90,10 +90,9 @@ You can find courses below curated just for you whether you're looking for a par
               height={463}
               alt="Get Really Good at React on EpicReact.dev by Kent C. Dodds"
               className="hover:scale-[102%] transform ease-in-out duration-500"
-              // default
-              // src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1611336740/next.egghead.io/react/epic_react_link_banner.png"
+              src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1626109728/epic-react/default-banners/banner-react-page_2x.jpg"
               // 25% off
-              src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226676/epic-react/summer-sale-2021/banner-react-page_2x.jpg"
+              // src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1625226676/epic-react/summer-sale-2021/banner-react-page_2x.jpg"
             />
           </div>
         </ExternalTrackedLink>


### PR DESCRIPTION
this does not remove "Learn React with Kent" section on homepage — LMK if it should.

![image](https://user-images.githubusercontent.com/25487857/125330086-96135f80-e346-11eb-899c-cea569bda5bc.png)


<img src="https://media.giphy.com/media/l2YWG1JlDixTKYlX2/giphy.gif" width="250">