### PR TITLE
re-added vojtas code to fix code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@types/cookie": "^0.4.1",
+    "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.171",
     "@types/mdx-js__react": "^1.5.4",
     "@types/node": "^15.14.0",

--- a/src/pages/api/__tests__/github-load-notes.test.ts
+++ b/src/pages/api/__tests__/github-load-notes.test.ts
@@ -11,5 +11,37 @@ This is a **note**.
 `
   const parsedNotes = parseMdxNotesFile(markdownNotes)
 
-  await expect(parsedNotes).resolves.toEqual('not the answer')
+  await expect(parsedNotes).resolves.toEqual(`WEBVTT
+
+note
+00:00:44.000 --> 00:00:50.000
+This is a **note**.
+
+`)
+})
+
+test('properly parses markdown codeblock and text in the same timestamp', async () => {
+  const markdownNotes = `
+<TimeStamp start="0:44" end="0:50">
+
+This is a **note**.
+
+\`\`\`js
+This is a code block!
+\`\`\`
+
+</TimeStamp>
+`
+
+  const parsedNotes = parseMdxNotesFile(markdownNotes)
+  await expect(parsedNotes).resolves.toBe(`WEBVTT
+
+note
+00:00:44.000 --> 00:00:50.000
+This is a **note**.
+ \`\`\`js
+This is a code block!
+\`\`\`
+
+`)
 })

--- a/src/pages/api/__tests__/github-load-notes.test.ts
+++ b/src/pages/api/__tests__/github-load-notes.test.ts
@@ -1,0 +1,15 @@
+import {parseMdxNotesFile} from '../github-load-notes'
+
+// this had to use an async/await because the mdx compiler
+// is set up to be async and return a promise
+test('properly parses a markdown text string', async () => {
+  const markdownNotes = `<TimeStamp start="0:44" end="0:50">
+
+This is a **note**.
+
+</TimeStamp>
+`
+  const parsedNotes = parseMdxNotesFile(markdownNotes)
+
+  await expect(parsedNotes).resolves.toEqual('not the answer')
+})

--- a/src/pages/api/github-load-notes.ts
+++ b/src/pages/api/github-load-notes.ts
@@ -64,7 +64,9 @@ export async function loadNotesFromUrl(url: string) {
         }
       }, {})
       note.type = 'root'
-      const contents = toMarkdown(note)
+      const contents = note.children
+        .map((node: any) => toMarkdown(node))
+        .join(' ')
 
       return {
         text: contents.trim(),

--- a/src/pages/api/github-load-notes.ts
+++ b/src/pages/api/github-load-notes.ts
@@ -17,11 +17,7 @@ const loadGithubNotes = async (req: NextApiRequest, res: NextApiResponse) => {
 
 export default loadGithubNotes
 
-export async function loadNotesFromUrl(url: string) {
-  const result = await fetch(url)
-
-  const text = await result.text()
-
+export function parseMdxNotesFile(text: string) {
   // @ts-ignore
   const file = new VFile(text.trimStart())
 
@@ -89,4 +85,12 @@ ${note.text}\n\n`
 
     return vtt
   })
+}
+
+export async function loadNotesFromUrl(url: string) {
+  const result = await fetch(url)
+
+  const text = await result.text()
+
+  return parseMdxNotesFile(text)
 }

--- a/src/styles/cueplayer.css
+++ b/src/styles/cueplayer.css
@@ -32,6 +32,10 @@
   @apply bg-white opacity-50;
 }
 
+.tippy-content {
+  user-select: text !important;
+}
+
 /* progress bar */
 .cueplayer-react .cueplayer-react-progress-control {
   @apply bottom-0 w-full h-6 absolute flex px-2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5481,6 +5481,14 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jest@^26.0.24":
+  version "26.0.24"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
+  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/js-cookie@^2.2.6":
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"


### PR DESCRIPTION
I re-added Vojta's code from this PR https://github.com/eggheadio/egghead-next/pull/785. 

This PR fixes #793.

The code blocks are now working again. 

![Screen Shot 2021-08-03 at 3 30 08 PM](https://user-images.githubusercontent.com/26470581/128095766-f1f9474a-35e8-4f4a-838c-ef11abcda99a.png)

![](https://media4.giphy.com/media/WS6CDvvyNDrhZRFBtT/giphy.gif?cid=5a38a5a2fec0658gbu5wh3cokr2opeyepgi394bmuuv9tk0e&rid=giphy.gif&ct=g)