### PR TITLE
Created standardised button components

### DIFF
--- a/src/components/app/header/header-button-shaped-link.tsx
+++ b/src/components/app/header/header-button-shaped-link.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import Link from 'next/link'
 import noop from 'utils/noop'
 import {PrimaryButton} from 'components/buttons/index'
 

--- a/src/components/app/header/header-button-shaped-link.tsx
+++ b/src/components/app/header/header-button-shaped-link.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import Link from 'next/link'
 import noop from 'utils/noop'
+import {PrimaryButton} from 'components/buttons/index'
 
 type HeaderButtonShapedLinkProps = {
   url: string
@@ -14,15 +15,11 @@ export const HeaderButtonShapedLink: React.FC<HeaderButtonShapedLinkProps> = ({
   onClick = noop,
 }) => {
   return (
-    <div className="hidden lg:block">
-      <Link href={url}>
-        <a
-          onClick={onClick}
-          className="inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white transition-all hover:bg-blue-700 ease-in-out duration-200"
-        >
-          {label}
-        </a>
-      </Link>
-    </div>
+    <PrimaryButton
+      className="hidden lg:block"
+      url={url}
+      onClick={onClick}
+      label={label}
+    />
   )
 }

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export function PrimaryButton({className = '', children}) {
+  return (
+    <button
+      className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function SecondaryButton({className = '', children}) {
+  return (
+    <button
+      className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -39,10 +39,10 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
     <Link href={url}>
       <a
         onClick={onClick}
-        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md text-gray-600 font-normal transition-all   hover:text-gray-800 ease-in-out duration-200 mt-12 ${
+        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md  font-normal transition-all   hover:text-gray-800 ease-in-out duration-200 mt-12 ${
           quiet
-            ? 'hover:bg-gray-100'
-            : 'hover:bg-gray-50 border border-gray-50 bg-white shadow-sm hover:shadow'
+            ? 'hover:bg-gray-100 text-gray-700'
+            : 'hover:bg-gray-50 text-gray-600 border border-gray-100 bg-white shadow-sm hover:shadow'
         }`}
       >
         {label}

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -6,6 +6,7 @@ type ButtonProps = {
   url: string
   label: string
   className?: string
+  quiet?: boolean
   onClick?: () => void
 }
 
@@ -27,17 +28,22 @@ export const PrimaryButton: React.FC<ButtonProps> = ({
   )
 }
 
-export const Secondary: React.FC<ButtonProps> = ({
+export const SecondaryButton: React.FC<ButtonProps> = ({
   url,
   className,
   label,
+  quiet,
   onClick = noop,
 }) => {
   return (
     <Link href={url}>
       <a
         onClick={onClick}
-        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
+        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md text-gray-600 font-normal transition-all   hover:text-gray-800 ease-in-out duration-200 mt-12 ${
+          quiet
+            ? 'hover:bg-gray-100'
+            : 'hover:bg-gray-50 border border-gray-50 bg-white shadow-sm hover:shadow'
+        }`}
       >
         {label}
       </a>

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -1,21 +1,46 @@
-import React from 'react'
+import * as React from 'react'
+import Link from 'next/link'
+import noop from 'utils/noop'
 
-export function PrimaryButton({className = '', children}) {
+type ButtonProps = {
+  url: string
+  label: string
+  className?: string
+  onClick?: () => void
+}
+
+export const PrimaryButton: React.FC<ButtonProps> = ({
+  url,
+  className,
+  label,
+  onClick = noop,
+}) => {
   return (
-    <button
-      className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
-    >
-      {children}
-    </button>
+    <Link href={url}>
+      <a
+        onClick={onClick}
+        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
+      >
+        {label}
+      </a>
+    </Link>
   )
 }
 
-export function SecondaryButton({className = '', children}) {
+export const Secondary: React.FC<ButtonProps> = ({
+  url,
+  className,
+  label,
+  onClick = noop,
+}) => {
   return (
-    <button
-      className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
-    >
-      {children}
-    </button>
+    <Link href={url}>
+      <a
+        onClick={onClick}
+        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
+      >
+        {label}
+      </a>
+    </Link>
   )
 }

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -20,7 +20,7 @@ export const PrimaryButton: React.FC<ButtonProps> = ({
     <Link href={url}>
       <a
         onClick={onClick}
-        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 ease-in-out duration-200`}
+        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium transition-all hover:bg-blue-800 dark:hover:bg-blue-500 ease-in-out duration-200`}
       >
         {label}
       </a>
@@ -39,10 +39,10 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
     <Link href={url}>
       <a
         onClick={onClick}
-        className={`${className} inline-flex justify-center items-center px-4 py-2 rounded-md  font-normal transition-all   hover:text-gray-800 ease-in-out duration-200 mt-12 ${
+        className={`${className}  inline-flex justify-center items-center px-4 py-2 rounded-md font-normal transition-all   hover:text-gray-800 ease-in-out duration-200 ${
           quiet
-            ? 'hover:bg-gray-100 text-gray-700'
-            : 'hover:bg-gray-50 text-gray-600 border border-gray-100 bg-white shadow-sm hover:shadow'
+            ? 'hover:bg-gray-100 text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:border-gray-600'
+            : 'hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-200 border dark:border-gray-600 border-gray-100 dark:bg-gray-700 bg-white shadow-sm hover:shadow'
         }`}
       >
         {label}


### PR DESCRIPTION
## Context

The button styles across our site are declared individually in every location. This leads to lots of repetitive code and inconsistencies in the way our buttons look and behave. 

We've discussed this in the past, but decided it's not high on our priority list to go through all the existing code to update old buttons.

However, that shouldn't prevent us from improving button consistency in the future. It's much easier to have single components like `<PrimaryButton />` and `<SecondaryButton />` we can import and know the styles will be consistent across instances. It's also faster to import these rather than hunt for one of multiple button styles + functionality sets to copypasta every time we need a new button.

We can use these new components on future pages and features without any obligation to backfill the codebase with them.

This PR adds two buttons to the codebase – `<PrimaryButton />` and `<SecondaryButton />`

Both take props for `label`, `url`, `onClick` (optional), and `className` (optional)

The secondary button also takes an optional `quiet` prop that makes it slightly less visually dominant.

Preview:

![Build the portfolio you need to be a badass web developer  egghead io 2021-09-13 at 12 19 59 pm](https://user-images.githubusercontent.com/5599295/133074875-fca2dc7f-5831-4fa4-b1ab-eb3e27d73a9e.jpg)

![Build the portfolio you need to be a badass web developer  egghead io 2021-09-13 at 12 19 49 pm](https://user-images.githubusercontent.com/5599295/133074866-5691e316-8328-407e-a963-f85f3ee160de.jpg)


Hover states:
![Screen Recording 2021-09-13 at 12 18 51 pm](https://user-images.githubusercontent.com/5599295/133074777-b506a820-cde0-44fc-ad05-e3cbfdea9ebe.gif)

## TODO

- [x] Check TypeScript components for errors / bugs (I wrote them and I'm a TS n00b)