### PR TITLE
Add strong confirm modal for ownership transfer

### DIFF
--- a/src/components/team/transfer-ownership-confirm-dialog.tsx
+++ b/src/components/team/transfer-ownership-confirm-dialog.tsx
@@ -4,7 +4,7 @@ import IconX from 'components/icons/icon-x'
 import {State} from 'xstate'
 
 type DialogProps = {
-  current: State<any>
+  current: any
   inviteeEmail: string
   inviteeEmailConfirmation: string
   onClose: () => void

--- a/src/components/team/transfer-ownership-confirm-dialog.tsx
+++ b/src/components/team/transfer-ownership-confirm-dialog.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import {DialogOverlay, DialogContent} from '@reach/dialog'
+import IconX from 'components/icons/icon-x'
+import {State} from 'xstate'
+
+type DialogProps = {
+  current: State<any>
+  inviteeEmail: string
+  inviteeEmailConfirmation: string
+  onClose: () => void
+  onConfirm: () => void
+  handleInputChange: (value: string) => void
+}
+
+const TransferOwnershipConfirmDialog: React.FunctionComponent<DialogProps> = ({
+  current,
+  inviteeEmail,
+  inviteeEmailConfirmation,
+  onClose,
+  onConfirm,
+  handleInputChange,
+}) => {
+  const isOpen = !current.matches('closed')
+  const loading = current.matches({open: 'executingAction'})
+
+  return (
+    <div>
+      <DialogOverlay isOpen={isOpen} onDismiss={onClose}>
+        <DialogContent
+          aria-label="Confirm removing team member"
+          className="bg-white rounded-md border-gray-400"
+          css={{padding: '2rem'}}
+        >
+          <div className="flex justify-center relative mb-6">
+            <h3 className="text-xl font-medium">Are you sure?</h3>
+            <button onClick={onClose} className="absolute right-0 top-0">
+              <IconX className="w-5" />
+            </button>
+          </div>
+          <div className="flex flex-col space-y-4">
+            <p>
+              Confirm that you would like to transfer your ownership of this
+              team account to{' '}
+              <strong className="font-semibold text-gray-800">
+                {inviteeEmail}
+              </strong>{' '}
+              by re-typing their email. Then click 'Confirm'.
+            </p>
+            {current.context.errorMessage && (
+              <p className="text-sm text-red-600">
+                {current.context.errorMessage}
+              </p>
+            )}
+            <input
+              id="email"
+              type="email"
+              value={inviteeEmailConfirmation}
+              onChange={(e) => handleInputChange(e.target.value)}
+              autoFocus
+              required
+              disabled={loading}
+              className="bg-gray-50 dark:bg-gray-800 focus:outline-none focus:shadow-outline border border-gray-100 dark:border-gray-700 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
+            />
+            <div className="flex flex-row justify-end space-x-2">
+              <button
+                disabled={loading || !current.matches({open: 'confirmable'})}
+                onClick={onConfirm}
+                className={`text-white bg-red-600 border-0 py-2 px-4 focus:outline-none rounded-md
+                    ${
+                      loading || !current.matches({open: 'confirmable'})
+                        ? 'cursor-not-allowed opacity-50'
+                        : 'hover:bg-red-700'
+                    }`}
+              >
+                Confirm
+              </button>
+              <button
+                onClick={onClose}
+                disabled={loading}
+                className={`text-gray-700 bg-white border border-1 border-gray-700 py-2 px-4 focus:outline-none rounded-md
+                    ${
+                      loading
+                        ? 'cursor-not-allowed opacity-50'
+                        : 'hover:bg-gray-200'
+                    }`}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </DialogOverlay>
+    </div>
+  )
+}
+
+export default TransferOwnershipConfirmDialog

--- a/src/machines/strong-confirmation-dialog-machine.ts
+++ b/src/machines/strong-confirmation-dialog-machine.ts
@@ -149,17 +149,21 @@ const strongConfirmationDialogMachine = createMachine<
           errorMessage,
         }
       }),
