### PR TITLE
Show Thank You to signed in user, remove session_id from URL

### DIFF
--- a/src/components/pages/lessons/overlay/confirm-membership.tsx
+++ b/src/components/pages/lessons/overlay/confirm-membership.tsx
@@ -6,6 +6,7 @@ import axios from 'axios'
 import {track} from 'utils/analytics'
 import {useViewer} from 'context/viewer-context'
 import {LessonResource} from '../../../../types'
+import {useRouter} from 'next/router'
 
 type HeaderProps = {
   heading: React.ReactElement
@@ -243,6 +244,7 @@ const ConfirmMembership: React.FC<ConfirmMembershipProps> = ({
   sessionId,
   viewLesson,
 }) => {
+  const router = useRouter()
   const [alreadyAuthenticated, currentState] = usePurchaseAndPlay()
   const [session, setSession] = React.useState<any>()
   const {viewer, refreshUser} = useViewer()
@@ -268,20 +270,31 @@ const ConfirmMembership: React.FC<ConfirmMembershipProps> = ({
   if (loadingSession || currentState.matches('pending'))
     return <LoadingSession />
 
+  const {session_id, ...nonSessionQueryParams} = router.query
+
+  const cleanUrlAndViewLesson = () => {
+    router.replace({
+      pathname: router.pathname,
+      query: nonSessionQueryParams,
+    })
+
+    setTimeout(viewLesson, 750)
+  }
+
   return session ? (
     <div className="w-full max-w-screen-lg mx-auto space-y-16 text-white dark:text-white">
       {alreadyAuthenticated ? (
         <ExistingMemberConfirmation
           lesson={lesson}
           session={session}
-          viewLesson={viewLesson}
+          viewLesson={cleanUrlAndViewLesson}
         />
       ) : (
         <NewMemberConfirmation
           lesson={lesson}
           session={session}
           currentState={currentState}
-          viewLesson={viewLesson}
+          viewLesson={cleanUrlAndViewLesson}
         />
       )}
     </div>

--- a/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
@@ -21,6 +21,7 @@ import {FormikProps, useFormik} from 'formik'
 import Spinner from 'components/spinner'
 import ConfirmMembership from './confirm-membership'
 import {useRouter} from 'next/router'
+import noop from 'utils/noop'
 
 type JoinCTAProps = {
   lesson: LessonResource

--- a/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
@@ -21,6 +21,7 @@ import {FormikProps, useFormik} from 'formik'
 import Spinner from 'components/spinner'
 import ConfirmMembership from './confirm-membership'
 import {useRouter} from 'next/router'
+import noop from 'utils/noop'
 
 type JoinCTAProps = {
   lesson: LessonResource
@@ -289,7 +290,7 @@ const GoProCtaOverlay: FunctionComponent<JoinCTAProps> = ({lesson}) => {
 }
 
 const OverlayParent: FunctionComponent<JoinCTAProps> = ({
-  viewLesson,
+  viewLesson = noop,
   lesson,
 }) => {
   const {query} = useRouter()

--- a/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
@@ -288,8 +288,11 @@ const GoProCtaOverlay: FunctionComponent<JoinCTAProps> = ({lesson}) => {
   )
 }
 
-const OverlayParent: FunctionComponent<JoinCTAProps> = ({lesson}) => {
-  const {query, reload} = useRouter()
+const OverlayParent: FunctionComponent<JoinCTAProps> = ({
+  viewLesson,
+  lesson,
+}) => {
+  const {query} = useRouter()
 
   const {session_id} = query
 
@@ -298,7 +301,7 @@ const OverlayParent: FunctionComponent<JoinCTAProps> = ({lesson}) => {
       <ConfirmMembership
         lesson={lesson}
         sessionId={session_id as string}
-        viewLesson={reload}
+        viewLesson={viewLesson}
       />
     )
   } else {

--- a/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
@@ -21,7 +21,6 @@ import {FormikProps, useFormik} from 'formik'
 import Spinner from 'components/spinner'
 import ConfirmMembership from './confirm-membership'
 import {useRouter} from 'next/router'
-import noop from 'utils/noop'
 
 type JoinCTAProps = {
   lesson: LessonResource

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -325,6 +325,8 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
     }
   }
 
+  const {session_id} = router.query
+
   React.useEffect(() => {
     //TODO: We are doing work here that the lesson machine should
     //be handling but we don't have enough information in the context
@@ -335,17 +337,30 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
       case 'loaded':
         const viewLimitNotReached = watchCount < MAX_FREE_VIEWS
 
-        if (isEmpty(viewer) && free_forever) {
-          if (viewLimitNotReached && mediaPresent) {
+        // TODO: Detangle this nested series of `if` statements to make the
+        // logic more immediately easy to reason about.
+
+        if (session_id) {
+          // If the URL contains the session ID, even if there is a viewer, put
+          // them in the `subscribing` state.
+          send('SUBSCRIBE')
+        } else {
+          if (isEmpty(viewer) && free_forever) {
+            if (viewLimitNotReached && mediaPresent) {
+              send('VIEW')
+            } else {
+              send('JOIN')
+            }
+          } else if (mediaPresent) {
             send('VIEW')
           } else {
-            send('JOIN')
+            // If lesson is not 'free_forever' and the media isn't present,
+            // then we deduce that the lesson is Pro-only and the user needsto
+            // subscribe before viewing it.
+            send('SUBSCRIBE')
           }
-        } else if (mediaPresent) {
-          send('VIEW')
-        } else {
-          send('SUBSCRIBE')
         }
+
         break
       case 'viewing':
         console.debug(
@@ -393,9 +408,14 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
 
         break
     }
-  }, [currentPlayerState])
+  }, [currentPlayerState, session_id])
 
   React.useEffect(() => {
+    // only execute the contents of this effect if the machine is in the
+    // process of loading. Any other Player Machine state change should bail
+    // early.
+    if (currentPlayerState !== 'loading') return
+
     async function run() {
       console.debug('loading video with auth')
       const loadedLesson = await loadLesson(initialLesson.slug)
@@ -427,7 +447,7 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
     })
 
     run()
-  }, [initialLesson.slug])
+  }, [initialLesson.slug, currentPlayerState])
 
   const numberOfComments = filter(
     comments,
@@ -560,12 +580,11 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
                   <GoProCtaOverlay
                     lesson={lesson}
                     viewLesson={() => {
-                      // noop
-                      // TODO: Ideally this would provide a state transition
-                      // that would allow the user to start watching the video.
-                      //
-                      // For now, we are faking it with a `router.reload` in
-                      // the sub-component.
+                      send({
+                        type: 'LOAD',
+                        lesson: initialLesson,
+                        viewer,
+                      })
                     }}
                   />
                 </OverlayWrapper>

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -560,7 +560,12 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
                   <GoProCtaOverlay
                     lesson={lesson}
                     viewLesson={() => {
-                      router.reload()
+                      // noop
+                      // TODO: Ideally this would provide a state transition
+                      // that would allow the user to start watching the video.
+                      //
+                      // For now, we are faking it with a `router.reload` in
+                      // the sub-component.
                     }}
                   />
                 </OverlayWrapper>


### PR DESCRIPTION
_This plays on top of https://github.com/eggheadio/egghead-next/pull/968, but there are some details in the changeset that I wanted to look at separately in the PR review._

This PR does two things:
1. It allows a signed in user who has just completed Stripe Checkout to see the Thank You overlay. Before this, the `useEffect` state transition logic was immediately loading the lesson after checkout.
2. It removes the `session_id` from the URL after we've fetched their session and displayed the Thank You overlay.

![radishes](https://media4.giphy.com/media/l0IyoEU7iKgmUjlao/giphy.gif?cid=d1fd59abav53dkwe0qi9g197q82cwgw2w5jxi67qz0q2s1im&rid=giphy.gif&ct=g)