### PR TITLE
Updating Sorting Hat tests according to feedback

### DIFF
--- a/src/components/survey/sorting-hat-reducer.test.js
+++ b/src/components/survey/sorting-hat-reducer.test.js
@@ -2,11 +2,11 @@
  * @jest-environment jsdom
  */
 
-import {cioIdentify} from '../cio-identify'
-import {sortingHatReducer, sortingHatInitialState} from '../sorting-hat-reducer'
+import {cioIdentify} from 'utils/cio-identify'
+import {sortingHatReducer, sortingHatInitialState} from './sorting-hat-reducer'
 import {track} from 'utils/analytics'
 
-jest.mock('../cio-identify', () => ({
+jest.mock('utils/cio-identify', () => ({
   cioIdentify: jest.fn(() => null),
 }))
 

--- a/src/components/survey/sorting-hat-reducer.ts
+++ b/src/components/survey/sorting-hat-reducer.ts
@@ -2,7 +2,7 @@ import sortingHatData, {SurveyQuestion} from 'data/sorting-hat'
 import {CIOSubscriber} from 'hooks/use-cio'
 import {track} from 'utils/analytics'
 import {isEmpty} from 'lodash'
-import {cioIdentify} from './cio-identify'
+import {cioIdentify} from 'utils/cio-identify'
 
 const DEFAULT_FIRST_QUESTION = `biggest_path`
 const DEFAULT_FINAL_QUESTION = `thanks`

--- a/src/utils/cio-identify.ts
+++ b/src/utils/cio-identify.ts
@@ -1,4 +1,4 @@
-import {SortingHatState} from './sorting-hat-reducer'
+import {SortingHatState} from 'components/survey/sorting-hat-reducer'
 
 export function cioIdentify(id: string, answers: any, state: SortingHatState) {
   if (id) {


### PR DESCRIPTION
@joelhooks gave me good feedback in #831 -- made those changes here

> why do you prefer `toStrictEqual` over `toEqual`?

It seems appropriate to expect that the returned state doesn't have any unexpected `undefined` properties. Though, I could see how `toStrictEqual` might not be worth the hit in readability/aesthetic.

![](https://media.giphy.com/media/YfOP4V0GugHohdb4US/giphy-downsized.gif?cid=ecf05e478k8gds9pskauvr6jujmnohda2tb3c2oyrx4lmccd&rid=giphy-downsized.gif&ct=g)