### PR TITLE
changed jumbotron text color

### DIFF
--- a/src/components/pages/home/jumbotron/index.tsx
+++ b/src/components/pages/home/jumbotron/index.tsx
@@ -60,7 +60,7 @@ const Jumbotron: FunctionComponent<JumbotronProps> = ({
               </h2>
               <Link href={path}>
                 <a
-                  className="sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-gray-50 hover:text-gray-400"
+                  className="sm:text-2xl md:text-4xl text-xl max-w-screen-lg font-extrabold leading-tighter text-teal-400 hover:text-teal-200"
                   onClick={() =>
                     track('clicked jumbotron resource', {
                       resource: path,


### PR DESCRIPTION
Changed the text color and text hover color for the Chakra UI course release.
![Screen Shot 2021-10-05 at 11 37 49 AM](https://user-images.githubusercontent.com/26470581/136082958-93babde8-69b5-451b-8047-6a6aff9293cd.png)

![](https://media3.giphy.com/media/lYgsRPkt16EL5U2fvR/200w.gif?cid=5a38a5a2cnzgq6xvxmdwhyjqpzdetr8hcfi8tayet4r5xt00&rid=200w.gif&ct=g)