### PR TITLE
Display discounted price if it is available

### DIFF
--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -15,7 +15,8 @@ const PlanPrice: React.FunctionComponent<{
   plan: any
   pricesLoading: boolean
 }> = ({plan, pricesLoading}) => {
-  const {price, interval, interval_count} = plan
+  const {price, price_discounted, interval, interval_count} = plan
+  const priceToDisplay = price_discounted || price
   const intervalLabel = interval_count > 1 ? 'quarter' : interval
   return (
     <div className="flex flex-col items-center">
@@ -28,7 +29,7 @@ const PlanPrice: React.FunctionComponent<{
               <span className="opacity-0">––</span>
             </div>
           ) : (
-            price
+            priceToDisplay
           )}
         </span>
         <span className="text-lg font-light mb-1">/{intervalLabel}</span>
@@ -43,7 +44,9 @@ const PlanQuantitySelect: React.FunctionComponent<{
   plan: any
   pricesLoading: boolean
 }> = ({quantity, onQuantityChanged, plan, pricesLoading}) => {
-  const {price} = plan
+  const {price, price_discounted} = plan
+  const priceToDisplay = price_discounted || price
+
   return (
     <div className="flex flex-col items-center space-y-2">
       <label>
@@ -59,7 +62,7 @@ const PlanQuantitySelect: React.FunctionComponent<{
       </label>
       {quantity > 1 && (
         <div className="py-2">
-          ${!pricesLoading ? price / quantity : '---'}/seat
+          ${!pricesLoading ? priceToDisplay / quantity : '---'}/seat
         </div>
       )}
     </div>


### PR DESCRIPTION
As is, the pricing page assumes that no coupons are being applied. It
only displays the `price` and doesn't account for whether they may be a
`discounted_price` in the `plan` object it receives. This commit tries
to display the `discounted_price` if it is available, otherwise it falls
back to the standard `price`.

This PR is good to go in as is. However, I wonder if we want to do anything with how we display discounted pricing.

The pricing is going to look just like this, even if a discounted value is being displayed:

<img width="518" alt="CleanShot 2021-09-30 at 10 56 39@2x" src="https://user-images.githubusercontent.com/694063/135490178-0877c316-d19e-4c17-87e7-89654717ec3c.png">

What I've seen a lot of places (and what we probably do on partner products) is showing the original price slashed out and then the discounted price next to it. E.g.:

<img width="445" alt="CleanShot 2021-09-30 at 10 56 17@2x" src="https://user-images.githubusercontent.com/694063/135490303-9dde262c-42d8-4738-9bfc-3c0f1fdd3497.png">

If we want to do this, I wonder if @vojtaholik or @DrShpongle could help with the design and styling of it.