### PR TITLE
Fix Notes tab scrolling

### DIFF
--- a/src/components/pages/lessons/collection-lessons-list.tsx
+++ b/src/components/pages/lessons/collection-lessons-list.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {FunctionComponent} from 'react'
-// import {Element, scroller} from 'react-scroll'
+import {Element, scroller} from 'react-scroll'
 import SimpleBar from 'simplebar-react'
 import {LessonResource} from 'types'
 import {get} from 'lodash'
@@ -13,25 +13,29 @@ type NextUpListProps = {
   currentLessonSlug: string
   course: any
   progress: any
+  onActiveTab: boolean
 }
 
 const CollectionLessonsList: FunctionComponent<NextUpListProps> = ({
   course,
   currentLessonSlug,
   progress,
+  onActiveTab,
 }) => {
   const {lessons} = course
   const [activeElement, setActiveElement] = React.useState(currentLessonSlug)
-  // const scrollableNodeRef: any = React.createRef()
+  const scrollableNodeRef: any = React.createRef()
 
   React.useEffect(() => {
     setActiveElement(currentLessonSlug)
-    // scrollableNodeRef.current.id = 'scrollable-container'
-    // scroller.scrollTo(activeElement, {
-    //   duration: 0,
-    //   delay: 0,
-    //   containerId: 'scrollable-container',
-    // })
+    scrollableNodeRef.current.id = 'scrollable-container'
+    if (onActiveTab) {
+      scroller.scrollTo(activeElement, {
+        duration: 0,
+        delay: 0,
+        containerId: 'scrollable-container',
+      })
+    }
   }, [activeElement, setActiveElement, currentLessonSlug])
 
   return lessons ? (
@@ -40,7 +44,7 @@ const CollectionLessonsList: FunctionComponent<NextUpListProps> = ({
         <SimpleBar
           autoHide={false}
           className="h-full"
-          // scrollableNodeProps={{ref: scrollableNodeRef}}
+          scrollableNodeProps={{ref: scrollableNodeRef}}
         >
           <ol
             className="h-full"
@@ -64,7 +68,9 @@ const CollectionLessonsList: FunctionComponent<NextUpListProps> = ({
                 lesson.completed || completedLessons.includes(lesson.slug)
               return (
                 <li key={lesson.slug}>
-                  {/* <Element name={lesson.slug} /> */}
+                  {lesson.slug === currentLessonSlug && (
+                    <Element name={lesson.slug} />
+                  )}
                   <div>
                     <Item
                       active={lesson.slug === currentLessonSlug}

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -111,26 +111,6 @@ const NoteCue: React.FC<any> = ({
   const [clickedOpen, setClickedOpen] = React.useState(false)
   const {muteNotes, activeSidebarTab} = getPlayerPrefs()
 
-  useCue(cue, actions)
-
-  const clickOpen = () => {
-    if (activeSidebarTab === 1) {
-      scrollToActiveNote()
-    }
-    setVisible(true)
-    setClickedOpen(true)
-    // if we seek to the correct time, the note is displayed
-    actions.seek(cue.startTime)
-    actions.pause()
-    track('opened cue', {cue: cue.text})
-    !muteNotes && setPlayerPrefs({activeSidebarTab: 1})
-  }
-
-  const clickClose = () => {
-    setClickedOpen(false)
-    setVisible(false)
-  }
-
   const scrollToActiveNote = () => {
     scroller.scrollTo('active-note', {
       duration: 0,
@@ -138,6 +118,26 @@ const NoteCue: React.FC<any> = ({
       offset: -16,
       containerId: 'notes-tab-scroll-container',
     })
+  }
+
+  useCue(cue, actions)
+
+  const clickOpen = () => {
+    setVisible(true)
+    setClickedOpen(true)
+    // if we seek to the correct time, the note is displayed
+    actions.seek(cue.startTime)
+    actions.pause()
+    track('opened cue', {cue: cue.text})
+    // !muteNotes && setPlayerPrefs({activeSidebarTab: 1})
+    if (activeSidebarTab === 1) {
+      scrollToActiveNote()
+    }
+  }
+
+  const clickClose = () => {
+    setClickedOpen(false)
+    setVisible(false)
   }
 
   const cueActive = player.activeMetadataTrackCues.includes(cue)
@@ -165,12 +165,6 @@ const NoteCue: React.FC<any> = ({
 
   React.useEffect(() => {
     if (visible && activeSidebarTab === 1) {
-      // scroller.scrollTo('active-note', {
-      //   duration: 0,
-      //   delay: 0,
-      //   offset: -16,
-      //   containerId: 'notes-tab-scroll-container',
-      // })
       scrollToActiveNote()
     }
   }, [visible, setPlayerPrefs])

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 import {isEmpty} from 'lodash'
 import Tippy from '@tippyjs/react'
-// import {scroller} from 'react-scroll'
+import {scroller} from 'react-scroll'
 import {useEggheadPlayerPrefs} from 'components/EggheadPlayer/use-egghead-player'
 import ReactMarkdown from 'react-markdown'
 import {track} from 'utils/analytics'
@@ -109,7 +109,7 @@ const NoteCue: React.FC<any> = ({
   const {setPlayerPrefs, getPlayerPrefs} = useEggheadPlayerPrefs()
   const [visible, setVisible] = React.useState(false)
   const [clickedOpen, setClickedOpen] = React.useState(false)
-  const {muteNotes} = getPlayerPrefs()
+  const {muteNotes, activeSidebarTab} = getPlayerPrefs()
 
   useCue(cue, actions)
 
@@ -151,16 +151,16 @@ const NoteCue: React.FC<any> = ({
   const startPosition = `${(cue.startTime / duration) * 100}%`
   const note = cue.text
 
-  // React.useEffect(() => {
-  //   if (visible) {
-  //     scroller.scrollTo('active-note', {
-  //       duration: 0,
-  //       delay: 0,
-  //       offset: -16,
-  //       containerId: 'notes-tab-scroll-container',
-  //     })
-  //   }
-  // }, [visible, setPlayerPrefs])
+  React.useEffect(() => {
+    if (visible && activeSidebarTab === 1) {
+      scroller.scrollTo('active-note', {
+        duration: 0,
+        delay: 0,
+        offset: -16,
+        containerId: 'notes-tab-scroll-container',
+      })
+    }
+  }, [visible, setPlayerPrefs])
 
   return (
     <Tippy

--- a/src/components/player/cue-bar.tsx
+++ b/src/components/player/cue-bar.tsx
@@ -114,6 +114,9 @@ const NoteCue: React.FC<any> = ({
   useCue(cue, actions)
 
   const clickOpen = () => {
+    if (activeSidebarTab === 1) {
+      scrollToActiveNote()
+    }
     setVisible(true)
     setClickedOpen(true)
     // if we seek to the correct time, the note is displayed
@@ -126,6 +129,15 @@ const NoteCue: React.FC<any> = ({
   const clickClose = () => {
     setClickedOpen(false)
     setVisible(false)
+  }
+
+  const scrollToActiveNote = () => {
+    scroller.scrollTo('active-note', {
+      duration: 0,
+      delay: 0,
+      offset: -16,
+      containerId: 'notes-tab-scroll-container',
+    })
   }
 
   const cueActive = player.activeMetadataTrackCues.includes(cue)
@@ -153,12 +165,13 @@ const NoteCue: React.FC<any> = ({
 
   React.useEffect(() => {
     if (visible && activeSidebarTab === 1) {
-      scroller.scrollTo('active-note', {
-        duration: 0,
-        delay: 0,
-        offset: -16,
-        containerId: 'notes-tab-scroll-container',
-      })
+      // scroller.scrollTo('active-note', {
+      //   duration: 0,
+      //   delay: 0,
+      //   offset: -16,
+      //   containerId: 'notes-tab-scroll-container',
+      // })
+      scrollToActiveNote()
     }
   }, [visible, setPlayerPrefs])
 

--- a/src/components/player/player-sidebar.tsx
+++ b/src/components/player/player-sidebar.tsx
@@ -26,6 +26,7 @@ const PlayerSidebar: React.FC<{
 }> = ({videoResource, lessonView, onAddNote}) => {
   const {setPlayerPrefs, getPlayerPrefs} = useEggheadPlayerPrefs()
   const {activeSidebarTab} = getPlayerPrefs()
+  console.log('activeSidebarTab: ', activeSidebarTab)
   return (
     <div className="relative h-full">
       {/* TODO: remove weird logic that assumes 2 tabs */}
@@ -47,6 +48,7 @@ const PlayerSidebar: React.FC<{
             <LessonListTab
               videoResource={videoResource}
               lessonView={lessonView}
+              onActiveTab={activeSidebarTab === 0}
             />
             <NotesTab onAddNote={onAddNote} />
           </div>
@@ -59,7 +61,8 @@ const PlayerSidebar: React.FC<{
 const LessonListTab: React.FC<{
   videoResource: VideoResource
   lessonView?: any
-}> = ({videoResource, lessonView}) => {
+  onActiveTab: boolean
+}> = ({videoResource, lessonView, onActiveTab}) => {
   const hidden: boolean = isEmpty(videoResource.collection)
 
   return hidden ? null : (
@@ -76,6 +79,7 @@ const LessonListTab: React.FC<{
             course={videoResource.collection}
             currentLessonSlug={videoResource.slug}
             progress={lessonView?.collection_progress}
+            onActiveTab={onActiveTab}
           />
         </div>
       </div>

--- a/src/components/player/player-sidebar.tsx
+++ b/src/components/player/player-sidebar.tsx
@@ -7,7 +7,7 @@ import {hasNotes, useNotesCues} from './index'
 import {VideoResource} from 'types'
 import {usePlayer} from 'cueplayer-react'
 import SimpleBar from 'simplebar-react'
-// import {Element} from 'react-scroll'
+import {Element} from 'react-scroll'
 import classNames from 'classnames'
 import ReactMarkdown from 'react-markdown'
 import {convertTime} from 'utils/time-utils'
@@ -93,7 +93,7 @@ const NotesTab: React.FC<any> = ({onAddNote}) => {
   const {cues} = useNotesCues()
   const actions = manager?.getActions()
   const hidden: boolean = isEmpty(cues)
-  // const scrollableNodeRef: any = React.createRef()
+  const scrollableNodeRef: any = React.createRef()
 
   return hidden ? null : (
     <TabPanel className="bg-gray-100 dark:bg-gray-1000 w-full h-96 lg:h-full">
@@ -102,10 +102,10 @@ const NotesTab: React.FC<any> = ({onAddNote}) => {
           <SimpleBar
             forceVisible="y"
             autoHide={false}
-            // scrollableNodeProps={{
-            //   ref: scrollableNodeRef,
-            //   id: 'notes-tab-scroll-container',
-            // }}
+            scrollableNodeProps={{
+              ref: scrollableNodeRef,
+              id: 'notes-tab-scroll-container',
+            }}
             className="h-full overscroll-contain p-4"
           >
             <div className="space-y-3">
@@ -114,7 +114,7 @@ const NotesTab: React.FC<any> = ({onAddNote}) => {
                 const active = player.activeMetadataTrackCues.includes(cue)
                 return (
                   <div key={cue.text}>
-                    {/* {active && <Element name="active-note" />} */}
+                    {active && <Element name="active-note" />}
                     <div
                       className={classNames(
                         'text-sm p-4 bg-white dark:bg-gray-900 rounded-md shadow-sm border-2 border-transparent',


### PR DESCRIPTION
I did some rework related to scroll inside Notes tab inside player sidebar.

Now:

1) it doesn't fail when enter cue with Lessons tab active:
![01-on-lessons-tab](https://user-images.githubusercontent.com/1519448/128398631-462c2410-5fdc-48e0-ac78-90876bd73d67.gif)

2) it doesn't fail when new lesson starts with Notes tab active:
![02-on-notes-tab](https://user-images.githubusercontent.com/1519448/128398716-55c46e29-c37e-4aa9-b85d-52de12d3a9db.gif)

3) Autoscroll to active note works well:
![03-autoscroll-on-play](https://user-images.githubusercontent.com/1519448/128399048-0800a35d-2fab-4aa0-bb3c-794fcca2be52.gif)


The thing I was not able to figure out is that scrolling to active note on click on some cue works after second click only:
![04-scrolls-on-double-click](https://user-images.githubusercontent.com/1519448/128399029-64ed087e-201c-40f2-bcd8-08ed264e63cd.gif)
