### PR TITLE
fixes single term as topic for search

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -10,7 +10,7 @@ import {
   ClearRefinements,
   ScrollTo,
 } from 'react-instantsearch-dom'
-import {get, isEqual, isEmpty} from 'lodash'
+import {get, isEqual, isEmpty, first} from 'lodash'
 import {useToggle, useClickAway} from 'react-use'
 
 import config from 'lib/config'
@@ -52,16 +52,10 @@ const Search: FunctionComponent<SearchProps> = ({
   }
 
   const noTopicsSelected = (searchState: any) => {
-    return get(searchState, 'refinementList._tags', []).length === 0
-  }
-
-  const onlyTheseTagsSelected = (tags: string[], searchState: any) => {
-    const selectedTags = get(
-      searchState,
-      'refinementList._tags',
-      [],
-    ) as string[]
-    return isEqual(tags, selectedTags)
+    return (
+      isEmpty(topic) &&
+      get(searchState, 'refinementList._tags', []).length === 0
+    )
   }
 
   const isRefinementOn =
@@ -84,8 +78,12 @@ const Search: FunctionComponent<SearchProps> = ({
     : undefined
 
   const shouldDisplayLandingPageForTopics = (topic: string) => {
+    const query = (searchState.query || '').trim()
+
+    const terms = query.split(' ')
+
     return (
-      isEmpty(searchState.query) &&
+      (isEmpty(searchState.query) || terms.length === 1) &&
       isEmpty(searchState.page) &&
       noInstructorsSelected(searchState)
     )

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -26,6 +26,7 @@ import {isArray} from 'lodash'
 import SearchCuratedEssential from './curated/curated-essential'
 import SearchInstructorEssential from './instructors/instructor-essential'
 import CuratedTopicsIndex from './curated'
+import {searchQueryToArray} from '../../utils/search/topic-extractor'
 
 const ALGOLIA_INDEX_NAME =
   process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || 'content_production'
@@ -78,9 +79,7 @@ const Search: FunctionComponent<SearchProps> = ({
     : undefined
 
   const shouldDisplayLandingPageForTopics = (topic: string) => {
-    const query = (searchState.query || '').trim()
-
-    const terms = query.split(' ')
+    const terms = searchQueryToArray(searchState)
 
     return (
       (isEmpty(searchState.query) || terms.length === 1) &&

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -21,6 +21,7 @@ import Main from 'components/app/main'
 import Footer from 'components/app/footer'
 import {loadTag} from 'lib/tags'
 import {tagCacheLoader} from 'utils/tag-cache-loader'
+import {topicExtractor} from '../../utils/search/topic-extractor'
 
 const tracer = getTracer('search-page')
 
@@ -91,15 +92,7 @@ const SearchIndex: any = ({
       setInstructor(null)
     }
 
-    const selectedTopics = searchState?.refinementList?._tags || []
-
-    const query = (searchState?.query || '').trim()
-
-    const terms = query.split(' ')
-
-    if (terms.length === 1 && selectedTopics.length === 0) {
-      selectedTopics.push(first(terms))
-    }
+    const selectedTopics = topicExtractor(searchState)
 
     if (
       isArray(selectedTopics) &&
@@ -202,15 +195,7 @@ export const getServerSideProps: GetServerSideProps = async function ({
   const noIndexInitial = queryParamsPresent || noHits || userQueryPresent
 
   const selectedInstructors = getInstructorsFromSearchState(initialSearchState)
-  const selectedTopics = initialSearchState.refinementList?._tags || []
-
-  const userQuery = (initialSearchState?.query || '').trim()
-
-  const terms = userQuery.split(' ')
-
-  if (terms.length === 1 && selectedTopics.length === 0) {
-    selectedTopics.push(first(terms))
-  }
+  const selectedTopics = topicExtractor(initialSearchState)
 
   if (selectedTopics?.length === 1 && !selectedTopics.includes('undefined')) {
     const topic = first<string>(selectedTopics)

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -202,7 +202,15 @@ export const getServerSideProps: GetServerSideProps = async function ({
   const noIndexInitial = queryParamsPresent || noHits || userQueryPresent
 
   const selectedInstructors = getInstructorsFromSearchState(initialSearchState)
-  const selectedTopics = initialSearchState.refinementList?._tags
+  const selectedTopics = initialSearchState.refinementList?._tags || []
+
+  const userQuery = (initialSearchState?.query || '').trim()
+
+  const terms = userQuery.split(' ')
+
+  if (terms.length === 1 && selectedTopics.length === 0) {
+    selectedTopics.push(first(terms))
+  }
 
   if (selectedTopics?.length === 1 && !selectedTopics.includes('undefined')) {
     const topic = first<string>(selectedTopics)

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -91,7 +91,15 @@ const SearchIndex: any = ({
       setInstructor(null)
     }
 
-    const selectedTopics = searchState?.refinementList?._tags
+    const selectedTopics = searchState?.refinementList?._tags || []
+
+    const query = (searchState?.query || '').trim()
+
+    const terms = query.split(' ')
+
+    if (terms.length === 1 && selectedTopics.length === 0) {
+      selectedTopics.push(first(terms))
+    }
 
     if (
       isArray(selectedTopics) &&
@@ -99,6 +107,7 @@ const SearchIndex: any = ({
       !selectedTopics.includes('undefined')
     ) {
       const newTopic = first<string>(selectedTopics)
+
       try {
         if (newTopic) {
           const cachedTag = tagCacheLoader(newTopic)
@@ -121,7 +130,7 @@ const SearchIndex: any = ({
       const href: string = createUrl(searchState)
       setNoIndex(queryParamsPresent(href))
 
-      router.push(`/q/[[all]]`, href, {
+      router.push(href, undefined, {
         shallow: true,
       })
     }, 250)

--- a/src/utils/search/topic-extractor.ts
+++ b/src/utils/search/topic-extractor.ts
@@ -1,0 +1,18 @@
+import {SearchState} from 'react-instantsearch-core'
+import {first} from 'lodash'
+
+export const topicExtractor = (searchState: SearchState) => {
+  const selectedTopics = searchState.refinementList?._tags || []
+
+  const terms: string[] = searchQueryToArray(searchState)
+
+  if (terms.length === 1 && selectedTopics.length === 0) {
+    selectedTopics.push(first(terms) as string)
+  }
+
+  return selectedTopics
+}
+
+export const searchQueryToArray = (searchState: SearchState) => {
+  return (searchState?.query || '').trim().split(' ')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,6 +2334,16 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@headlessui/react@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.3.0.tgz#62287c92604923e5dfb394483e5ec2463e1baea6"
+  integrity sha512-2gqTO6BQ3Jr8vDX1B67n1gl6MGKTt6DBmR+H0qxwj0gTMnR2+Qpktj8alRWxsZBODyOiBb77QSQpE/6gG3MX4Q==
+
+"@heroicons/react@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.2.tgz#e44a25d139e6fc8f94f4b146aeebad8f9af3d7dc"
+  integrity sha512-4FqozK7QCwyYTTWgtmG+Sffo20arFzIXuzY6TnsShNIPBRn6FKK/CuaYorVkNogxk7FW8MdOvSnpMPQpNeA04g==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
when typing a single term like `react` or navigating to the search page with a query like `q=react` it should load the associated topic page and not just search results.

this does not affect the loading of instructor pages, but those queries are much less frequent and generally more complex to load this way.

![](https://media.giphy.com/media/1QGRJ9cOTbh5K/giphy.gif)