### PR TITLE
Fixed styles on disabled button modals

### DIFF
--- a/src/components/cta/email/email-form.tsx
+++ b/src/components/cta/email/email-form.tsx
@@ -59,11 +59,11 @@ const EmailForm: FunctionComponent<LoginFormProps> = ({
           ) : (
             <>
               <h2 className="text-center text-3xl leading-9 font-bold">
-                Sign in (or up) to egghead
+                Sign in or create a free account
               </h2>
             </>
           ))}
-        <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+        <div className="mt-4 sm:mt-6 sm:mx-auto sm:w-full sm:max-w-xl">
           {!isSubmitted && !isError && (
             <Formik
               initialValues={{email: ''}}

--- a/src/components/customer-io/email-entry-form.tsx
+++ b/src/components/customer-io/email-entry-form.tsx
@@ -40,7 +40,7 @@ const EmailEntryForm: React.FC<any> = ({
     <div className="flex flex-col items-center p-16 my-16 bg-gray-100 dark:bg-gray-800 rounded-lg">
       <EmailForm
         className="w-full mx-auto flex flex-col items-center justify-center text-white"
-        label="Your email:"
+        label="Email address"
         formClassName="max-w-xs md:max-w-sm mx-auto w-full"
         button={buttonText}
         onSubmit={onSubmit}

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -571,10 +571,9 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                       button="Sign In or Create an Account"
                       track={trackEmailCapture}
                     >
-                      <p className="max-w-10 text-center text-gray-700">
-                        You need to be signed in to bookmark courses.
-                        <br />
-                        Sign in or create a free account to save this course.
+                      <p className="max-w-10 text-center text-gray-700 dark:text-gray-400 px-3">
+                        You need to be signed in to bookmark courses. Sign in or
+                        create a free account to save this course.
                       </p>
                     </LoginForm>
                   </DialogButton>

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -559,19 +559,19 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 ) : (
                   <DialogButton
                     buttonText="Bookmark"
-                    title="Sign in (or up) to bookmark"
+                    title="Sign in or create a free account to bookmark"
                     buttonStyles="text-gray-600 dark:text-gray-300 flex flex-row items-center rounded hover:bg-gray-100 
                       dark:hover:bg-gray-700 border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-600 px-4 py-2 border transition-colors text-sm xs:text-base ease-in-out opacity-90 shadow-sm"
                   >
                     <LoginForm
                       image={<></>}
                       className="w-full mx-auto flex flex-col items-center justify-center"
-                      label="Your email:"
+                      label="Email address"
                       formClassName="max-w-xs md:max-w-sm mx-auto w-full"
-                      button="Create account or login to view"
+                      button="Sign In or Create an Account"
                       track={trackEmailCapture}
                     >
-                      <p className="max-w-10 text-center text-gray-700 mb-2">
+                      <p className="max-w-10 text-center text-gray-700">
                         You need to be signed in to bookmark courses.
                         <br />
                         Sign in or create a free account to save this course.
@@ -601,10 +601,10 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 ) : (
                   <MembershipDialogButton
                     buttonText="Download"
-                    title="Become a Pro member to download this course"
+                    title="Become a member to download this course"
                   >
-                    As a member you can download any of our courses and watch
-                    them offline.
+                    As an egghead member you can download any of our courses and
+                    watch them offline.
                   </MembershipDialogButton>
                 )}
 
@@ -636,10 +636,10 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   >
                     <MembershipDialogButton
                       buttonText="RSS"
-                      title="Become a Pro member to access RSS feeds"
+                      title="Become a member to access RSS feeds"
                     >
-                      As a member you can subscribe to any of our courses using
-                      an RSS feed.
+                      As an egghead member you can subscribe to any of our
+                      courses using an RSS feed.
                     </MembershipDialogButton>
                   </a>
                 )}

