### PR TITLE
add note control on player control bar

### DIFF
--- a/src/components/pages/lessons/overlay/add-note-overlay.tsx
+++ b/src/components/pages/lessons/overlay/add-note-overlay.tsx
@@ -6,7 +6,7 @@ import readingTime from 'reading-time'
 import {track} from '../../../../utils/analytics'
 
 const AddNoteOverlay: React.FC<{
-  onClose: any
+  onClose: (newNote: any) => void
   resourceId: string
   currentTime: number
 }> = ({onClose, resourceId, currentTime}) => {

--- a/src/components/player/add-note-control.tsx
+++ b/src/components/player/add-note-control.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import {FunctionComponent} from 'react'
+import {track} from 'utils/analytics'
+import Tippy from '@tippyjs/react'
+import {useViewer} from 'context/viewer-context'
+
+type AddNoteButtonProps = {
+  lesson: any
+  onAddNote?: () => void
+}
+
+type AddNoteControlProps = {
+  lesson: any
+  key: string
+  order: number
+  actions?: any
+  onAddNote?: () => void
+}
+
+const notesCreationAvailable =
+  process.env.NEXT_PUBLIC_NOTES_CREATION_AVAILABLE === 'true'
+
+const NewNoteButton: FunctionComponent<AddNoteButtonProps> = ({
+  lesson,
+  onAddNote,
+}) => {
+  const {viewer} = useViewer()
+  const canCreateNote = viewer?.can_comment && notesCreationAvailable
+  return (
+    <button
+      onClick={() => {
+        if (canCreateNote && onAddNote) {
+          onAddNote()
+        }
+        track(`clicked add note`, {
+          lesson: lesson.slug,
+        })
+      }}
+      aria-label="download video"
+      className={`w-10 h-10 flex items-center justify-center border-none text-white ${
+        !canCreateNote ? 'opacity-50 cursor-default' : ''
+      }`}
+    >
+      Add Note
+    </button>
+  )
+}
+
+const AddNoteControl: FunctionComponent<AddNoteControlProps> = ({
+  lesson,
+  actions,
+  onAddNote,
+}) => {
+  const {viewer} = useViewer()
+  const canCreateNote = viewer?.can_comment && notesCreationAvailable
+
+  return canCreateNote ? (
+    <NewNoteButton
+      lesson={lesson}
+      onAddNote={() => {
+        if (actions) actions.pause()
+        if (onAddNote) onAddNote()
+      }}
+    />
+  ) : (
+    <Tippy content="Notes feature is for members only">
+      <div>
+        <NewNoteButton lesson={lesson} />
+      </div>
+    </Tippy>
+  )
+}
+
+export default AddNoteControl

--- a/src/components/player/index.tsx
+++ b/src/components/player/index.tsx
@@ -28,6 +28,7 @@ import {
 } from 'components/EggheadPlayer/use-egghead-player'
 import {VideoResource} from 'types'
 import {MutableRefObject, SyntheticEvent} from 'react'
+import AddNoteControl from './add-note-control'
 
 export type VideoResourcePlayerProps = {
   videoResource: VideoResource
@@ -41,6 +42,7 @@ export type VideoResourcePlayerProps = {
   onFullscreenChange?: (isFullscreen: boolean) => void
   onEnded?: () => void
   onVolumeChange?: (event: any) => void
+  onAddNote?: () => void
   newNotes?: any[]
   hidden?: boolean
   className?: string
@@ -57,6 +59,7 @@ const VideoResourcePlayer: React.FC<VideoResourcePlayerProps> = ({
   onFullscreenChange,
   onLoadStart,
   newNotes,
+  onAddNote,
   ...props
 }) => {
   const {setPlayerPrefs, getPlayerPrefs} = useEggheadPlayerPrefs()
@@ -170,15 +173,21 @@ const VideoResourcePlayer: React.FC<VideoResourcePlayerProps> = ({
               setPlayerPrefs({playbackRate})
             }}
           />
+          <AddNoteControl
+            key="add-note-control"
+            order={11}
+            lesson={videoResource}
+            onAddNote={onAddNote}
+          />
           <DownloadControl
             key="download-control"
-            order={11}
+            order={12}
             lesson={videoResource}
           />
           {videoResource.subtitles_url && (
             <ClosedCaptionButton
               key={videoResource.subtitles_url}
-              order={12}
+              order={13}
               selected={subtitle}
               onChange={(track?: TextTrack) => {
                 const updatedSubtitlePref = track
@@ -201,7 +210,7 @@ const VideoResourcePlayer: React.FC<VideoResourcePlayerProps> = ({
           <FullscreenToggle
             key="fullscreen-toggle"
             fullscreenElement={containerRef?.current}
-            order={13}
+            order={14}
             onFullscreenChange={onFullscreenChange}
           />
         </ControlBar>

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -489,6 +489,9 @@ const Lesson: FunctionComponent<LessonProps> = ({initialLesson}) => {
                     console.debug(`received ended event from player`)
                     send('COMPLETE')
                   }}
+                  onAddNote={() => {
+                    send('ADD_NOTE')
+                  }}
                 />
               </PlayerContainer>
               {spinnerVisible && (


### PR DESCRIPTION
this isn't perfect visually, but it at least isn't hidden by default and brings the context of note creation **into the player** more instead of buried to the side. 

![Image 2021-08-24 at 6 30 03 PM](https://user-images.githubusercontent.com/86834/130711490-89561b1d-fb37-4af6-9364-188bde7cb74e.jpg)

![man taking notes](https://media.giphy.com/media/uDZexRVCffGww/giphy.gif?cid=ecf05e47f8heemsxm4zuq2jf1qhyqqg5zfu0nzie155s35ur&rid=giphy.gif&ct=g)