### PR TITLE
Fix session setting on Thank You page

### DIFF
--- a/src/pages/confirm/membership.tsx
+++ b/src/pages/confirm/membership.tsx
@@ -14,8 +14,9 @@ const ConfirmMembershipPage: React.FC = () => {
 
   const [session, setSession] = React.useState<any>()
 
+  const {session_id} = query
+
   React.useEffect(() => {
-    const {session_id} = query
     if (session_id) {
       axios
         .get(`/api/stripe/checkout/session?session_id=${session_id}`)
@@ -27,7 +28,7 @@ const ConfirmMembershipPage: React.FC = () => {
           if (viewer) refreshUser()
         })
     }
-  }, [])
+  }, [session_id])
 
   if (!session) return null
 


### PR DESCRIPTION
This was preventing the Thank You page from rendering.

The useEffect was firing during the initial render when the Router's
`query` object was still empty, so `session_id` was falsy and then the
fetch wasn't firing. This moves it out of the useEffect and adds it to
the dependency array so that the session can get fetched and set.

![session](https://media1.giphy.com/media/3ogsk0BBj8GBBJV2yk/giphy.gif?cid=d1fd59ab8rcmuiq9a38egva83dhzkwbvrby7l69gb36lk7b9&rid=giphy.gif&ct=g)
