### PR TITLE
Put Purchase and Play logic in custom hook

### DIFF
--- a/src/hooks/use-purchase-and-play.ts
+++ b/src/hooks/use-purchase-and-play.ts
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import {useRouter} from 'next/router'
+import axios from 'axios'
+import {useViewer} from 'context/viewer-context'
+import {AUTH_DOMAIN} from 'utils/auth'
+import {useMachine} from '@xstate/react'
+import {authTokenPollingMachine} from 'machines/auth-token-polling-machine'
+
+const TWENTY_FOUR_HOURS_IN_SECONDS = JSON.stringify(24 * 60 * 60)
+
+const usePurchaseAndPlay = (): [boolean, any] => {
+  const {query} = useRouter()
+  const {
+    viewer,
+    handleAccessTokenAuthentication: _handleAccessTokenAuthentication,
+  } = useViewer()
+
+  // We want to know if the user was already authenticated when the component
+  // loads, not after. Hence capturing that boolean in a ref.
+  const alreadyAuthenticated = React.useRef(!!viewer)
+
+  // This polling machine will attempt to fetch a fresh access token for the
+  // customer associated with the Stripe Checkout Session ID using the declared
+  // service.
+  const [current, send] = useMachine(authTokenPollingMachine, {
+    services: {
+      requestAuthToken: async (context) => {
+        const {data} = await axios.post(
+          `${AUTH_DOMAIN}/api/v1/purchase_sessions`,
+          {checkout_session_id: context.stripeCheckoutSessionId},
+        )
+
+        const {auth_token: authToken} = data || {}
+
+        if (authToken) {
+          return Promise.resolve({authToken})
+        } else {
+          return Promise.reject()
+        }
+      },
+    },
+  })
+
+  const {session_id} = query
+  // Narrow the type of the session ID
+  const stripeCheckoutSessionId =
+    session_id instanceof Array ? session_id[0] : session_id
+
+  // Update the stripeCheckoutSessionId if it changes
+  // (this is for when it goes from undefined to defined)
+  React.useEffect(() => {
+    if (stripeCheckoutSessionId !== undefined) {
+      send({type: 'UPDATE_SESSION_ID', stripeCheckoutSessionId})
+    }
+  }, [stripeCheckoutSessionId])
+
+  console.log({
+    session_id,
+    stripeCheckoutSessionId,
+    inMachine: current.context.stripeCheckoutSessionId,
+  })
+
+  // Memoize the function so that it doesn't re-trigger the useEffect over and
+  // over.
+  const handleAccessTokenAuthentication = React.useCallback(
+    (authToken, expiration) => {
+      _handleAccessTokenAuthentication(authToken, expiration)
+    },
+    [],
+  )
+
+  // Once we have an authToken, update the viewer-context
+  React.useEffect(() => {
+    if (current.context.authToken) {
+      handleAccessTokenAuthentication(
+        current.context.authToken,
+        TWENTY_FOUR_HOURS_IN_SECONDS,
+      )
+    }
+  }, [current.context.authToken, handleAccessTokenAuthentication])
+
+  return [alreadyAuthenticated.current, current]
+}
+
+export default usePurchaseAndPlay

--- a/src/machines/auth-token-polling-machine.ts
+++ b/src/machines/auth-token-polling-machine.ts
@@ -2,7 +2,10 @@ import {createMachine, assign} from 'xstate'
 
 type DoneEventObject = import('xstate').DoneEventObject
 
