### PR TITLE
adds a CTA for sidebar on video lessons with no course or notes

### DIFF
--- a/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
@@ -65,12 +65,14 @@ const WatchNextLessonCtaOverlay: React.FunctionComponent<{
           </h3>
           {ctaContent.linksTo.map((content: any) => {
             return (
-              <Link href={content.path || '#'}>
+              <Link
+                href={content.slug ? `/${content.type}s/${content.slug}` : '#'}
+              >
                 <a
                   onClick={() => {
                     track('clicked cta content', {
                       from: lesson.slug,
-                      [content.type]: content.title,
+                      [content.type]: content.slug,
                     })
                   }}
                   className="px-3 py-2 flex items-center ml-4 transition-colors duration-200 ease-in-out space-x-2 hover:underline"

--- a/src/components/player/player-sidebar.tsx
+++ b/src/components/player/player-sidebar.tsx
@@ -24,22 +24,26 @@ const PlayerSidebar: React.FC<{
   videoResource: VideoResource
   lessonView?: any
   onAddNote?: any
-}> = ({videoResource, lessonView, onAddNote}) => {
+  relatedResources?: any
+}> = ({videoResource, lessonView, onAddNote, relatedResources}) => {
   const {setPlayerPrefs, getPlayerPrefs} = useEggheadPlayerPrefs()
   const {activeSidebarTab} = getPlayerPrefs()
+
+  const videoResourceHasNotes = hasNotes(videoResource)
+  const videoResourceHasCollection = !isEmpty(videoResource.collection)
+  const hasRelatedResources = !isEmpty(relatedResources)
   return (
     <div className="relative h-full">
-      {/* TODO: remove weird logic that assumes 2 tabs */}
       <Tabs
-        index={(hasNotes(videoResource) && activeSidebarTab) || 0}
+        index={(videoResourceHasNotes && activeSidebarTab) || 0}
         onChange={(tabIndex) => setPlayerPrefs({activeSidebarTab: tabIndex})}
         className="shadow-sm lg:absolute left-0 top-0 w-full h-full flex flex-col bg-gray-100 dark:bg-gray-1000 text-gray-900 dark:text-white"
       >
         <TabList className="relative z-[1] flex-shrink-0">
-          {!isEmpty(videoResource.collection) && (
+          {videoResourceHasCollection && (
             <Tab onClick={(e) => console.log('e')}>Lessons</Tab>
           )}
-          {hasNotes(videoResource) && (
+          {videoResourceHasNotes && (
             <Tab onClick={(e) => console.log('e')}>Notes</Tab>
           )}
         </TabList>
@@ -54,6 +58,45 @@ const PlayerSidebar: React.FC<{
           <TabPanel className="lg:absolute inset-0">
             <NotesTab onAddNote={onAddNote} />
           </TabPanel>
+          {hasRelatedResources &&
+            !videoResourceHasCollection &&
+            !videoResourceHasNotes && (
+              <div className="flex flex-col space-y-3 w-full">
+                <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
+                  {relatedResources.headline}
+                </h3>
+                {relatedResources.linksTo.map((content: any) => {
+                  return (
+                    <Link
+                      href={
+                        content.slug ? `/${content.type}s/${content.slug}` : '#'
+                      }
+                    >
+                      <a
+                        onClick={() => {
+                          track('clicked sidebar cta content', {
+                            from: videoResource.slug,
+                            [content.type]: content.slug,
+                          })
+                        }}
+                        className="px-3 py-2 flex items-center ml-4 transition-colors duration-200 ease-in-out space-x-2 hover:underline"
+                      >
+                        <div className="w-12 h-12 relative flex-shrink-0 ">
+                          <Image
+                            src={content.imageUrl}
+                            alt={`illustration of ${content.title} course`}
+                            width="64"
+                            height="64"
+                            layout="fill"
+                          />
+                        </div>
+                        <div className="font-bold">{content.title}</div>
+                      </a>
+                    </Link>
+                  )
+                })}
+              </div>
+            )}
         </TabPanels>
       </Tabs>
     </div>

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -59,20 +59,44 @@ const specialLessons: any = {
       linksTo: [
         {
           title: 'Understand JavaScript Arrays',
-          path: '/courses/understand-javascript-arrays',
+          isPro: true,
+          path: 'understand-javascript-arrays',
           type: 'course',
           imageUrl:
             'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/432/714/square_480/EGH_JSarrays.png',
         },
         {
           title: 'Reduce Data with Javascript Array#reduce',
-          path: '/courses/reduce-data-with-javascript-array-reduce',
+          isPro: true,
+          path: 'reduce-data-with-javascript-array-reduce',
           type: 'course',
           imageUrl:
             'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/432/557/square_480/EGH_ReduceDataJS.png',
         },
       ],
     },
+
+  'javascript-creating-demo-apis-with-json-server': {
+    headline: 'Build better APIs with these in-depth courses',
+    linksTo: [
+      {
+        title: 'Build a Serverless API with Cloudflare Workers',
+        isPro: false,
+        slug: 'build-a-serverless-api-with-cloudflare-workers-d67ca551',
+        type: 'course',
+        imageUrl:
+          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/441/045/square_480/EGH_cloudflare-workers_424_2x.png',
+      },
+      {
+        title: 'Building an API with Express',
+        isPro: true,
+        slug: 'building-an-api-with-express-f1ea',
+        type: 'course',
+        imageUrl:
+          'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/359/square_480/expressjslogo.png',
+      },
+    ],
+  },
 }
 
 export const getServerSideProps: GetServerSideProps = async function ({
@@ -625,6 +649,7 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
             </div>
             <div className="lg:col-span-3 side-bar">
               <PlayerSidebar
+                relatedResources={specialLessons[lesson.slug]}
                 videoResource={lesson}
                 onAddNote={() => send('ADD_NOTE')}
               />


### PR DESCRIPTION
This adds a sidebar CTA for https://egghead.io/lessons/javascript-creating-demo-apis-with-json-server

I didn't spend much effort on formatting at all but it will only display on this specific lesson so should be upgraded before we spread it more widely

![Image 2021-11-01 at 3 48 29 PM](https://user-images.githubusercontent.com/86834/139752248-94ad134a-7f32-4961-b8a9-c86e663ae8e9.jpg)

![resources](https://media.giphy.com/media/3rgXBr5eZph7ry7Uuk/giphy.gif)
