### PR TITLE
updates styles and copy on Parity Coupon Message

### DIFF
--- a/src/components/pricing/parity-coupon-message.tsx
+++ b/src/components/pricing/parity-coupon-message.tsx
@@ -20,8 +20,8 @@ const ParityCouponMessage = ({
   const [showFlag, setShowFlag] = React.useState<boolean>(false)
 
   return (
-    <div className="max-w-screen-lg mx-auto p-7 shadow-lg rounded-lg border border-cool-gray-50 text-left">
-      <h2 className="text-lg font-semibold mb-4 sm:text-left text-center">
+    <div className="max-w-screen-lg mx-auto p-8 m-5 shadow-lg rounded-lg text-left bg-white dark:bg-gray-800">
+      <h2 className="text-base mb-4 sm:text-left text-center">
         It looks like you're in{' '}
         <img
           loading="lazy"
@@ -32,18 +32,18 @@ const ParityCouponMessage = ({
           src={`https://hardcore-golick-433858.netlify.app/image?code=${coupon.coupon_region_restricted_to}`}
         />
         {countryName}. 👋 To support global learning, we'd like to offer you a
-        discount of {percentOff}% to account for differences in currencies.
+        discount of <strong>{percentOff}%</strong> to account for differences in
+        currencies.
       </h2>
-      <p className="text-base">
-        Please note the following restrictions associated with choosing to apply
-        the discount.
+      <p className="text-base font-semibold">
+        The following restrictions apply:
       </p>
       <ul className="list-disc ml-4 mt-2">
+        <li>Downloads and bonuses are not included.</li>
         <li>
           Members-only content will only be available while browsing from{' '}
           {countryName}.
         </li>
-        <li>Downloads and bonuses are not included.</li>
         <li>
           The discount is only valid for single-user accounts and does not apply
           to team accounts.
@@ -54,7 +54,7 @@ const ParityCouponMessage = ({
       </p>
       <div className="mt-4">
         <label
-          className={`inline-flex items-center px-4 py-3 rounded-md  transition-all ease-in-out duration-150 cursor-pointer border ${
+          className={`inline-flex items-center px-4 py-3 rounded-md  transition-all ease-in-out duration-150 cursor-pointer border hover:bg-gray-100 dark:hover:bg-gray-700 border-opacity-40 ${
             isPPP ? 'border-blue-500' : ' border-gray-300'
           }`}
         >
@@ -65,7 +65,7 @@ const ParityCouponMessage = ({
             checked={isPPP}
             onChange={isPPP ? onDismiss : onApply}
           />
-          <span className="ml-2 font-semibold">
+          <span className="ml-4 leading-4 font-semibold">
             {isPPP
               ? `Activated ${percentOff}% off with regional pricing`
               : `Activate ${percentOff}% off with regional pricing`}
@@ -73,10 +73,9 @@ const ParityCouponMessage = ({
         </label>
         {isPPP && (
           <div className="mt-4">
-            🛑 You currently have a Purchasing Power Parity coupon applied. With
-            this discount your purchase will be restricted to your country
-            region/country. You will have the opportunity to upgrade to a full
-            license at a later time if you choose to do so.
+            🛑 You currently have a Purchasing Power Parity coupon applied. You
+            will have the opportunity to upgrade to a full license at a later
+            time if you choose to do so.
           </div>
         )}
       </div>

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -147,7 +147,7 @@ const Pricing: FunctionComponent<PricingProps> & {getLayout: any} = () => {
             />
           </div>
           {pppCouponAvailable && pppCouponEligible && (
-            <div className="mt-4 pb-5 max-w-screen-sm mx-auto">
+            <div className="mt-4 pb-5 max-w-screen-md mx-auto">
               <ParityCouponMessage
                 coupon={parityCoupon as Coupon}
                 countryName={countryName as string}


### PR DESCRIPTION
small updates @jbranchaud 

- there's no need for an H2 to be a whole paragraph 
- inverted triangle hierarchy for the bullet points provides better readability 
- background color to improve readability

<img width="870" alt="CleanShot 2021-10-19 at 17 14 45@2x" src="https://user-images.githubusercontent.com/57044804/138007281-ebbd4bfd-84cf-4366-9210-a6ea08320a04.png">

