### PR TITLE
Refactor styles on search result pages

### DIFF
--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -122,8 +122,8 @@ const FooterNavigation: FunctionComponent = () => {
 
 const Footer: FunctionComponent = () => {
   return (
-    <div className="bg-gray-50 dark:bg-gray-900 print:hidden dark:text-gray-200">
-      <footer className="max-w-screen-xl w-full mx-auto xl:px-0 px-5">
+    <div className="bg-gray-50 dark:bg-gray-900 print:hidden dark:text-gray-200 px-5">
+      <footer className="max-w-screen-xl w-full mx-auto">
         <FooterNavigation />
         <small className="space-x-6 py-6 text-xs w-full flex items-center md:justify-end justify-center text-gray-500 dark:text-gray-300">
           <div>©egghead.io</div>

--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -163,7 +163,7 @@ const Header: FunctionComponent = () => {
 
   return (
     <>
-      <header className="h-16 px-5 py-5 sm:mb-5 mb-3 dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between print:hidden dark:text-gray-100">
+      <header className="h-16 px-5 py-5 dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between print:hidden dark:text-gray-100">
         <div className="flex items-center justify-between w-full max-w-screen-xl mx-auto space-x-4">
           <div className="flex items-center">
             <Link href="/">

--- a/src/components/app/main.tsx
+++ b/src/components/app/main.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react'
 import {FunctionComponent} from 'react'
 
-const Main: FunctionComponent = ({children}) => {
+type MainProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+const Main: FunctionComponent<MainProps> = ({children, className = ''}) => {
   return (
-    <div className="w-full flex flex-col flex-grow px-5 dark:bg-gray-900 dark:text-gray-100">
+    <div
+      className={`w-full flex flex-col flex-grow px-5 dark:bg-gray-900 dark:text-gray-100 sm:py-5 py-3 ${className}`}
+    >
       {children}
     </div>
   )

--- a/src/components/app/main.tsx
+++ b/src/components/app/main.tsx
@@ -9,7 +9,7 @@ type MainProps = {
 const Main: FunctionComponent<MainProps> = ({children, className = ''}) => {
   return (
     <div
-      className={`w-full flex flex-col flex-grow px-5 dark:bg-gray-900 dark:text-gray-100 sm:py-5 py-3 ${className}`}
+      className={`w-full flex flex-col flex-grow px-5 dark:bg-gray-900 dark:text-gray-100 py-5 ${className}`}
     >
       {children}
     </div>

--- a/src/components/search/components/hit/index.tsx
+++ b/src/components/search/components/hit/index.tsx
@@ -43,7 +43,7 @@ const HitComponent: FunctionComponent<HitComponentProps> = ({hit}) => {
             >
               <Image
                 src={image}
-                className={type === 'lesson' ? 'opacity-70' : ''}
+                className={type === 'lesson' ? 'opacity-90' : ''}
                 layout="fill"
               />
             </a>

--- a/src/components/search/components/hit/index.tsx
+++ b/src/components/search/components/hit/index.tsx
@@ -38,7 +38,9 @@ const HitComponent: FunctionComponent<HitComponentProps> = ({hit}) => {
                 })
               }}
               className={`flex-shrink-0 relative ${
-                type === 'lesson' ? 'w-8 h-8 opacity-70' : 'w-20 h-20'
+                type === 'lesson'
+                  ? 'w-8 h-8 opacity-70'
+                  : 'w-16 h-16 md:w-20 md:h-20'
               }`}
             >
               <Image

--- a/src/components/search/components/hit/index.tsx
+++ b/src/components/search/components/hit/index.tsx
@@ -37,13 +37,14 @@ const HitComponent: FunctionComponent<HitComponentProps> = ({hit}) => {
                   [type]: slug,
                 })
               }}
-              className="flex-shrink-0"
+              className={`flex-shrink-0 relative ${
+                type === 'lesson' ? 'w-8 h-8 opacity-70' : 'w-20 h-20'
+              }`}
             >
               <Image
                 src={image}
                 className={type === 'lesson' ? 'opacity-70' : ''}
-                width={type === 'lesson' ? 28 : 96}
-                height={type === 'lesson' ? 28 : 96}
+                layout="fill"
               />
             </a>
           </Link>

--- a/src/components/search/curated/angular/index.tsx
+++ b/src/components/search/curated/angular/index.tsx
@@ -40,7 +40,7 @@ const SearchAngular = () => {
   })
 
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+    <div className="mb-6 pb-6 md:mb-10 md:pb-10">
       <NextSeo
         description={description}
         title={title}
@@ -91,7 +91,7 @@ It’s worth an hour or so of your time to see what’s up!`}
         location={location}
       />
 
-      <div className="mt-5 md:bg-gray-100 dark:bg-gray-700 rounded-lg py-10 p-5">
+      <div className="mt-5 md:bg-gray-100 dark:bg-gray-700 rounded-lg px-0 md:px-5 py-5">
         <h1 className="md:text-3xl text-2xl dark:text-gray-100 font-bold leading-tight text-center mb-4">
           State Management in Angular
         </h1>

--- a/src/components/search/curated/aws/index.tsx
+++ b/src/components/search/curated/aws/index.tsx
@@ -33,7 +33,7 @@ const SearchAWS = () => {
   })
 
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+    <div className="mb-6 pb-6 md:mb-10 md:pb-10">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/css/index.tsx
+++ b/src/components/search/curated/css/index.tsx
@@ -18,7 +18,7 @@ const SearchCSS = () => {
   const animation: any = find(resources, {slug: {current: 'css-animation'}})
 
   return (
-    <main className="max-w-screen-xl px-5 mx-auto lg:px-0">
+    <>
       <SearchCuratedEssential
         verticalImage={data?.image}
         topic={{
@@ -43,10 +43,10 @@ const SearchCSS = () => {
           )
         })}
       </div>
-      <div className="grid grid-cols-2 gap-5 mt-5 md:gap-8 md:mt-8">
+      <div className="grid md:grid-cols-2 gap-5 mt-5 md:gap-8 md:mt-8">
         <VerticalResourceCollectionCard resource={{...animation, name: ''}} />
       </div>
-    </main>
+    </>
   )
 }
 

--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -48,7 +48,7 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
   const advanced: any = find(pageData, {id: 'advanced'})
 
   return (
-    <div className="sm:pb-8 pb-5 max-w-screen-xl lg:mx-auto mx-5 dark:bg-gray-900">
+    <div className="sm:pb-8 pb-5 dark:bg-gray-900">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/curated-essential.tsx
+++ b/src/components/search/curated/curated-essential.tsx
@@ -48,7 +48,7 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
   const advanced: any = find(pageData, {id: 'advanced'})
 
   return (
-    <div className="sm:pb-8 pb-5 dark:bg-gray-900">
+    <>
       <NextSeo
         description={description}
         title={title}
@@ -90,7 +90,7 @@ const SearchCuratedEssential: React.FC<CuratedEssentialProps> = ({
         location={location}
       />
       {children}
-    </div>
+    </>
   )
 }
 

--- a/src/components/search/curated/graphql/index.tsx
+++ b/src/components/search/curated/graphql/index.tsx
@@ -27,7 +27,7 @@ const SearchGraphql = () => {
   })
 
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+    <div className="mb-6 pb-6 md:mb-10 md:pb-10">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/javascript/index.tsx
+++ b/src/components/search/curated/javascript/index.tsx
@@ -42,7 +42,7 @@ const SearchJavaScript = () => {
   })
 
   return (
-    <div className="mb-10 pb-10 py-5 xl:px-0 px-5 max-w-screen-xl mx-auto">
+    <div className="mb-6 pb-6 md:mb-10 md:pb-10">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/node/index.tsx
+++ b/src/components/search/curated/node/index.tsx
@@ -30,7 +30,7 @@ const SearchNode = () => {
   })
 
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+    <div className="mb-6 pb-6 md:mb-10 md:pb-10">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/react/index.tsx
+++ b/src/components/search/curated/react/index.tsx
@@ -38,7 +38,7 @@ const SearchReact = ({topic}: any) => {
 
   const recoilCollection = get(topic?.reactStateManagement, 'recoilCollection')
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+    <div className="mb-6 pb-6 md:mb-10 md:pb-10">
       <NextSeo
         description={description}
         title={title}

--- a/src/components/search/curated/typescript/index.tsx
+++ b/src/components/search/curated/typescript/index.tsx
@@ -34,7 +34,7 @@ Love them or hate them, static types are here to stay, and at the very least an 
       pageData={typescriptPageData}
       CTAComponent={CourseFeatureCard}
     >
-      <div className="mb-10 pb-10 xl:px-0 max-w-screen-xl mx-2">
+      <div className="mb-6 pb-6 md:mb-10 md:pb-10">
         {/* Featured Section */}
         <section className="grid lg:grid-cols-12 grid-cols-1 items-start mt-12 ">
           <div className="md:col-span-8 mr-0 md:mr-5">

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -215,9 +215,9 @@ const Search: FunctionComponent<SearchProps> = ({
           <div className="dark:bg-gray-900 bg-gray-50  md:-mt-5">
             <ScrollTo scrollOn="page" />
 
-            <div className="flex flex-col-reverse md:flex-row justify-between items-center pb-4 md:pb-2 mb-6 border-b border-gray-200">
+            <div className="flex flex-col-reverse md:flex-row justify-between items-center pb-4 md:pb-2 mb-4 md:mb-6 border-b border-gray-200">
               <Stats searchQuery={searchState.query} />
-              <div className="flex space-x-2 items-center flex-nowrap flex-shrink-0 md:ml-6 mb-5 md:mb-0">
+              <div className="flex space-x-2 items-center flex-nowrap flex-shrink-0 md:ml-6">
                 <div className="font-bold whitespace-nowrap flex-shrink-0">
                   Sort by:
                 </div>

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -196,7 +196,7 @@ const Search: FunctionComponent<SearchProps> = ({
             )}
           </div>
           {!isEmpty(instructor) && (
-            <div className="mb-10 pb-8 xl:px-0 px-5 mx-auto dark:bg-gray-900">
+            <div className="mb-10 pb-8">
               {shouldDisplayLandingPageForInstructor(instructor.slug) && (
                 <InstructorCuratedPage instructor={instructor} />
               )}

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -104,7 +104,7 @@ const Search: FunctionComponent<SearchProps> = ({
     topic && (CuratedTopicsIndex[topic.name] || SearchCuratedEssential)
 
   return (
-    <>
+    <div className="max-w-screen-xl mx-auto">
       <Head>
         <link
           rel="stylesheet"
@@ -119,12 +119,9 @@ const Search: FunctionComponent<SearchProps> = ({
         {...rest}
       >
         <Configure hitsPerPage={config.searchResultCount} />
-        <div className="sm:pb-16 pb-8 space-y-8 bg-gray-50 dark:bg-gray-900 -mx-5">
-          <div
-            className="max-w-screen-xl md:-mt-5 -mt-3 pt-5 mx-auto"
-            ref={refinementRef}
-          >
-            <header className="flex xl:px-0 px-5">
+        <div className="space-y-8 bg-gray-50 dark:bg-gray-900">
+          <div ref={refinementRef}>
+            <header className="flex">
               <SearchBox
                 placeholder={searchBoxPlaceholder}
                 className="w-full "
@@ -237,7 +234,7 @@ const Search: FunctionComponent<SearchProps> = ({
               </div>
             </div>
 
-            <div className="flex mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900">
+            <div className="flex mb-10 pb-10">
               <div className="flex-shrink-0">
                 {!sm && (
                   <div className="pl-0 pt-0 p-10 flex flex-col space-y-6">
@@ -271,7 +268,7 @@ const Search: FunctionComponent<SearchProps> = ({
           {children}
         </div>
       </InstantSearch>
-    </>
+    </div>
   )
 }
 

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -215,10 +215,12 @@ const Search: FunctionComponent<SearchProps> = ({
           <div className="dark:bg-gray-900 bg-gray-50  md:-mt-5">
             <ScrollTo scrollOn="page" />
 
-            <div className="flex justify-between items-end pb-4 mb-6 border-b border-gray-200 max-w-screen-xl mx-auto">
+            <div className="flex flex-col-reverse md:flex-row justify-between items-center pb-4 md:pb-2 mb-6 border-b border-gray-200">
               <Stats searchQuery={searchState.query} />
-              <div className="flex space-x-2 items-center">
-                <div className="font-bold">Sort by:</div>
+              <div className="flex space-x-2 items-center flex-nowrap flex-shrink-0 md:ml-6 mb-5 md:mb-0">
+                <div className="font-bold whitespace-nowrap flex-shrink-0">
+                  Sort by:
+                </div>
                 <SortBy
                   defaultRefinement="popular"
                   items={[

--- a/src/components/search/instructors/instructor-essential.tsx
+++ b/src/components/search/instructors/instructor-essential.tsx
@@ -29,7 +29,7 @@ const SearchInstructorEssential: FunctionComponent<InstructorProps> = ({
 
   const location = `${name} landing`
   return (
-    <div className="mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900 w-full">
+    <>
       <NextSeo
         title={`Learn web development from ${name} on egghead`}
         twitter={{
@@ -132,7 +132,7 @@ const SearchInstructorEssential: FunctionComponent<InstructorProps> = ({
         {CTAComponent ? CTAComponent : <DefaultCTA location={location} />}
       </div>
       {children}
-    </div>
+    </>
   )
 }
 

--- a/src/components/search/instructors/stephanie-eckles/index.tsx
+++ b/src/components/search/instructors/stephanie-eckles/index.tsx
@@ -31,7 +31,7 @@ export default function SearchStephanieEckles({instructor}: {instructor: any}) {
           />
         }
       />
-      <section className="grid lg:grid-cols-6 grid-cols-1 -mt-10 mb-10 pb-10 xl:px-0 px-5 max-w-screen-xl mx-auto dark:bg-gray-900 w-full gap-0 lg:gap-3">
+      <section className="grid lg:grid-cols-6 grid-cols-1 -mt-10 mb-10 pb-10 w-full gap-0 lg:gap-3">
         <ProjectStack
           className="col-span-2 mb-3 lg:mb-0"
           data={projects.resources}

--- a/src/components/search/stats.tsx
+++ b/src/components/search/stats.tsx
@@ -13,7 +13,7 @@ const CustomStats: FunctionComponent<CustomStatsProps> = ({
   return !searchQuery || /^\s*$/.test(searchQuery) ? (
     <div />
   ) : (
-    <div className="flex items-center flex-nowrap flex-grow overflow-hidden max-w-full">
+    <div className="flex items-center flex-nowrap overflow-hidden max-w-full flex-grow mt-5 md:mt-0">
       <div className="font-bold whitespace-nowrap">
         {nbHits.toLocaleString()} results
       </div>

--- a/src/components/search/stats.tsx
+++ b/src/components/search/stats.tsx
@@ -13,9 +13,13 @@ const CustomStats: FunctionComponent<CustomStatsProps> = ({
   return !searchQuery || /^\s*$/.test(searchQuery) ? (
     <div />
   ) : (
-    <div>
-      <span className="font-bold">{nbHits.toLocaleString()} results</span> found
-      for "{searchQuery}"
+    <div className="flex items-center flex-nowrap flex-grow overflow-hidden max-w-full">
+      <div className="font-bold whitespace-nowrap">
+        {nbHits.toLocaleString()} results
+      </div>
+      <div className="ml-1 whitespace-nowrap flex overflow-hidden">
+        found for "<div className="truncate">{searchQuery}</div>"
+      </div>
     </div>
   )
 }

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -156,7 +156,7 @@ SearchIndex.getLayout = (Page: any, pageProps: any) => {
   return (
     <>
       <Header />
-      <Main>
+      <Main className="bg-gray-50 dark:bg-gray-900">
         <Page {...pageProps} />
       </Main>
       <Footer />

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -156,7 +156,7 @@ SearchIndex.getLayout = (Page: any, pageProps: any) => {
   return (
     <>
       <Header />
-      <Main className="bg-gray-50 dark:bg-gray-900">
+      <Main className="bg-gray-50">
         <Page {...pageProps} />
       </Main>
       <Footer />


### PR DESCRIPTION
- styles for search matches number and SortBy selector
- there were a lot of negative margin classes that overcomplicated the markup. I tried to clean it up.

![broken-paddings](https://user-images.githubusercontent.com/1519448/133458607-3411c94e-938f-4cc9-9a04-ece7eef16bac.jpg)

![incosistent-max-width](https://user-images.githubusercontent.com/1519448/133458634-e4a2ec81-e50c-497f-8f10-25ecba2f35f1.jpg)

![mob-1](https://user-images.githubusercontent.com/1519448/133458643-b042114d-08f3-4423-b0ff-c61387e60513.jpg)

![mob-2](https://user-images.githubusercontent.com/1519448/133458648-4010d81a-86d0-4df0-8e2b-cbd2c5087d98.jpg)

![mob-3](https://user-images.githubusercontent.com/1519448/133458653-50a605fd-8c43-46d3-97cc-10a4e63617f3.jpg)

Also predicted the situation when search query is too long:
![truncate](https://user-images.githubusercontent.com/1519448/133458886-86fda76e-4350-46c1-b93e-05cd01f81626.jpg)

![giphy](https://user-images.githubusercontent.com/1519448/133459105-91b7defb-39ef-45c7-be96-6c708f5dbe56.gif)




