### PR TITLE
Add tests for auth token polling machine

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -15,7 +15,7 @@ declare global {
       /**
        *  Match wheter the XState State matches the provided value.
        */
-      toMatchState(state: string): CustomMatcherResult
+      toMatchState(state: string | object): CustomMatcherResult
     }
   }
 }

--- a/src/hooks/use-purchase-and-play.ts
+++ b/src/hooks/use-purchase-and-play.ts
@@ -54,12 +54,6 @@ const usePurchaseAndPlay = (): [boolean, any] => {
     }
   }, [stripeCheckoutSessionId])
 
-  console.log({
-    session_id,
-    stripeCheckoutSessionId,
-    inMachine: current.context.stripeCheckoutSessionId,
-  })
-
   // Memoize the function so that it doesn't re-trigger the useEffect over and
   // over.
   const handleAccessTokenAuthentication = React.useCallback(

--- a/src/machines/__tests__/auth-token-polling-machine.test.ts
+++ b/src/machines/__tests__/auth-token-polling-machine.test.ts
@@ -1,0 +1,76 @@
+import {authTokenPollingMachine} from '../auth-token-polling-machine'
+import {interpret} from 'xstate'
+
+function sleep(time) {
+  return new Promise((resolve) => {
+    return setTimeout(resolve, time)
+  })
+}
+
+test('it starts polling immediately', () => {
+  const pollingService = interpret(
+    authTokenPollingMachine.withConfig({
+      services: {
+        requestAuthToken: () => Promise.resolve(),
+      },
+    }),
+  )
+
+  pollingService.start()
+
+  expect(pollingService.state).toMatchState({pending: 'polling'})
+})
+
+test('it invokes the requestAuthToken service', () => {
+  const mockedFunc = jest.fn()
+
+  const pollingService = interpret(
+    authTokenPollingMachine.withConfig({
+      services: {
+        requestAuthToken: () => {
+          mockedFunc()
+
+          return Promise.resolve()
+        },
+      },
+    }),
+  )
+
+  pollingService.start()
+
+  expect(mockedFunc).toHaveBeenCalled()
+})
+
+test('it assigns the authToken to context when received', async () => {
+  const pollingService = interpret(
+    authTokenPollingMachine.withConfig({
+      services: {
+        requestAuthToken: () => Promise.resolve({authToken: 'auth123'}),
+      },
+    }),
+  )
+
+  pollingService.start()
+
+  await sleep(0)
+
+  expect(pollingService.state.context.authToken).toEqual('auth123')
+
+  expect(pollingService.state).toMatchState({pending: 'verifyRetrieval'})
+})
+
+test('it schedules the next poll if lookup failed', async () => {
+  const pollingService = interpret(
+    authTokenPollingMachine.withConfig({
+      services: {
+        requestAuthToken: () => Promise.reject(),
+      },
+    }),
+  )
+
+  pollingService.start()
+
+  await sleep(0)
+
+  expect(pollingService.state).toMatchState({pending: 'scheduleNextPoll'})
+})

--- a/src/machines/auth-token-polling-machine.ts
+++ b/src/machines/auth-token-polling-machine.ts
@@ -89,7 +89,7 @@ export const authTokenPollingMachine = createMachine<Context, Event>(
     actions: {
       assignAuthToken: assign({
         authToken: (_, event) => {
-          return event.data.authToken
+          return event.data?.authToken
         },
       }),
       increasePollingCount: assign({

--- a/src/utils/test/simulated-clock.ts
+++ b/src/utils/test/simulated-clock.ts
@@ -1,3 +1,6 @@
+// Source: https://github.com/statelyai/xstate/blob/264679d1393095eca54209a790005b3cf48922c7/packages/core/src/SimulatedClock.ts
+// Per XState Discord: https://discord.com/channels/795785288994652170/809564635614150686/898257435750461490
+
 export interface Clock {
   setTimeout(fn: (...args: any[]) => void, timeout: number): any
   clearTimeout(id: any): void

--- a/src/utils/test/simulated-clock.ts
+++ b/src/utils/test/simulated-clock.ts
@@ -1,0 +1,65 @@
+export interface Clock {
+  setTimeout(fn: (...args: any[]) => void, timeout: number): any
+  clearTimeout(id: any): void
+}
+
+export interface SimulatedClock extends Clock {
+  start(speed: number): void
+  increment(ms: number): void
+  set(ms: number): void
+}
+
+interface SimulatedTimeout {
+  start: number
+  timeout: number
+  fn: (...args: any[]) => void
+}
+export class SimulatedClock implements SimulatedClock {
+  private timeouts: Map<number, SimulatedTimeout> = new Map()
+  private _now: number = 0
+  private _id: number = 0
+  public now() {
+    return this._now
+  }
+  private getId() {
+    return this._id++
+  }
+  public setTimeout(fn: (...args: any[]) => void, timeout: number) {
+    const id = this.getId()
+    this.timeouts.set(id, {
+      start: this.now(),
+      timeout,
+      fn,
+    })
+    return id
+  }
+  public clearTimeout(id: number) {
+    this.timeouts.delete(id)
+  }
+  public set(time: number) {
+    if (this._now > time) {
+      throw new Error('Unable to travel back in time')
+    }
+
+    this._now = time
+    this.flushTimeouts()
+  }
+  private flushTimeouts() {
+    ;[...this.timeouts]
+      .sort(([_idA, timeoutA], [_idB, timeoutB]) => {
+        const endA = timeoutA.start + timeoutA.timeout
+        const endB = timeoutB.start + timeoutB.timeout
+        return endB > endA ? -1 : 1
+      })
+      .forEach(([id, timeout]) => {
+        if (this.now() - timeout.start >= timeout.timeout) {
+          this.timeouts.delete(id)
+          timeout.fn.call(null)
+        }
+      })
+  }
+  public increment(ms: number): void {
+    this._now += ms
+    this.flushTimeouts()
+  }
+}


### PR DESCRIPTION
This adds some tests to cover the XState machine that polls the server for an auth token. It adds the `SimulatedClock` module recommended by @davidkpiano for advancing timers used by delayed transitions.

![polling](https://media0.giphy.com/media/3orieZaGxNP4493CVy/giphy.gif?cid=d1fd59abyz1w6tepk9pa0w0kqk09cyfzyjsmru6505j7xe0b&rid=giphy.gif&ct=g)
