### PR TITLE
Check if value exists when applying syntax highlighting

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -10,7 +10,7 @@ type CodeBlockProps = {
 }
 
 const CodeBlock: FunctionComponent<CodeBlockProps> = ({language, value}) => {
-  return (
+  return value ? (
     <Highlight {...defaultProps} code={value} language={language} theme={theme}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <pre
@@ -27,7 +27,7 @@ const CodeBlock: FunctionComponent<CodeBlockProps> = ({language, value}) => {
         </pre>
       )}
     </Highlight>
-  )
+  ) : null
 }
 
 export default CodeBlock

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -182,7 +182,15 @@ const NoteCue: React.FC<any> = ({
             </button>
           </div>
           <div className="line-clamp-6 prose-sm prose leading-normal">
-            <ReactMarkdown>{note}</ReactMarkdown>
+            <ReactMarkdown
+              renderers={{
+                code: (props) => {
+                  return <CodeBlock {...props} />
+                },
+              }}
+            >
+              {note}
+            </ReactMarkdown>
           </div>
         </div>
       }

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -7,6 +7,7 @@ import {useEggheadPlayerPrefs} from 'components/EggheadPlayer/use-egghead-player
 import ReactMarkdown from 'react-markdown'
 import {track} from 'utils/analytics'
 import {useNotesCues} from './index'
+import CodeBlock from 'components/code-block'
 
 const CueBar: React.FC<any> = ({
   className,

--- a/src/components/player/player-sidebar.tsx
+++ b/src/components/player/player-sidebar.tsx
@@ -14,6 +14,7 @@ import {convertTime} from 'utils/time-utils'
 import {track} from 'utils/analytics'
 import Link from 'components/link'
 import Image from 'next/image'
+import CodeBlock from 'components/code-block'
 
 const notesCreationAvailable =
   process.env.NEXT_PUBLIC_NOTES_CREATION_AVAILABLE === 'true'

--- a/src/components/player/player-sidebar.tsx
+++ b/src/components/player/player-sidebar.tsx
@@ -121,7 +121,14 @@ const NotesTab: React.FC<any> = ({onAddNote}) => {
                       )}
                     >
                       {note && (
-                        <ReactMarkdown className="leading-normal prose-sm prose dark:prose-dark">
+                        <ReactMarkdown
+                          className="leading-normal prose-sm prose dark:prose-dark"
+                          renderers={{
+                            code: (props) => {
+                              return <CodeBlock {...props} />
+                            },
+                          }}
+                        >
                           {note}
                         </ReactMarkdown>
                       )}


### PR DESCRIPTION
this fixes #786 by preventing incorrect markdown syntax to surface.

also see [this related PR in course notes repo](https://github.com/eggheadio/eggheadio-course-notes/pull/199) fixing notes for given lesson and pointing out causes of particular issues, such as blank/empty blocks mentioned [here](https://github.com/eggheadio/egghead-next/issues/786#issuecomment-890569763).

<img src="https://media.giphy.com/media/vgma60qfjjBwNSaAYv/giphy.gif" width="200">