### PR TITLE
css fixes for safari on hp for anon users

### DIFF
--- a/src/components/pages/landing/create-account/index.tsx
+++ b/src/components/pages/landing/create-account/index.tsx
@@ -73,7 +73,7 @@ const CreateAccount: React.FC<{actionLabel?: string; location: string}> = ({
             onChange={formik.handleChange}
             onBlur={formik.handleBlur}
             placeholder="you@company.com"
-            className="dark:autofill:text-fill-black block w-full py-3 pl-10 text-black placeholder-gray-400 bg-transparent sm:border-r-0 border-gray-300 dark:border-gray-700 sm:rounded-r-none rounded-md shadow-sm dark:text-white autofill:text-fill-black focus:outline-none outline-none focus:ring-0 dark:focus:border-blue-500 focus:border-blue-500"
+            className="block w-full py-3 pl-10 text-black placeholder-gray-400 bg-transparent sm:border-r-0 border-gray-300 dark:border-gray-700 sm:rounded-r-none rounded-md shadow-sm dark:text-white focus:outline-none outline-none focus:ring-0 dark:focus:border-blue-500 focus:border-blue-500"
             required
           />
         </div>

--- a/src/components/pages/landing/header/index.tsx
+++ b/src/components/pages/landing/header/index.tsx
@@ -32,7 +32,7 @@ const Header = () => {
         )}
         <div
           aria-hidden
-          className="h-64 bg-gradient-to-t dark:from-gray-900 from-white to-transparent w-full absolute bottom-0 left-0"
+          className="h-64 bg-gradient-to-t dark:from-gray-900 dark:to-transparentDark from-white to-transparentLight w-full absolute bottom-0 left-0"
         />
         <div className="flex flex-col items-center justify-center max-w-screen-lg relative z-10 pb-8">
           <h1 className="font-semibold lg:text-4xl sm:text-3xl text-2xl leading-tighter text-center lg:max-w-none md:max-w-screen-md">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,6 +35,8 @@ module.exports = {
     colors: {
       ...defaultTheme.colors,
       ...colors,
+      transparentLight: 'rgba(255, 255, 255, 0)', // safari fix
+      transparentDark: 'rgba(17, 24, 39, 0)', // safari fix
       gray: {...colors.coolGray, 1000: '#0A0F19'},
     },
     container: {


### PR DESCRIPTION
making sure that autofill styles won't ruin readability and that gradients with transparent color will render correctly in safari. 
 
safari is the new IE 😭 

<img src="https://media.giphy.com/media/MeCd6OdblEMMiijqF2/giphy-downsized.gif" width="200" alt="hippo" />

