### PR TITLE
use a div instead of a fragment for layout to avoid double renders

### DIFF
--- a/src/components/app/layout.tsx
+++ b/src/components/app/layout.tsx
@@ -6,12 +6,11 @@ import Footer from './footer'
 
 const Layout: FunctionComponent = ({children}) => {
   return (
-    <>
+    <div>
       <Header />
       <Main>{children}</Main>
       <Footer />
-      <div />
-    </>
+    </div>
   )
 }
 

--- a/src/components/search/components/cta-card.tsx
+++ b/src/components/search/components/cta-card.tsx
@@ -22,7 +22,7 @@ const CtaCard: React.FC<{
       href={path}
     >
       <div
-        className="md:-mt-5 flex items-center justify-center bg-white dark:bg-gray-900 text-white overflow-hidden rounded-b-lg md:rounded-t-none rounded-t-lg shadow-sm"
+        className="relative md:-mt-5 flex items-center justify-center bg-white dark:bg-gray-900 text-white overflow-hidden rounded-b-lg md:rounded-t-none rounded-t-lg shadow-sm"
         css={{
           [bpMinMD]: {
             minHeight: 477,

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -154,14 +154,13 @@ const SearchIndex: any = ({
 // this fixes the issue with a double footer rendering. 🥴
 SearchIndex.getLayout = (Page: any, pageProps: any) => {
   return (
-    <>
+    <div>
       <Header />
       <Main className="bg-gray-50">
         <Page {...pageProps} />
       </Main>
       <Footer />
-      <div />
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION

![double render](https://user-images.githubusercontent.com/86834/134417817-b1550ff7-ffda-4fc5-90a3-998b6a92753a.jpg)

The footer was rendering twice, which has happened before. Through process of elimination I found that changing the `<>` fragment element to a `<div>` in the layout caused this to return to normal.

An interesting thing to note here is that the rendered double was outside of the `_next` component

![outside of _next structure](https://user-images.githubusercontent.com/86834/134418071-54a2477c-da1a-48ec-aafb-dc72f9985afc.jpg)


![double vision](https://media.giphy.com/media/jP5p77MqB3mJGLRt5b/giphy.gif?cid=ecf05e47sq2jev20pm75wnoa0is9679zwty8x6f5f5ygjmnr&rid=giphy.gif&ct=g)