### PR TITLE
Revert "small fix to the default cta to fill the height of the component"

### DIFF
--- a/src/components/search/curated/default-cta.tsx
+++ b/src/components/search/curated/default-cta.tsx
@@ -15,7 +15,8 @@ const DefaultCTA: React.FC<{location: string}> = ({location}) => {
       <Image
         priority
         quality={100}
-        layout="fill"
+        width={417}
+        height={463}
         className="rounded-lg"
         alt="Get Really Good at React on EpicReact.dev by Kent C. Dodds"
         src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1626109728/epic-react/default-banners/banner-react-page_2x.jpg"


### PR DESCRIPTION
Reverts eggheadio/egghead-next#894