### PR TITLE
pl/Fix dark mode button switch position bug 

### DIFF
--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -167,7 +167,7 @@ const DarkModeToggle = () => {
       >
         <div
           className={`bg-white w-8 h-8 rounded-full shadow-md duration-300 ease-in-out flex items-center justify-center dark:bg-gray-800 ${
-            theme === 'dark' ? 'transform translate-x-6' : ''
+            mounted && (theme === 'dark' ? 'transform translate-x-6' : '')
           }`}
         >
           {mounted && (


### PR DESCRIPTION
![wrong position](https://i.gyazo.com/cc2ec2871ccc79166a401d09fd33bf31.gif)
For default dark mode users, the dark mode button was starting in the wrong position. This small change updates the position of the button switch once the component is mounted, thus fixing the problem.
![fixed](https://user-images.githubusercontent.com/45955761/125657493-34515a31-4aa8-4d2b-81a8-b0bfef1858ab.png)
![bug squashing](https://media.giphy.com/media/UTHARUk53V1BHdYohY/giphy.gif)