### PR TITLE
Exclude empty coupon param from URL

### DIFF
--- a/src/components/pricing/pricing-widget/index.tsx
+++ b/src/components/pricing/pricing-widget/index.tsx
@@ -87,12 +87,15 @@ const PricingWidget: FunctionComponent<{}> = () => {
       await track('checkout: get email', {
         priceId: priceId,
       })
+
+      const couponCode = state.context.couponToApply?.couponCode
+
       router.push({
         pathname: '/pricing/email',
         query: {
           priceId,
           quantity,
-          coupon: state.context.couponToApply?.couponCode,
+          ...(couponCode && {coupon: couponCode}),
         },
       })
       setLoaderOn(true)


### PR DESCRIPTION
Before this, if there wasn't a coupon being applied, an empty `coupon`
param would still appear in the URL.

![CleanShot 2021-11-05 at 10 46 35@2x](https://user-images.githubusercontent.com/694063/140538920-69e654db-aedd-40d7-8e08-e4924a25ba0e.png)


![](https://media2.giphy.com/media/WohZR4JZv95ZObQhRh/200.gif?cid=5a38a5a2wfqlbj6g7ulv27fi8ij5wiooyoqgx6g6ehxfr28j&rid=200.gif&ct=g)