--- a/src/components/pages/courses/dialog-button.tsx
+++ b/src/components/pages/courses/dialog-button.tsx
@@ -31,7 +31,7 @@ const DialogButton = ({title, buttonStyles, buttonText, children}: any) => {
           className="bg-white dark:bg-gray-900 shadow-lg rounded-lg max-w-screen-sm border dark:border-gray-800 relative xs:px-6 py-6"
           style={{width: '28rem'}}
         >
-          <div className="w-full flex flex-col mt-3">
+          <div className="w-full flex flex-col mt-3 mb-3">
             {title && (
               <h4
                 id={labelId}

--- a/src/components/pages/courses/dialog-button.tsx
+++ b/src/components/pages/courses/dialog-button.tsx
@@ -24,25 +24,23 @@ const DialogButton = ({title, buttonStyles, buttonText, children}: any) => {
       <DialogOverlay
         isOpen={showDialog}
         onDismiss={closeDialog}
-        className="bg-black/50 backdrop-blur-sm flex justify-center items-center p-4 xs:px-6 xs:py-8 z-50"
+        className="bg-black/50 backdrop-blur-sm flex justify-center items-center px-4 py-6 xs:px-6 xs:py-8 z-50"
       >
         <DialogContent
           aria-labelledby={labelId}
-          className="bg-white dark:bg-gray-900 shadow-lg rounded-lg max-w-screen-sm border dark:border-gray-800 relative p-3 xs:p-6"
+          className="bg-white dark:bg-gray-900 shadow-lg rounded-lg max-w-screen-sm border dark:border-gray-800 relative xs:px-6 py-6"
           style={{width: '28rem'}}
         >
-          <div className="w-full flex flex-col">
+          <div className="w-full flex flex-col mt-3">
             {title && (
               <h4
                 id={labelId}
-                className="text-lg sm:text-xl mb-4 font-semibold text-center px-4 leading-tight"
+                className="text-xl sm:text-2xl mb-3 font-semibold text-center px-0 sm:px-6 leading-7 sm:leading-9"
               >
                 {title}
               </h4>
             )}
-            <div className="flex flex-col space-y-4">
-              {children}
-            </div>
+            <div className="flex flex-col space-y-4">{children}</div>
           </div>
           <div className="block absolute top-0 right-0 pt-3 pr-3">
             <button
@@ -51,7 +49,7 @@ const DialogButton = ({title, buttonStyles, buttonText, children}: any) => {
               className={`text-gray-500 dark:text-gray-400 hover:bg-blue-100 hover:text-blue-600 dark:hover:text-blue-300 dark:hover:bg-gray-700 p-1 focus:shadow-outline-blue transition-all rounded-full hover:scale-110 ease-in-out duration-200`}
               aria-label="Close"
             >
-              <span className="sr-only">close feedback dialog</span>
+              <span className="sr-only">close dialog</span>
               {/* prettier-ignore */}
               <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" /></svg>
             </button>

--- a/src/components/pages/courses/membership-dialog-button.tsx
+++ b/src/components/pages/courses/membership-dialog-button.tsx
@@ -12,11 +12,13 @@ const MembershipDialogButton = ({title, children, buttonText}: any) => {
         dark:hover:bg-gray-700 border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-600 px-4 py-2 border transition-colors text-sm xs:text-base ease-in-out opacity-90 shadow-sm"
     >
       <p className="max-w-10 text-center text-gray-700">{children}</p>
-      <p className="max-w-10 text-center text-gray-700">PRO members get:</p>
+      <p className="uppercase text-sm tracking-wide text-gray-500 font-bold text-center border-t border-gray-200 pt-5">
+        Membership includes
+      </p>
       <FeaturesList />
       <Link href="/pricing">
-        <a className="text-sm w-full inline-flex justify-center items-center pb-2 rounded-md text-blue-600 underline transition-all hover:text-blue-800 ease-in-out duration-200">
-          <button className="font-semibold w-full mt-6 inline-flex justify-center items-center px-4 py-3 rounded-md bg-blue-600 text-white transition-all hover:bg-blue-700 ease-in-out duration-200">
+        <a className="w-full inline-flex justify-center rounded-md text-blue-600 transition-all hover:text-blue-800 ease-in-out duration-200">
+          <button className="font-semibold w-full inline-flex justify-center py-4 rounded-md bg-blue-600 text-white transition-all hover:bg-blue-700 ease-in-out duration-200">
             Become a Member
           </button>
         </a>

--- a/src/components/pages/courses/membership-dialog-button.tsx
+++ b/src/components/pages/courses/membership-dialog-button.tsx
@@ -11,8 +11,10 @@ const MembershipDialogButton = ({title, children, buttonText}: any) => {
       buttonStyles="text-gray-600 dark:text-gray-300 flex flex-row items-center rounded hover:bg-gray-100 
         dark:hover:bg-gray-700 border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-600 px-4 py-2 border transition-colors text-sm xs:text-base ease-in-out opacity-90 shadow-sm"
     >
-      <p className="max-w-10 text-center text-gray-700">{children}</p>
-      <p className="uppercase text-sm tracking-wide text-gray-500 font-bold text-center border-t border-gray-200 pt-5">
+      <p className="max-w-10 text-center text-gray-700 dark:text-gray-400">
+        {children}
+      </p>
+      <p className="uppercase text-sm tracking-wide text-gray-500 font-bold text-center border-t border-gray-200 dark:border-gray-700 pt-5">
         Membership includes
       </p>
       <FeaturesList />

--- a/src/components/pages/lessons/overlay/email-capture-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/email-capture-cta-overlay.tsx
@@ -24,7 +24,7 @@ const EmailCaptureCtaOverlay: FunctionComponent<CreateAccountCTAProps> = ({
       <LoginForm
         image={<></>}
         className="w-full mx-auto flex flex-col items-center justify-center text-white"
-        label="Your email:"
+        label="Email address"
         formClassName="max-w-xs md:max-w-sm mx-auto w-full"
         button="Create account or login to view"
         track={trackEmailCapture}

--- a/src/components/pages/level-up/email-entry-form.tsx
+++ b/src/components/pages/level-up/email-entry-form.tsx
@@ -33,7 +33,7 @@ const EmailEntryForm: React.FC = () => {
     <div className="flex flex-col items-center p-16 my-16 bg-gray-100 dark:bg-gray-800 rounded-lg">
       <EmailForm
         className="w-full mx-auto flex flex-col items-center justify-center text-white"
-        label="Your email:"
+        label="Email address"
         formClassName="max-w-xs md:max-w-sm mx-auto w-full"
         button="chat with egghead"
         onSubmit={onSubmit}

--- a/src/components/pages/own-your-online-presence/email-entry-form.tsx
+++ b/src/components/pages/own-your-online-presence/email-entry-form.tsx
@@ -33,7 +33,7 @@ const OnlinePresenceEmailEntryForm: React.FC = () => {
     <div className="flex flex-col items-center p-16 my-16 bg-gray-100 dark:bg-gray-800 rounded-lg">
       <EmailForm
         className="w-full mx-auto flex flex-col items-center justify-center text-white"
-        label="Your email:"
+        label="Email address"
         formClassName="max-w-xs md:max-w-sm mx-auto w-full"
         button="Show me how to zhuzh up my profile!"
         onSubmit={onSubmit}

--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -106,12 +106,12 @@ const PlanIntervalsSwitch: React.FunctionComponent<{
 }
 
 const DEFAULT_FEATURES = [
-  'Full access to all premium courses and lessons',
-  'RSS course feeds for your favorite podcast app',
-  'Offline viewing',
+  'Full access to all the premium courses',
+  'Download courses for offline viewing',
+  'Closed captions for every video',
   'Commenting and support',
   'Enhanced Transcripts',
-  'Closed captions for every video',
+  'RSS course feeds',
 ]
 
 const PlanFeatures: React.FunctionComponent<{

--- a/src/components/pro-member-features.tsx
+++ b/src/components/pro-member-features.tsx
@@ -1,103 +1,38 @@
 import * as React from 'react'
 
 const FeaturesList = () => (
-  <ul className="mt-8 lg:grid lg:grid-cols-2 lg:gap-x-8 lg:gap-y-5">
-    <li className="flex items-start lg:col-span-1">
-      <div className="flex-shrink-0">
-        <svg
-          className="h-5 w-5 text-green-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          />
-        </svg>
+  <ul className="mt-8 mx-4">
+    {[
+      'Full access to all premium courses and lessons',
+      'RSS course feeds for your favorite podcast app',
+      'Offline viewing',
+      'Commenting and support',
+      'Enhanced Transcripts',
+      'Closed captions for every video',
+    ].map((feature) => (
+      <div className="flex flex-row space-x-3 mb-2">
+        <CheckIcon />
+        <li className="font-medium" key={feature}>
+          {feature}
+        </li>
       </div>
-      <p className="ml-3 text-sm leading-5 text-gray-700 dark:text-gray-100">
-        Access to all 192 premium courses
-      </p>
-    </li>
-    <li className="flex items-start lg:col-span-1">
-      <div className="flex-shrink-0">
-        <svg
-          className="h-5 w-5 text-green-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </div>
-      <p className="ml-3 text-sm leading-5 text-gray-700 dark:text-gray-100">
-        Access to thousands of premium lessons
-      </p>
-    </li>
-    <li className="flex items-start lg:col-span-1">
-      <div className="flex-shrink-0">
-        <svg
-          className="h-5 w-5 text-green-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </div>
-      <p className="ml-3 text-sm leading-5 text-gray-700 dark:text-gray-100">
-        Download videos to watch offline
-      </p>
-    </li>
-    <li className="flex items-start lg:col-span-1">
-      <div className="flex-shrink-0">
-        <svg
-          className="h-5 w-5 text-green-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </div>
-      <p className="ml-3 text-sm leading-5 text-gray-700 dark:text-gray-100">
-        Commenting
-      </p>
-    </li>
-    <li className="flex items-start lg:col-span-1">
-      <div className="flex-shrink-0">
-        <svg
-          className="h-5 w-5 text-green-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </div>
-      <p className="ml-3 text-sm leading-5 text-gray-700 dark:text-gray-100">
-        RSS feed
-      </p>
-    </li>
+    ))}
   </ul>
+)
+
+const CheckIcon = () => (
+  <svg
+    className="text-blue-500 inline-block flex-shrink-0 mt-1"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+  >
+    <path
+      fill="currentColor"
+      d="M6.00266104,15 C5.73789196,15 5.48398777,14.8946854 5.29679603,14.707378 L0.304822855,9.71382936 C0.0452835953,9.46307884 -0.0588050485,9.09175514 0.0325634765,8.74257683 C0.123932001,8.39339851 0.396538625,8.12070585 0.745606774,8.02930849 C1.09467492,7.93791112 1.46588147,8.04203262 1.71655287,8.30165379 L5.86288579,12.4482966 L14.1675324,0.449797837 C14.3666635,0.147033347 14.7141342,-0.0240608575 15.0754425,0.00274388845 C15.4367507,0.0295486344 15.7551884,0.250045268 15.9074918,0.578881992 C16.0597953,0.907718715 16.0220601,1.29328389 15.8088932,1.58632952 L6.82334143,14.5695561 C6.65578773,14.8145513 6.38796837,14.9722925 6.09251656,15 C6.06256472,15 6.03261288,15 6.00266104,15 Z"
+    />
+  </svg>
 )
 
 export default FeaturesList

--- a/src/components/pro-member-features.tsx
+++ b/src/components/pro-member-features.tsx
@@ -3,16 +3,16 @@ import * as React from 'react'
 const FeaturesList = () => (
   <ul className="mt-8 mx-4">
     {[
-      'Full access to all premium courses and lessons',
-      'RSS course feeds for your favorite podcast app',
-      'Offline viewing',
+      'Full access to all the premium courses',
+      'Download courses for offline viewing',
+      'Closed captions for every video',
       'Commenting and support',
       'Enhanced Transcripts',
-      'Closed captions for every video',
-    ].map((feature) => (
+      'RSS course feeds',
+    ].map((feature, id) => (
       <div className="flex flex-row space-x-3 mb-2">
         <CheckIcon />
-        <li className="font-medium" key={feature}>
+        <li className="font-medium" key={id}>
           {feature}
         </li>
       </div>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -166,7 +166,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                           <ExternalTrackedLink
                             href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
                             eventName="clicked github login"
-                            className="flex justify-center mt-4 py-3 px-5 text-white bg-gray-900 hover:bg-gray-700 active:bg-gray-600 rounded-md font-medium transition-all ease-in-out duration-300"
+                            className="flex justify-center mt-4 py-3 px-5 text-white bg-gray-800 hover:bg-gray-700 active:bg-gray-600 rounded-md font-medium transition-all ease-in-out duration-300"
                           >
                             <div className="flex items-center dark:text-gray-100">
                               <span className="mr-2 flex items-center justify-center">
@@ -176,7 +176,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                             </div>
                           </ExternalTrackedLink>
                           <a
-                            className="pt-2 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150 text-gray-600"
+                            className="pt-2 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150 dark:text-gray-400 text-gray-600"
                             href="/login"
                             onClick={(e) => {
                               e.preventDefault()

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -79,8 +79,8 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
             children
           ) : (
             <>
-              <h2 className="text-center text-3xl leading-9 font-bold">
-                Sign in (or up) to egghead
+              <h2 className="text-center text-3xl font-bold w-2/3 mx-auto leading-10">
+                Sign in or create a free account
               </h2>
             </>
           ))}
@@ -91,7 +91,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
             }}
           />
         ) : (
-          <div className="mt-4 sm:mt-6 md:mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+          <div className="mt-4 sm:mt-6 sm:mx-auto sm:w-full sm:max-w-xl">
             {!isSubmitted && !isError && (
               <Formik
                 initialValues={{email: ''}}
@@ -155,7 +155,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                             <button
                               type="submit"
                               disabled={isSubmitting}
-                              className="w-full mt-4 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 hover:scale-105 hover:shadow-xl text-white font-semibold py-3 px-5 rounded-md"
+                              className="w-full mt-2 transition-all duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium py-3 px-5 rounded-md"
                             >
                               {button}
                             </button>
@@ -166,7 +166,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                           <ExternalTrackedLink
                             href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
                             eventName="clicked github login"
-                            className="flex justify-center mt-4 py-3 px-5 text-white bg-black hover:bg-gray-800 active:bg-gray-700 rounded-md transition-all ease-in-out duration-300"
+                            className="flex justify-center mt-4 py-3 px-5 text-white bg-gray-900 hover:bg-gray-700 active:bg-gray-600 rounded-md font-medium transition-all ease-in-out duration-300"
                           >
                             <div className="flex items-center dark:text-gray-100">
                               <span className="mr-2 flex items-center justify-center">
@@ -176,7 +176,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                             </div>
                           </ExternalTrackedLink>
                           <a
-                            className="pt-4 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150"
+                            className="pt-2 block text-center hover:text-blue-600 transition-colors ease-in-out duration-150 text-gray-600"
                             href="/login"
                             onClick={(e) => {
                               e.preventDefault()


### PR DESCRIPTION
Cleaned up the design and copywriting on the modals on our course page disabled buttons. Iteration on https://github.com/eggheadio/egghead-next/pull/864

@Creeland did a great job of hooking up all the functionality 👍 

I took another pass at the styles and copywriting to make them consistent across the modals, our standard login page, and our pricing page. As much as possible we should keep copywriting on buttons/forms, and styling on elements (bullet list icons, buttons, font sizes) consistent.

Also cleaned up some responsive styling details and dark mode accommodations

Course page modal and /pricing now match:

<img width="1683" alt="Screenshot - 2021-09-16 09 40 34" src="https://user-images.githubusercontent.com/5599295/133582093-53c7498a-6654-4fcd-9c9b-6d5e124ececf.png">

Course page modal and /login match:

<img width="1716" alt="Screenshot - 2021-09-16 09 40 59" src="https://user-images.githubusercontent.com/5599295/133582081-6008a2b2-185d-4447-8901-e51b6a35c6c8.png">

### Copywriting notes

- Changed login form titles from "Sign in (or up)" to "Sign in or create a free account" for clarity
- Change login buttons to match titles
- Removed "Pro" from any mentions of "member". "Pro membership" is an old term from when we had free account, members, and PRO members. We now only have free accounts and members. So instead of "Become a Pro member", we should just say "become a member"
- Changed the label above some of the email address forms from "Your email:" to "Email address". Both of these work but we had a random mix of the two and should just pick one for consistency

### Responsive styling and dark mode previews

<img width="1390" alt="Screenshot - 2021-09-16 10 16 14" src="https://user-images.githubusercontent.com/5599295/133586748-2bc881a9-86cf-45f1-8eb5-459e6e717144.png">
<img width="1383" alt="Screenshot - 2021-09-16 10 16 19" src="https://user-images.githubusercontent.com/5599295/133586759-4345a5c4-fe9d-4715-9115-1d1b5a4d31b1.png">
<img width="1373" alt="Screenshot - 2021-09-16 10 16 26" src="https://user-images.githubusercontent.com/5599295/133586765-94120209-3f89-4db2-80a5-7eca0a9c25d8.png">
<img width="439" alt="Screenshot - 2021-09-16 10 16 41" src="https://user-images.githubusercontent.com/5599295/133586787-05a40639-8ec4-4caf-8c78-07c85db3ccc4.png">
<img width="433" alt="Screenshot - 2021-09-16 10 16 48" src="https://user-images.githubusercontent.com/5599295/133586790-2ba37e51-44da-428f-90b1-335ebaf4bf26.png">
<img width="354" alt="Screenshot - 2021-09-16 10 20 27" src="https://user-images.githubusercontent.com/5599295/133586791-775f8b07-8553-475b-aa5f-f37c437e11b3.png">
<img width="402" alt="Screenshot - 2021-09-16 10 21 52" src="https://user-images.githubusercontent.com/5599295/133586792-52b35f68-8fd0-41e4-bcab-2daaee9ac544.png">
