### PR TITLE
pl/set search filter menu visible by default and have it persist across sessions

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -120,11 +120,26 @@ const Search: FunctionComponent<SearchProps> = ({
         {...rest}
       >
         <Configure hitsPerPage={config.searchResultCount} />
+        <ScrollTo scrollOn="query" />
         <div className="sm:pb-16 pb-8 space-y-8 bg-gray-50 dark:bg-gray-900 -mx-5">
-          <div
-            className="max-w-screen-xl md:-mt-5 -mt-3 pt-5 mx-auto"
-            ref={refinementRef}
-          >
+          {!isEmpty(instructor) && (
+            <div className="mb-10 pb-8 xl:px-0 px-5 mx-auto dark:bg-gray-900">
+              {shouldDisplayLandingPageForInstructor(instructor.slug) && (
+                <InstructorCuratedPage instructor={instructor} />
+              )}
+            </div>
+          )}
+
+          {!isEmpty(topic) && (
+            <div className="dark:bg-gray-900 bg-gray-50">
+              {CuratedTopicPage &&
+                shouldDisplayLandingPageForTopics(topic.name) && (
+                  <CuratedTopicPage topic={topic} />
+                )}
+            </div>
+          )}
+
+          <div className="max-w-screen-xl mx-auto " ref={refinementRef}>
             <header className="flex xl:px-0 px-5">
               <SearchBox
                 placeholder={searchBoxPlaceholder}
@@ -201,24 +216,8 @@ const Search: FunctionComponent<SearchProps> = ({
               </div>
             </div>
           </div>
-          {!isEmpty(instructor) && (
-            <div className="mb-10 pb-8 xl:px-0 px-5 mx-auto dark:bg-gray-900">
-              {shouldDisplayLandingPageForInstructor(instructor.slug) && (
-                <InstructorCuratedPage instructor={instructor} />
-              )}
-            </div>
-          )}
 
-          {!isEmpty(topic) && (
-            <div className="dark:bg-gray-900 bg-gray-50  md:-mt-5">
-              {CuratedTopicPage &&
-                shouldDisplayLandingPageForTopics(topic.name) && (
-                  <CuratedTopicPage topic={topic} />
-                )}
-            </div>
-          )}
-
-          <div className="dark:bg-gray-900 bg-gray-50  md:-mt-5">
+          <div className="dark:bg-gray-900 bg-gray-50 mt-5">
             <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
               <ScrollTo scrollOn="page" />
               <Hits />

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, useEffect} from 'react'
 import Head from 'next/head'
 import Hits from './hits'
 import SearchBox from './search-box'
@@ -11,7 +11,7 @@ import {
   ScrollTo,
 } from 'react-instantsearch-dom'
 import {get, isEqual, isEmpty, first} from 'lodash'
-import {useToggle, useClickAway} from 'react-use'
+import {useToggle} from 'react-use'
 
 import config from 'lib/config'
 
@@ -46,7 +46,15 @@ const Search: FunctionComponent<SearchProps> = ({
   topic,
   ...rest
 }) => {
-  const [isFilterShown, setShowFilter] = useToggle(false)
+  const [isFilterShown, setShowFilter] = useToggle(true)
+
+  useEffect(() => {
+    if (localStorage.getItem('isFilterShown')) {
+      setShowFilter(localStorage.getItem('isFilterShown') === 'true')
+    } else {
+      localStorage.setItem('isFilterShown', 'true')
+    }
+  }, [setShowFilter])
 
   const noInstructorsSelected = (searchState: any) => {
     return get(searchState, 'refinementList.instructor_name', []).length === 0
@@ -72,7 +80,6 @@ const Search: FunctionComponent<SearchProps> = ({
     get(searchState, 'refinementList.type', []).length
 
   const refinementRef = React.useRef(null)
-  useClickAway(refinementRef, () => setShowFilter(false))
 
   const searchBoxPlaceholder = !isEmpty(instructor)
     ? `Search resources by ${instructor.full_name}`
@@ -129,7 +136,13 @@ const Search: FunctionComponent<SearchProps> = ({
                 className="w-full "
               />
               <button
-                onClick={setShowFilter}
+                onClick={() => {
+                  setShowFilter()
+                  localStorage.setItem(
+                    'isFilterShown',
+                    isFilterShown ? 'false' : 'true',
+                  )
+                }}
                 className={`ml-2 flex items-center sm:px-5 px-3 py-2 rounded-md border-2 ${
                   isRefinementOn ? 'border-blue-400' : 'border-transparent'
                 } focus:border-blue-600 focus:outline-none`}


### PR DESCRIPTION
( #768 )
The filter is now open by default and the state of the filter is stored in localStorage so that it persists across sessions. Filter no longer toggles off on click away. 

![searching](https://media.giphy.com/media/26n6WywJyh39n1pBu/giphy.gif)