### PR TITLE
Rebirth of the In Progress component

### DIFF
--- a/src/components/pages/home/in-progress-section/index.tsx
+++ b/src/components/pages/home/in-progress-section/index.tsx
@@ -18,7 +18,7 @@ const InProgressSection: FunctionComponent<InProgressSectionProps> = ({
   coursesInProgress,
 }) => {
   return (
-    <section className="pt-4 pb-10">
+    <section className="pt-4 pb-12">
       <div className="flex justify-between align-text-top">
         <h2 className="md:text-xl text-lg mb-4 text-left">
           {isEmpty(viewer.name) ? (

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -2,10 +2,12 @@ import React, {FunctionComponent} from 'react'
 import {Card} from 'components/card'
 import Link from 'next/link'
 import Image from 'next/image'
-import {map, get, isEmpty} from 'lodash'
+import {map, get, first, isEmpty} from 'lodash'
 
 import Markdown from 'react-markdown'
 import {useViewer} from 'context/viewer-context'
+import InProgressSection from 'components/pages/home/in-progress-section'
+
 import useEggheadSchedule, {ScheduleEvent} from 'hooks/use-egghead-schedule'
 import {loadUserProgress} from 'lib/users'
 import {track} from 'utils/analytics'
@@ -23,6 +25,8 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
   const location = 'home landing'
   const {viewer, loading} = useViewer()
   const [progress, setProgress] = React.useState<any>([])
+  const currentCourse: any = first(progress)
+  const coursesInProgress: any = progress.slice(1, 3)
 
   const video: any = get(homePageData, 'video')
   let featured: any = get(homePageData, 'featured.resources', {})
@@ -66,7 +70,20 @@ const Home: FunctionComponent<any> = ({homePageData}) => {
 
   return (
     <>
-      <div className="mt-8">
+      <div className="mb-32">
+        {console.log(currentCourse)}
+        {console.log(viewer)}
+        <div>
+          {currentCourse && viewer && (
+            <InProgressSection
+              viewer={viewer}
+              progress={progress}
+              currentCourse={currentCourse}
+              coursesInProgress={coursesInProgress}
+            />
+          )}
+        </div>
+
         <WhatsNew resource={featureWhatsNew} />
 
         <section className="mt-32">

--- a/src/components/pages/users/dashboard/activity/in-progress-resource.tsx
+++ b/src/components/pages/users/dashboard/activity/in-progress-resource.tsx
@@ -90,8 +90,8 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
               <Image
                 src={image_url}
                 alt={title}
-                width={small ? 72 : square_cover_480_url ? 160 : 48}
-                height={small ? 72 : square_cover_480_url ? 160 : 48}
+                width={small ? 84 : square_cover_480_url ? 160 : 48}
+                height={small ? 84 : square_cover_480_url ? 160 : 48}
               />
             </a>
           </Link>
@@ -111,7 +111,7 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
               >
                 <h3
                   className={`${
-                    small ? 'text-lg' : 'text-xl'
+                    small ? 'text-md sm:text-lg' : 'text-lg sm:text-xl'
                   } font-semibold leading-tight`}
                 >
                   {title}

--- a/src/components/pages/users/dashboard/activity/in-progress-resource.tsx
+++ b/src/components/pages/users/dashboard/activity/in-progress-resource.tsx
@@ -90,8 +90,8 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
               <Image
                 src={image_url}
                 alt={title}
-                width={small ? 84 : square_cover_480_url ? 160 : 48}
-                height={small ? 84 : square_cover_480_url ? 160 : 48}
+                width={small ? 84 : square_cover_480_url ? 200 : 48}
+                height={small ? 84 : square_cover_480_url ? 200 : 48}
               />
             </a>
           </Link>
@@ -111,7 +111,7 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
               >
                 <h3
                   className={`${
-                    small ? 'text-md sm:text-lg' : 'text-lg sm:text-xl'
+                    small ? 'text-md sm:text-lg' : 'text-xl'
                   } font-semibold leading-tight`}
                 >
                   {title}
@@ -124,7 +124,7 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
           </div>
 
           {isInProgress && (
-            <h2 className="uppercase font-semibold text-xs text-gray-600 dark:text-gray-300 pb-1">
+            <h2 className="uppercase font-semibold text-xs text-gray-500 dark:text-gray-400 pb-2">
               {lessons_left} lessons left
               <span className="lowercase font-normal">
                 {time_left ? ` (${convertTimeWithTitles(time_left)} left)` : ''}
@@ -136,7 +136,7 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
             <div className="flex items-center space-x-1">
               <Link href={resource_path || '#'}>
                 <a
-                  className="text-teal-500 dark:text-teal-600 flex bg-white rounded-full"
+                  className="text-teal-500 dark:text-teal-600 flex hover:text-teal-600 transition-all hover:scale-110 ease-in-out bg-white rounded-full"
                   onClick={() =>
                     track(`clicked continue watching`, {
                       slug: slug,
@@ -149,14 +149,7 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
                 </a>
               </Link>
 
-              {/* <div className="relative w-full h-2 bg-gray-200 dark:bg-gray-600 overflow-hidden rounded-sm">
-                <div
-                  style={{width: `${percent_complete}%`}}
-                  className="absolute left-0 top-0 bg-blue-600 h-full"
-                />
-              </div> */}
-
-              <div className="flex relative w-full h-2 bg-gray-200 dark:bg-gray-600 overflow-hidden rounded-sm">
+              <div className="flex relative w-full h-2 overflow-hidden rounded-sm">
                 {allLessons.map((lesson: any) => {
                   const isComplete = completedLessonSlugs.includes(lesson.slug)
                   return (
@@ -166,9 +159,9 @@ const InProgressResource: FunctionComponent<InProgressResourceProps> = ({
                         style={{width: `${100 / allLessons.length}%`}}
                         className={`${
                           isComplete
-                            ? 'dark:bg-teal-500 dark:hover:bg-teal-600 bg-teal-400 hover:bg-teal-500'
-                            : 'dark:bg-gray-500 dark:hover:bg-gray-400 bg-gray-200 hover:bg-gray-300'
-                        } h-full border dark:border-gray-800 border-white transition-colors ease-in-out duration-200`}
+                            ? 'dark:bg-teal-400 dark:hover:bg-teal-500 bg-teal-400 hover:bg-teal-500 border dark:border-gray-800 '
+                            : 'dark:bg-gray-500 dark:hover:bg-gray-400 bg-gray-200 border dark:border-gray-800 hover:bg-gray-300 '
+                        } h-full rounded-xl border-white ease-in-out transition-all hover:scale-105 duration-200`}
                       />
                     </Link>
                   )

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -20,7 +20,7 @@ const WhatsNewPage: FunctionComponent<any> = ({
   ] = secondary.resources
 
   return (
-    <section className="sm:-my-5 -my-3 mx-auto max-w-screen-xl">
+    <section className=" mx-auto max-w-screen-xl">
       <h2 className="md:text-xl text-lg sm:font-semibold font-bold mb-3 dark:text-white">
         What's New
       </h2>


### PR DESCRIPTION
A reimplementation of PR #551

We ran into some technical issues with the first attempt that should be resolved now. Context: https://github.com/eggheadio/egghead-next/issues/842

Component will appear when users are logged in and have current courses in progress:

![image](https://user-images.githubusercontent.com/5599295/130766924-312f2588-e9b1-419f-b319-5ed40333267f.png)

![image](https://user-images.githubusercontent.com/5599295/130766937-0dc107e7-a6fc-416a-8de3-9b410e5f69b0.png)


### 📹 Preview of interaction: https://share.getcloudapp.com/qGuJl8W0

Since the last attempt at doing this caused issues for a number of users, how can be stress test this to make sure it's not going to break the experience for anyone?