### PR TITLE
pl/Move dark mode toggle from navbar to footer

### DIFF
--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -144,52 +144,60 @@ const DarkModeToggle = () => {
   const {subscriber, cioIdentify} = useCio()
   const {theme, setTheme} = useTheme()
   React.useEffect(() => setMounted(true), [])
-
+  const handleClick = () => {
+    const nextTheme = theme === 'dark' ? 'light' : 'dark'
+    setTheme(nextTheme)
+    track(`toggled dark mode`, {
+      mode: nextTheme,
+    })
+    if (subscriber) {
+      cioIdentify(subscriber.id, {
+        theme_preference: nextTheme,
+      })
+    }
+  }
   return (
-    <button
-      aria-label="Toggle Dark Mode"
-      type="button"
-      className="rounded p-3 h-10 w-10"
-      onClick={() => {
-        const nextTheme = theme === 'dark' ? 'light' : 'dark'
-        setTheme(nextTheme)
-        track(`toggled dark mode`, {
-          mode: nextTheme,
-        })
-        if (subscriber) {
-          cioIdentify(subscriber.id, {
-            theme_preference: nextTheme,
-          })
-        }
-      }}
-    >
-      {mounted && (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          stroke="currentColor"
-          className="h-4 w-4 text-gray-800 dark:text-gray-200"
+    <div className="flex justify-between items-center">
+      <h2 className="mr-3">{theme === 'dark' ? 'Dark' : 'Light'} Mode</h2>
+      <div
+        className="w-16 h-10 bg-gray-300 dark:bg-gray-1000 rounded-full flex-shrink-0 p-1"
+        onClick={handleClick}
+        aria-label="Toggle Dark Mode"
+        role="button"
+      >
+        <div
+          className={`bg-white w-8 h-8 rounded-full shadow-md duration-300 ease-in-out flex items-center justify-center dark:bg-gray-800 ${
+            theme === 'dark' ? 'transform translate-x-6' : ''
+          }`}
         >
-          {theme === 'dark' ? (
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-            />
-          ) : (
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-            />
+          {mounted && (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              stroke="currentColor"
+              className="h-4 w-4 text-gray-400 dark:text-gray-200"
+            >
+              {theme === 'dark' ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+                />
+              )}
+            </svg>
           )}
-        </svg>
-      )}
-    </button>
+        </div>
+      </div>
+    </div>
   )
 }
-
 export default Footer

--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -5,6 +5,8 @@ import Eggo from '../images/eggo.svg'
 import {track} from 'utils/analytics'
 import {useViewer} from 'context/viewer-context'
 import {reject} from 'lodash'
+import {useTheme} from 'next-themes'
+import useCio from 'hooks/use-cio'
 
 const content = [
   {
@@ -130,9 +132,63 @@ const Footer: FunctionComponent = () => {
               Terms & Conditions
             </a>
           </Link>
+          <DarkModeToggle />
         </small>
       </footer>
     </div>
+  )
+}
+
+const DarkModeToggle = () => {
+  const [mounted, setMounted] = React.useState(false)
+  const {subscriber, cioIdentify} = useCio()
+  const {theme, setTheme} = useTheme()
+  React.useEffect(() => setMounted(true), [])
+
+  return (
+    <button
+      aria-label="Toggle Dark Mode"
+      type="button"
+      className="rounded p-3 h-10 w-10"
+      onClick={() => {
+        const nextTheme = theme === 'dark' ? 'light' : 'dark'
+        setTheme(nextTheme)
+        track(`toggled dark mode`, {
+          mode: nextTheme,
+        })
+        if (subscriber) {
+          cioIdentify(subscriber.id, {
+            theme_preference: nextTheme,
+          })
+        }
+      }}
+    >
+      {mounted && (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          stroke="currentColor"
+          className="h-4 w-4 text-gray-800 dark:text-gray-200"
+        >
+          {theme === 'dark' ? (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+            />
+          ) : (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+            />
+          )}
+        </svg>
+      )}
+    </button>
   )
 }
 

--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -8,7 +8,6 @@ import {isEmpty} from 'lodash'
 import Feedback from 'components/feedback-input'
 import useBreakpoint from 'utils/breakpoints'
 import {useRouter} from 'next/router'
-import {useTheme} from 'next-themes'
 import useCio from 'hooks/use-cio'
 import {Form, Formik} from 'formik'
 import ProjectClubCTA from 'components/survey/project-club'
@@ -139,7 +138,6 @@ const Header: FunctionComponent = () => {
                 </span>
               </a>
             </Link>
-            <DarkModeToggle />
           </div>
         ) : (
           <div className={className}>
@@ -157,7 +155,6 @@ const Header: FunctionComponent = () => {
                 Sign in
               </a>
             </Link>
-            <DarkModeToggle />
           </div>
         )}
       </div>
@@ -253,59 +250,6 @@ const SearchBar = () => {
         )
       }}
     </Formik>
-  )
-}
-
-const DarkModeToggle = () => {
-  const [mounted, setMounted] = React.useState(false)
-  const {subscriber, cioIdentify} = useCio()
-  const {theme, setTheme} = useTheme()
-  React.useEffect(() => setMounted(true), [])
-
-  return (
-    <button
-      aria-label="Toggle Dark Mode"
-      type="button"
-      className="rounded p-3 h-10 w-10"
-      onClick={() => {
-        const nextTheme = theme === 'dark' ? 'light' : 'dark'
-        setTheme(nextTheme)
-        track(`toggled dark mode`, {
-          mode: nextTheme,
-        })
-        if (subscriber) {
-          cioIdentify(subscriber.id, {
-            theme_preference: nextTheme,
-          })
-        }
-      }}
-    >
-      {mounted && (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          stroke="currentColor"
-          className="h-4 w-4 text-gray-800 dark:text-gray-200"
-        >
-          {theme === 'dark' ? (
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-            />
-          ) : (
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-            />
-          )}
-        </svg>
-      )}
-    </button>
   )
 }
 


### PR DESCRIPTION
[Notes/reasons on moving the dark mode toggle here.](https://roamresearch.com/#/app/egghead/page/NFSVQUOU4)

![New Header](https://user-images.githubusercontent.com/45955761/125500339-37512caa-81b8-4870-b7a8-af3adc41a138.png)
![new footer](https://user-images.githubusercontent.com/45955761/125500298-78d35921-f454-463d-8024-1fe4b17541ac.png)

I put the dark mode toggle on the same level as the copyright as is done on [the Vercel Dashboard](https://vercel.com/dashboard) **(bottom right of footer)**. Perhaps we should consider making it more visible/descriptive as they have done with the `<select>` element.

![Vercel Dashboard](https://user-images.githubusercontent.com/45955761/125500615-dc922ceb-67ce-43e4-bef1-68f3ac956435.png)

![giphy](https://user-images.githubusercontent.com/45955761/125501184-2a5461d6-e918-4624-a81d-eead2c6e85d4.gif)
