### PR TITLE
Remove need for SimClock from one test

### DIFF
--- a/src/machines/auth-token-polling-machine.ts
+++ b/src/machines/auth-token-polling-machine.ts
@@ -51,7 +51,7 @@ export const authTokenPollingMachine = createMachine<Context, Event>(
           },
           scheduleNextPoll: {
             after: {
-              2000: [
+              WAIT_BETWEEN_POLLS: [
                 {target: 'polling', cond: 'pollingLimitNotExceeded'},
                 {target: '#pollingExpired'},
               ],
@@ -107,6 +107,9 @@ export const authTokenPollingMachine = createMachine<Context, Event>(
         // otherwise, return true
         return typeof context.authToken !== 'string'
       },
+    },
+    delays: {
+      WAIT_BETWEEN_POLLS: 2000,
     },
   },
 )


### PR DESCRIPTION
Experimenting with one way of eliminating a conditional and the bleed of implementation details from machine tests.

By making the polling delay configurable and then overriding it to `0ms` in the test, I don't need to `increment` a simulated clock.

![simulated clock](https://media1.giphy.com/media/SFwSpZ4LaQlJqtgub9/giphy.gif?cid=d1fd59abouf3zsb6ez0s1clgyhtowisqx3ja6c2vbasxfc10&rid=giphy.gif&ct=g)