### PR TITLE
Remove state guard that blocks Next Lesson load

### DIFF
--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -414,7 +414,7 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
     // only execute the contents of this effect if the machine is in the
     // process of loading. Any other Player Machine state change should bail
     // early.
-    if (currentPlayerState !== 'loading') return
+    // if (currentPlayerState !== 'loading') return
 
     async function run() {
       console.debug('loading video with auth')
@@ -447,7 +447,7 @@ const Lesson: React.FC<LessonProps> = ({initialLesson}) => {
     })
 
     run()
-  }, [initialLesson.slug, currentPlayerState])
+  }, [initialLesson.slug])
 
   const numberOfComments = filter(
     comments,


### PR DESCRIPTION
Slack conversation: https://eggheadio.slack.com/archives/G01CAT0P9TL/p1637250599161900

![guard](https://media4.giphy.com/media/l0HUfgeRdp38flYmQ/giphy.gif?cid=d1fd59abm7ije8o5kj5zi4sxlwgrl39hax4p13xuxuyi2mpa&rid=giphy.gif&ct=g)