-      clearErrorMessage: assign({
-        errorMessage: undefined,
+      clearErrorMessage: assign((_context) => {
+        return {
+          errorMessage: undefined,
+        }
       }),
-      clearActionFromContext: assign({
-        action: () => Promise.resolve(),
-        invitationDetails: {
-          accountId: undefined,
-          inviteeEmail: '',
-          ownerId: undefined,
-        },
-        inputConfirmText: '',
+      clearActionFromContext: assign((_context) => {
+        return {
+          action: () => Promise.resolve(),
+          invitationDetails: {
+            accountId: undefined,
+            inviteeEmail: '',
+            ownerId: undefined,
+          },
+          inputConfirmText: '',
+        }
       }),
       onSuccess: () => {
         console.log(

--- a/src/machines/strong-confirmation-dialog-machine.ts
+++ b/src/machines/strong-confirmation-dialog-machine.ts
@@ -1,0 +1,178 @@
+import {assign, createMachine} from 'xstate'
+
+export interface StrongConfirmationDialogMachineContext {
+  action?: () => Promise<void>
+  errorMessage?: string
+  doubleConfirmText?: string
+  inputConfirmText: string
+  invitationDetails: {
+    accountId: number | undefined
+    inviteeEmail: string
+    ownerId: string | undefined
+  }
+}
+
+export type StrongConfirmationDialogMachineEvent =
+  | {
+      type: 'OPEN_DIALOG'
+      action: () => Promise<void>
+      invitationDetails: {
+        accountId: number | undefined
+        inviteeEmail: string
+        ownerId: string | undefined
+      }
+      doubleConfirmText?: string
+    }
+  | {
+      type: 'CONFIRM'
+    }
+  | {
+      type: 'CANCEL'
+    }
+  | {
+      type: 'CHANGE'
+      inputConfirmText?: string
+    }
+  | {
+      type: 'REPORT_MATCHING'
+    }
+
+const strongConfirmationDialogMachine = createMachine<
+  StrongConfirmationDialogMachineContext,
+  StrongConfirmationDialogMachineEvent
+>(
+  {
+    id: 'confirmationDialog',
+    initial: 'closed',
+    context: {
+      action: () => Promise.resolve(),
+      invitationDetails: {
+        accountId: undefined,
+        inviteeEmail: '',
+        ownerId: undefined,
+      },
+      inputConfirmText: '',
+    },
+    states: {
+      closed: {
+        id: 'closed',
+        entry: ['clearErrorMessage', 'clearActionFromContext'],
+        on: {
+          OPEN_DIALOG: {
+            target: 'open',
+            actions: 'assignActionToContext',
+          },
+        },
+      },
+      open: {
+        initial: 'idle',
+        on: {
+          CANCEL: {
+            target: '#closed',
+          },
+          CHANGE: {
+            target: '.idle',
+            internal: false,
+            actions: 'handleChangeToInputConfirmText',
+          },
+        },
+        states: {
+          idle: {
+            on: {
+              REPORT_MATCHING: {
+                target: 'confirmable',
+                actions: [],
+              },
+            },
+            invoke: {
+              src: 'checkInputConfirmText',
+              onDone: 'idle',
+            },
+          },
+          confirmable: {
+            on: {
+              CONFIRM: 'executingAction',
+            },
+          },
+          executingAction: {
+            invoke: {
+              src: 'executeAction',
+              onError: {
+                target: 'idle',
+                actions: ['assignErrorMessageToContext', 'onFail'],
+              },
+              onDone: {
+                target: '#closed',
+                actions: ['clearActionFromContext', 'onSuccess'],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    services: {
+      executeAction: (context) => async () => {
+        if (!context.action) return Promise.reject()
+
+        await context.action()
+      },
+      checkInputConfirmText: (context) => (send) => {
+        if (context.doubleConfirmText === context.inputConfirmText) {
+          send('REPORT_MATCHING')
+        }
+      },
+    },
+    actions: {
+      assignActionToContext: assign((_context, event) => {
+        if (event.type !== 'OPEN_DIALOG') return {}
+        return {
+          action: event.action,
+          doubleConfirmText: event.doubleConfirmText,
+        }
+      }),
+      handleChangeToInputConfirmText: assign((_context, event) => {
+        if (event.type !== 'CHANGE') return {}
+        return {
+          inputConfirmText: event.inputConfirmText,
+        }
+      }),
+      assignErrorMessageToContext: assign((_context, event: any) => {
+        const defaultPreamble =
+          'There was an issue sending the ownership transfer invite.'
+        const errorMessage = `${
+          event.data?.response?.data?.error || defaultPreamble
+        } Please contact support@egghead.io if the issue persists.`
+
+        return {
+          errorMessage,
+        }
+      }),
+      clearErrorMessage: assign({
+        errorMessage: undefined,
+      }),
+      clearActionFromContext: assign({
+        action: () => Promise.resolve(),
+        invitationDetails: {
+          accountId: undefined,
+          inviteeEmail: '',
+          ownerId: undefined,
+        },
+        inputConfirmText: '',
+      }),
+      onSuccess: () => {
+        console.log(
+          'Default onSuccess: to be replaced when the machine is interpreted.',
+        )
+      },
+      onFail: () => {
+        console.log(
+          'Default onFail: to be replaced when the machine is interpreted.',
+        )
+      },
+    },
+  },
+)
+
+export default strongConfirmationDialogMachine


### PR DESCRIPTION
Transferring ownership is a "destructive" action, so we want to help the
user be sure that they want to do it and that they have typed the email
of the recipient correctly.

Here is what this **strong** confirmation modal looks like:

https://user-images.githubusercontent.com/694063/130269474-cbb561d0-5ba4-4d5c-b8cb-5deaa3c5361b.mp4

---

![](https://media1.giphy.com/media/7EeTonu0tr2JMAVOmL/200.gif?cid=5a38a5a21b5pi0xaufkfzzg0kny9rsbq2d6qtntw2n9nh8fz&rid=200.gif&ct=g)