-type Event = DoneEventObject
+type Event = DoneEventObject & {
+  type: 'UPDATE_SESSION_ID'
+  stripeCheckoutSessionId: string
+}
 
 interface Context {
   stripeCheckoutSessionId?: string
@@ -22,6 +25,15 @@ export const authTokenPollingMachine = createMachine<Context, Event>(
     },
     states: {
       pending: {
+        on: {
+          UPDATE_SESSION_ID: {
+            actions: assign({
+              stripeCheckoutSessionId: (_context, event) => {
+                return event.stripeCheckoutSessionId
+              },
+            }),
+          },
+        },
         initial: 'polling',
         states: {
           polling: {

--- a/src/pages/confirm/membership.tsx
+++ b/src/pages/confirm/membership.tsx
@@ -1,27 +1,18 @@
 import * as React from 'react'
-import axios from 'axios'
-import {useViewer} from 'context/viewer-context'
 import {useRouter} from 'next/router'
+import axios from 'axios'
 import ConfirmMembership from 'components/pages/confirm/membership/index'
+import usePurchaseAndPlay from 'hooks/use-purchase-and-play'
 import {track} from 'utils/analytics'
-import {AUTH_DOMAIN} from 'utils/auth'
-import {useMachine} from '@xstate/react'
-import {authTokenPollingMachine} from 'machines/auth-token-polling-machine'
-
-const TWENTY_FOUR_HOURS_IN_SECONDS = JSON.stringify(24 * 60 * 60)
+import {useViewer} from 'context/viewer-context'
 
 const ConfirmMembershipPage: React.FC = () => {
   const {query} = useRouter()
-  const [session, setSession] = React.useState<any>()
-  const {
-    viewer,
-    refreshUser,
-    handleAccessTokenAuthentication: _handleAccessTokenAuthentication,
-  } = useViewer()
+  const {viewer, refreshUser} = useViewer()
 
-  // We want to know if the user was already authenticated when the component
-  // loads, not after. Hence capturing that boolean in a ref.
-  const alreadyAuthenticated = React.useRef(!!viewer)
+  const [alreadyAuthenticated, currentState] = usePurchaseAndPlay()
+
+  const [session, setSession] = React.useState<any>()
 
   React.useEffect(() => {
     const {session_id} = query
@@ -38,53 +29,6 @@ const ConfirmMembershipPage: React.FC = () => {
     }
   }, [])
 
-  const {session_id} = query
-  // Narrow the type of the session ID
-  const stripeCheckoutSessionId =
-    session_id instanceof Array ? session_id[0] : session_id
-
-  // This polling machine will attempt to fetch a fresh access token for the
-  // customer associated with the Stripe Checkout Session ID using the declared
-  // service.
-  const [current, _send] = useMachine(authTokenPollingMachine, {
-    context: {stripeCheckoutSessionId},
-    services: {
-      requestAuthToken: async (context) => {
-        const {data} = await axios.post(
-          `${AUTH_DOMAIN}/api/v1/purchase_sessions`,
-          {checkout_session_id: context.stripeCheckoutSessionId},
-        )
-
-        const {auth_token: authToken} = data || {}
-
-        if (authToken) {
-          return Promise.resolve({authToken})
-        } else {
-          return Promise.reject()
-        }
-      },
-    },
-  })
-
-  // Memoize the function so that it doesn't re-trigger the useEffect over and
-  // over.
-  const handleAccessTokenAuthentication = React.useCallback(
-    (authToken, expiration) => {
-      _handleAccessTokenAuthentication(authToken, expiration)
-    },
-    [],
-  )
-
-  // Once we have an authToken, update the viewer-context
-  React.useEffect(() => {
-    if (current.context.authToken) {
-      handleAccessTokenAuthentication(
-        current.context.authToken,
-        TWENTY_FOUR_HOURS_IN_SECONDS,
-      )
-    }
-  }, [current.context.authToken, handleAccessTokenAuthentication])
-
   if (!session) return null
 
   return (
@@ -94,8 +38,8 @@ const ConfirmMembershipPage: React.FC = () => {
           <div className="max-w-screen-sm mx-auto p-5 w-full flex flex-col items-center justify-start sm:py-16 py-8">
             <ConfirmMembership
               session={session}
-              alreadyAuthenticated={alreadyAuthenticated.current}
-              currentState={current}
+              alreadyAuthenticated={alreadyAuthenticated}
+              currentState={currentState}
             />
           </div>
         </div>


### PR DESCRIPTION
This moves the Purchase and Play logic into a custom hook. That does a couple things:
- it helps isolate some dependencies, making it easier to reason about
- it makes it so that the hook can be used in other post-checkout contexts (e.g. lesson CTA overlay)

![](https://media2.giphy.com/media/xUOxf5WGyH97j7qPYI/200.gif?cid=5a38a5a24fedyo09gvaa0e4y1v107a6njjc94o6bmmbrgel9&rid=200.gif&ct=g)