### PR TITLE
update lesson cta background opacity to comply with AAA contrast

### DIFF
--- a/src/components/pages/lessons/overlay/wrapper.tsx
+++ b/src/components/pages/lessons/overlay/wrapper.tsx
@@ -4,7 +4,7 @@ const OverlayWrapper: FunctionComponent<{
   children: React.ReactNode
 }> = ({children}) => {
   return (
-    <div className="flex items-center justify-center bg-gray-800 text-white bg-opacity-30 w-full h-full">
+    <div className="flex items-center justify-center bg-gray-800 text-white bg-opacity-80 w-full h-full">
       {children}
     </div>
   )


### PR DESCRIPTION
New contrast ratio for light mode is `6.96` for while displaying light text.

![Request page data for Next js from the Notion API  egghead io](https://user-images.githubusercontent.com/6188161/139732121-c2c9d5d2-69d4-4cd4-9825-ea6af1c6f00b.png)
![Request page data for Next js from the Notion API  egghead io](https://user-images.githubusercontent.com/6188161/139732129-81e38cd1-dd96-42b3-93c1-bfa5f2dc0e03.png)
