### PR TITLE
Added metadata to bookmarks

### DIFF
--- a/src/pages/bookmarks/index.tsx
+++ b/src/pages/bookmarks/index.tsx
@@ -101,7 +101,7 @@ const Bookmarks: React.FunctionComponent<LoginRequiredParams> = ({
                       </button>
                     </div>
 
-                    <div className="text-sm text-gray-600 dark:text-gray-500">
+                    <div className="text-sm text-gray-600 dark:text-gray-400">
                       {bookmark.duration &&
                         `${convertTimeWithTitles(bookmark.duration)} • `}
                       {bookmark.instructor.full_name}

--- a/src/pages/bookmarks/index.tsx
+++ b/src/pages/bookmarks/index.tsx
@@ -54,9 +54,9 @@ const Bookmarks: React.FunctionComponent<LoginRequiredParams> = ({
           Your Bookmarks
         </h1>
         {loadingBookmarks || isEmpty(bookmarks) ? (
-          <div>
+          <div className="text-gray-600 dark:text-gray-400">
             {loadingBookmarks
-              ? 'loading...'
+              ? 'Loading...'
               : `You haven't bookmarked any courses yet.`}
           </div>
         ) : (
@@ -84,7 +84,7 @@ const Bookmarks: React.FunctionComponent<LoginRequiredParams> = ({
                       </Link>
                       <button
                         aria-label="remove"
-                        className="text-gray-600 hover:text-gray-900 bg-white hover:bg-gray-200 p-2 transition-colors rounded-full duration-200 ease-in-out"
+                        className="text-gray-600 hover:text-gray-900 dark:hover:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 p-2 transition-colors rounded-full duration-200 ease-in-out"
                         onClick={(e) => {
                           e.preventDefault()
                           axios.post(bookmark.toggle_favorite_url)
@@ -101,7 +101,7 @@ const Bookmarks: React.FunctionComponent<LoginRequiredParams> = ({
                       </button>
                     </div>
 
-                    <div className="text-sm text-gray-600">
+                    <div className="text-sm text-gray-600 dark:text-gray-500">
                       {bookmark.duration &&
                         `${convertTimeWithTitles(bookmark.duration)} • `}
                       {bookmark.instructor.full_name}

--- a/src/pages/bookmarks/index.tsx
+++ b/src/pages/bookmarks/index.tsx
@@ -6,9 +6,11 @@ import Link from 'next/link'
 import Image from 'next/image'
 import {reject, isEmpty} from 'lodash'
 import {track} from 'utils/analytics'
+import {convertTimeWithTitles} from 'utils/time-utils'
 import LoginRequired, {LoginRequiredParams} from 'components/login-required'
 import {GetServerSideProps} from 'next'
 import {getTokenFromCookieHeaders} from '../../utils/auth'
+import {XIcon} from '@heroicons/react/solid'
 
 export const getServerSideProps: GetServerSideProps = async function ({
   req,
@@ -47,53 +49,64 @@ const Bookmarks: React.FunctionComponent<LoginRequiredParams> = ({
 
   return (
     <LoginRequired loginRequired={loginRequired}>
-      <div className="mb-32 max-w-screen-md w-full mx-auto">
-        <h1 className="sm:text-3xl text-xl font-bold mb-3 leading-tight">
+      <div className="mt-8 mb-28 max-w-screen-md w-full mx-auto">
+        <h1 className="sm:text-2xl text-xl font-bold mb-6 leading-tight">
           Your Bookmarks
         </h1>
         {loadingBookmarks || isEmpty(bookmarks) ? (
           <div>
             {loadingBookmarks
               ? 'loading...'
-              : `You don't have any content bookmarked to watch later.`}
+              : `You haven't bookmarked any courses yet.`}
           </div>
         ) : (
-          <ul className="space-y-5">
+          <ul className="space-y-6">
             {bookmarks.map((bookmark: any) => {
               return (
-                <li className="flex items-center space-x-2" key={bookmark.slug}>
+                <li className="flex items-center space-x-5" key={bookmark.slug}>
                   {bookmark.square_cover_128_url && (
                     <div className="flex items-center flex-shrink-0">
                       <Image
-                        width={32}
-                        height={32}
+                        width={48}
+                        height={48}
                         src={bookmark.square_cover_128_url}
                       />
                     </div>
                   )}
-                  <Link href={bookmark.path}>
-                    <a className="group inline-flex items-center space-x-2">
-                      <div className="group-hover:underline font-medium md:text-lg text-normal leading-tight">
-                        {bookmark.title}
-                      </div>
-                    </a>
-                  </Link>
-                  <button
-                    className="rounded text-xs px-2 py-1 justify-center items-center text-black dark:text-white bg-gray-100 dark:bg-gray-800 hover:bg-gray-200  dark:hover:bg-gray-700 transition-colors duration-150 ease-in-out "
-                    onClick={(e) => {
-                      e.preventDefault()
-                      axios.post(bookmark.toggle_favorite_url)
-                      const lessBookmarks = reject(bookmarks, {
-                        slug: bookmark.slug,
-                      }) as []
-                      track('removed bookmark', {
-                        resource: bookmark.slug,
-                      })
-                      setBookmarks(lessBookmarks)
-                    }}
-                  >
-                    remove
-                  </button>
+                  <div className="flex flex-col">
+                    <div className="flex space-x-2">
+                      <Link href={bookmark.path}>
+                        <a className="group inline-flex items-center space-x-2">
+                          <div className="group-hover:underline font-medium md:text-lg text-normal leading-tight">
+                            {bookmark.title}
+                          </div>
+                        </a>
+                      </Link>
+                      <button
+                        aria-label="remove"
+                        className="text-gray-600 hover:text-gray-900 bg-white hover:bg-gray-200 p-2 transition-colors rounded-full duration-200 ease-in-out"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          axios.post(bookmark.toggle_favorite_url)
+                          const lessBookmarks = reject(bookmarks, {
+                            slug: bookmark.slug,
+                          }) as []
+                          track('removed bookmark', {
+                            resource: bookmark.slug,
+                          })
+                          setBookmarks(lessBookmarks)
+                        }}
+                      >
+                        <XIcon className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    </div>
+
+                    <div className="text-sm text-gray-600">
+                      {bookmark.duration &&
+                        `${convertTimeWithTitles(bookmark.duration)} • `}
+                      {bookmark.instructor.full_name}
+                    </div>
+                  </div>
                 </li>
               )
             })}


### PR DESCRIPTION
This adds metadata and some minor quality of life styling improvements to the bookmarks page.

- Adds instructor and course length information to bookmarked content
- Adjusts page spacing and styling

### Previous bookmarks page:

<img width="1117" alt="Screenshot - 2021-08-30 16 57 34" src="https://user-images.githubusercontent.com/5599295/131371969-18cda911-0428-4c2c-9bce-c66a183dfb3d.png">

### Revised bookmarks page:

<img width="1108" alt="Screenshot - 2021-08-30 16 56 42" src="https://user-images.githubusercontent.com/5599295/131371974-8b329a77-6830-49ed-aa52-98c48c3dac87.png">

![image](https://user-images.githubusercontent.com/5599295/131373334-3595ac86-c291-4ed5-938f-c19b2153b407.png)

Just a small step in the direction of building out this page into a more robust dashboard for learners.

---

![](https://media4.giphy.com/media/Oo1MAs4PmdkJO/giphy.gif)