### PR TITLE
Refactor HP (as separate page)

### DIFF
--- a/src/components/card/horizontal-resource-card.tsx
+++ b/src/components/card/horizontal-resource-card.tsx
@@ -19,7 +19,7 @@ const HorizontalResourceCard: React.FC<any> = ({
   className = 'border-none my-4',
   ...props
 }) => {
-  className = `${className} flex sm:flex-row flex-col sm:space-x-5 space-x-0 sm:space-y-0 space-y-5 items-center sm:text-left text-center`
+  className = `${className} bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden p-5 flex sm:flex-row flex-col sm:space-x-5 space-x-0 sm:space-y-0 space-y-5 items-center sm:text-left text-center`
 
   return (
     <Card {...props} className={className}>

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -162,7 +162,7 @@ const CardAuthor = React.forwardRef(function CardPreview(
         </div>
       )}
       <span className="text-left pl-2 dark:text-indigo-100 text-gray-700 sm:text-sm text-[0.65rem] opacity-80 leading-none">
-        <span className="sr-only">{resource.name} by </span>
+        <span className="sr-only">{resource?.name} by </span>
         {instructor.name}
       </span>
     </Comp>

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
+import Image from 'next/image'
 import {createNamedContext} from '@reach/utils/context'
 import {useId} from '@reach/auto-id'
 import type * as Polymorphic from '@reach/utils/polymorphic'
+import {CardResource} from 'types'
 
 const CardContext = createNamedContext<InternalCardContextValue>(
   'CardContext',
@@ -12,14 +14,17 @@ type InternalCardContextValue = {
   cardId: string | undefined
   quiet: boolean
   horizontal: boolean
+  resource?: CardResource
 }
 
 type CardProps = {
   quiet?: boolean
   horizontal?: boolean
+  resource?: CardResource
 }
 
-const cardDefaultClasses = `bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden p-5`
+const cardDefaultClasses =
+  'bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden p-5'
 
 const Card = React.forwardRef(function Card(
   {
@@ -28,12 +33,14 @@ const Card = React.forwardRef(function Card(
     quiet = false,
     horizontal = false,
     className,
+    resource,
     ...props
   },
   forwardRef,
 ) {
   if (!quiet) {
-    className = `${cardDefaultClasses} ${className ? className : ''}`
+    // className = `${cardDefaultClasses} ${className ? className : ''}`
+    className = `${className ? className : ''}`
   }
   const id = useId(props.id)
   const context: InternalCardContextValue = React.useMemo(
@@ -41,8 +48,9 @@ const Card = React.forwardRef(function Card(
       cardId: id,
       quiet,
       horizontal,
+      resource,
     }),
-    [quiet, id, horizontal],
+    [quiet, id, horizontal, resource],
   )
 
   return (
@@ -119,6 +127,48 @@ const CardBody = React.forwardRef(function CardPreview(
   )
 }) as Polymorphic.ForwardRefComponent<'div', CardBodyProps>
 
+type CardAuthorProps = {}
+
+const CardAuthor = React.forwardRef(function CardPreview(
+  {
+    children,
+    as: Comp = 'div',
+    className = 'flex items-center justify-center pt-4',
+    ...props
+  },
+  forwardRef,
+) {
+  const {resource} = React.useContext(CardContext)
+  const instructor = resource?.instructor
+  if (!instructor) return null
+
+  return (
+    <Comp
+      {...props}
+      className={className}
+      ref={forwardRef}
+      data-egghead-card-author=""
+    >
+      {instructor.image && (
+        <div className="w-5 h-5 overflow-hidden rounded-full sm:w-7 sm:h-7">
+          <Image
+            aria-hidden
+            src={instructor.image}
+            alt={instructor.name}
+            width={32}
+            height={32}
+            className="rounded-full"
+          />
+        </div>
+      )}
+      <span className="text-left pl-2 dark:text-indigo-100 text-gray-700 sm:text-sm text-[0.65rem] opacity-80 leading-none">
+        <span className="sr-only">{resource.name} by </span>
+        {instructor.name}
+      </span>
+    </Comp>
+  )
+}) as Polymorphic.ForwardRefComponent<'div', CardAuthorProps>
+
 type CardMetaProps = {}
 
 const CardMeta = React.forwardRef(function CardPreview(
@@ -157,6 +207,7 @@ export type {
   CardBodyProps,
   CardMetaProps,
   CardFooterProps,
+  CardAuthorProps,
 }
 
 export {
@@ -167,4 +218,5 @@ export {
   CardBody,
   CardMeta,
   CardFooter,
+  CardAuthor,
 }

--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import {
+  Card,
+  CardPreview,
+  CardHeader,
+  CardContent,
+  CardBody,
+  CardMeta,
+  CardAuthor,
+  CardFooter,
+} from './index'
+import Image from 'next/image'
+import Link from 'next/link'
+import Markdown from '../markdown'
+import {track} from 'utils/analytics'
+import {get, isEmpty} from 'lodash'
+import {CardResource} from 'types'
+import {Textfit} from 'react-textfit'
+import ReactMarkdown from 'react-markdown'
+
+const HorizontalResourceCard: React.FC<{
+  resource: CardResource
+  location?: string
+  describe?: boolean
+  className?: string
+}> = ({
+  children,
+  resource,
+  location,
+  className = '',
+  describe = false,
+  ...props
+}) => {
+  if (isEmpty(resource)) return null
+  const defaultClassName =
+    'rounded-md sm:aspect-w-4 aspect-w-3 sm:aspect-h-2 aspect-h-4 w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50'
+  return (
+    <ResourceLink
+      path={resource.path}
+      location={location}
+      className={className}
+    >
+      <Card {...props} resource={resource} className={defaultClassName}>
+        <CardContent className="grid sm:grid-cols-8 sm:gap-5 items-center px-5">
+          <CardHeader className="sm:col-span-3 flex items-center justify-center">
+            <PreviewImage image={resource.image} title={resource.title} />
+          </CardHeader>
+          <CardMeta className="sm:col-span-5">
+            <p
+              aria-hidden
+              className="uppercase font-medium text-[0.65rem] pb-1 text-gray-700 dark:text-indigo-100 opacity-60"
+            >
+              {resource.name}
+            </p>
+            <Textfit
+              mode="multi"
+              className="sm:h-[70px] h-[50px] font-medium leading-tight flex items-center"
+              max={22}
+            >
+              <h3>{resource.title}</h3>
+            </Textfit>
+            {resource.description && (
+              <ReactMarkdown className="pt-2 prose dark:prose-dark prose-sm dark:text-gray-300 text-gray-700">
+                {resource.description}
+              </ReactMarkdown>
+            )}
+            <CardFooter>
+              <CardAuthor className="flex items-center pt-4" />
+            </CardFooter>
+          </CardMeta>
+          {describe && (
+            <CardBody className="prose dark:prose-dark dark:prose-dark-sm prose-sm max-w-none">
+              <Markdown>{resource.description}</Markdown>
+            </CardBody>
+          )}
+        </CardContent>
+        {children}
+      </Card>
+    </ResourceLink>
+  )
+}
+
+export const ResourceLink: React.FC<{
+  path: string
+  location?: string
+  className?: string
+  linkType?: string
+}> = ({children, path, location, linkType = 'text', ...props}) => (
+  <Link href={path}>
+    <a
+      onClick={() => {
+        track('clicked resource', {
+          resource: path,
+          linkType,
+          location,
+        })
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  </Link>
+)
+
+const PreviewImage: React.FC<{title: string; image: any}> = ({
+  title,
+  image,
+}) => {
+  if (!image) return null
+
+  return (
+    <CardPreview className="relative flex items-center justify-center w-full xl:max-w-[200px] sm:max-w-[150px] max-w-[150px]">
+      <Image
+        aria-hidden
+        src={get(image, 'src', image)}
+        width={200}
+        height={200}
+        quality={100}
+        alt=""
+      />
+    </CardPreview>
+  )
+}
+export {HorizontalResourceCard}

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react'
+import {
+  Card,
+  CardPreview,
+  CardHeader,
+  CardContent,
+  CardBody,
+  CardMeta,
+  CardAuthor,
+  CardFooter,
+} from './index'
+import Image from 'next/image'
+import Link from 'next/link'
+import Markdown from '../markdown'
+import {track} from 'utils/analytics'
+import {get, isEmpty} from 'lodash'
+import {CardResource} from 'types'
+import {Textfit} from 'react-textfit'
+
+const VerticalResourceCard: React.FC<{
+  resource: CardResource
+  location?: string
+  describe?: boolean
+  className?: string
+}> = ({
+  children,
+  resource,
+  location,
+  className = 'rounded-md aspect-w-3 aspect-h-4 w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50',
+  describe = false,
+  ...props
+}) => {
+  if (isEmpty(resource)) return null
+
+  return (
+    <ResourceLink path={resource.path} location={location}>
+      <Card {...props} resource={resource} className={className}>
+        <CardContent className="grid grid-rows-7">
+          <CardHeader className="flex items-center justify-center row-span-4">
+            <PreviewImage image={resource.image} title={resource.title} />
+          </CardHeader>
+          <CardMeta className="row-span-2 px-5 text-center">
+            <p
+              aria-hidden
+              className="uppercase font-medium text-[0.65rem] pb-1 text-gray-700 dark:text-indigo-100 opacity-60"
+            >
+              {resource.name}
+            </p>
+            <Textfit
+              mode="multi"
+              className="sm:h-[70px] h-[50px] font-medium text-center leading-tight flex items-center justify-center"
+              max={22}
+            >
+              <h3>{resource.title}</h3>
+            </Textfit>
+            <CardFooter>
+              <CardAuthor />
+            </CardFooter>
+          </CardMeta>
+          {describe && (
+            <CardBody className="prose dark:prose-dark dark:prose-dark-sm prose-sm max-w-none">
+              <Markdown>{resource.description}</Markdown>
+            </CardBody>
+          )}
+        </CardContent>
+        {children}
+      </Card>
+    </ResourceLink>
+  )
+}
+
+export const ResourceLink: React.FC<{
+  path: string
+  location?: string
+  className?: string
+  linkType?: string
+}> = ({children, path, location, linkType = 'text', ...props}) => (
+  <Link href={path}>
+    <a
+      onClick={() => {
+        track('clicked resource', {
+          resource: path,
+          linkType,
+          location,
+        })
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  </Link>
+)
+
+const PreviewImage: React.FC<{title: string; image: any}> = ({
+  title,
+  image,
+}) => {
+  if (!image) return null
+
+  return (
+    <CardPreview className="relative flex items-center justify-center w-full xl:max-w-[180px] sm:max-w-[150px] max-w-[90px]">
+      <Image
+        aria-hidden
+        src={get(image, 'src', image)}
+        width={180}
+        height={180}
+        quality={100}
+        alt=""
+      />
+    </CardPreview>
+  )
+}
+export {VerticalResourceCard}

--- a/src/components/card/verticle-resource-card.tsx
+++ b/src/components/card/verticle-resource-card.tsx
@@ -23,12 +23,17 @@ const VerticalResourceCard: React.FC<{
   children,
   resource,
   location,
-  className = 'border-none flex flex-col items-center justify-center text-center sm:py-8 py-6',
+  className = 'bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden p-5 border-none flex flex-col items-center justify-center text-center sm:py-8 py-6',
   describe = false,
   ...props
 }) => {
   return (
-    <Card {...props} className={className}>
+    <Card
+      {...props}
+      className={
+        'bg-white dark:bg-gray-800 dark:text-gray-200 shadow-sm rounded-lg overflow-hidden p-5 border-none flex flex-col items-center justify-center text-center sm:py-8 py-6'
+      }
+    >
       {resource.image && resource.path ? (
         <ResourceLink path={resource.path} location={location} linkType="image">
           <PreviewImage image={resource.image} title={resource.title} />

--- a/src/components/grid/index.tsx
+++ b/src/components/grid/index.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import type * as Polymorphic from '@reach/utils/polymorphic'
+
+type GridProps = {}
+
+const gridDefaultClasses =
+  'grid grid-cols-2 gap-2 lg:grid-cols-4 md:grid-cols-3 xl:gap-5 sm:gap-3'
+
+const Grid = React.forwardRef(function Grid(
+  {children, as: Comp = 'div', className, ...props},
+  forwardRef,
+) {
+  return (
+    <Comp
+      className={className ? className : gridDefaultClasses}
+      ref={forwardRef}
+      {...props}
+    >
+      {children}
+    </Comp>
+  )
+}) as Polymorphic.ForwardRefComponent<'div', GridProps>
+
+export default Grid

--- a/src/components/pages/20-days-of-egghead/course-grid.tsx
+++ b/src/components/pages/20-days-of-egghead/course-grid.tsx
@@ -25,104 +25,131 @@ const CourseGrid: React.FC<CourseGridProps> = ({data}) => {
   })
 
   return (
-    <div className="grid grid-cols-2 gap-2 lg:grid-cols-4 md:grid-cols-3 xl:gap-5 sm:gap-3">
-      {data?.resources?.map((resource, i) => {
-        if (!resource.title) return null
+    <>
+      <Header />
+      <div className="grid grid-cols-2 gap-2 lg:grid-cols-4 md:grid-cols-3 xl:gap-5 sm:gap-3">
+        {data?.resources?.map((resource, i) => {
+          if (!resource.title) return null
 
-        const published = calendar[i].isPublished
-        const LinkOrDiv: React.FC<any> = ({className, children, ...props}) =>
-          published && resource.path ? (
-            <Link href={resource.path}>
-              <a className={className}>{children}</a>
-            </Link>
-          ) : (
-            <div className={className}>{children}</div>
-          )
-        const upcoming =
-          !isFuture(startDate) &&
-          first(calendar.filter((day) => !day.isPublished))?.date ===
-            calendar[i].date
+          const published = calendar[i].isPublished
+          const LinkOrDiv: React.FC<any> = ({className, children, ...props}) =>
+            published && resource.path ? (
+              <Link href={resource.path}>
+                <a className={className}>{children}</a>
+              </Link>
+            ) : (
+              <div className={className}>{children}</div>
+            )
+          const upcoming =
+            !isFuture(startDate) &&
+            first(calendar.filter((day) => !day.isPublished))?.date ===
+              calendar[i].date
 
-        return (
-          <LinkOrDiv
-            key={resource.id}
-            className={`rounded-md aspect-w-3 aspect-h-4 h-full w-full transition-all ease-in-out duration-200 relative overflow-hidden 
+          return (
+            <LinkOrDiv
+              key={resource.id}
+              className={`rounded-md aspect-w-3 aspect-h-4 h-full w-full transition-all ease-in-out duration-200 relative overflow-hidden 
             ${classNames({
               'group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 ':
                 published,
               'dark:bg-gray-1000 bg-gray-50 dark:bg-opacity-50 border-2 border-dotted border-collapse dark:border-gray-800 border-gray-200':
                 !published,
             })}`}
-          >
-            <div className="grid grid-rows-7">
-              <div className="flex items-center justify-center row-span-4">
-                <div className="relative flex items-center justify-center w-full xl:max-w-[180px] sm:max-w-[150px] max-w-[90px]">
-                  <Image
-                    src={resource.image as string}
-                    alt={resource.title}
-                    width={240}
-                    height={240}
-                    quality={100}
-                    loading="eager"
-                    className={`group-hover:scale-90 group-hover:opacity-90 transition-all ease-in-out duration-300 ${classNames(
-                      {
-                        'saturate-0 opacity-20': !published,
-                      },
-                    )}`}
-                  />
-                  {published && (
-                    <div className="absolute flex items-center justify-center w-10 h-10 font-mono text-xs leading-none transition-all duration-300 ease-in-out origin-center scale-0 bg-white rounded-full opacity-0 group-hover:scale-100 bg-opacity-90 shadow-smooth group-hover:opacity-100">
-                      <PlayIcon className="w-3 dark:text-gray-900" />
-                    </div>
-                  )}
-                </div>
-              </div>
-              {published && (
-                <div className="row-span-2 px-5 text-center">
-                  <h4>
-                    <Textfit
-                      aria-hidden
-                      mode="multi"
-                      className="sm:h-[70px] h-[50px] font-medium text-center leading-tight flex items-center justify-center"
-                      max={22}
-                    >
-                      {resource.title}
-                    </Textfit>
-                  </h4>
-                  {resource.instructor && (
-                    <div className="flex items-center justify-center pt-4">
-                      <div className="w-5 h-5 overflow-hidden rounded-full sm:w-7 sm:h-7">
-                        <Image
-                          src={resource.instructor.image}
-                          alt={resource.instructor.name}
-                          width={32}
-                          height={32}
-                          className="rounded-full"
-                        />
+            >
+              <div className="grid grid-rows-7">
+                <div className="flex items-center justify-center row-span-4">
+                  <div className="relative flex items-center justify-center w-full xl:max-w-[180px] sm:max-w-[150px] max-w-[90px]">
+                    <Image
+                      src={resource.image as string}
+                      alt={resource.title}
+                      width={240}
+                      height={240}
+                      quality={100}
+                      loading="eager"
+                      className={`group-hover:scale-90 group-hover:opacity-90 transition-all ease-in-out duration-300 ${classNames(
+                        {
+                          'saturate-0 opacity-20': !published,
+                        },
+                      )}`}
+                    />
+                    {published && (
+                      <div className="absolute flex items-center justify-center w-10 h-10 font-mono text-xs leading-none transition-all duration-300 ease-in-out origin-center scale-0 bg-white rounded-full opacity-0 group-hover:scale-100 bg-opacity-90 shadow-smooth group-hover:opacity-100">
+                        <PlayIcon className="w-3 dark:text-gray-900" />
                       </div>
-                      <span className="text-left pl-2 dark:text-indigo-100 text-gray-700 sm:text-sm text-[0.65rem] opacity-80 leading-none">
-                        {resource.instructor.name}
-                      </span>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
-              )}
-              {upcoming && (
-                <div className="absolute flex items-center justify-center w-full text-xs text-center text-gray-500 lg:bottom-9 sm:bottom-6 bottom-5 sm:text-sm leading-tighter dark:text-gray-300">
-                  Check back tomorrow!
-                  {/* {formatDistanceToNow(calendar[i].date, {addSuffix: true,})} */}
-                </div>
-              )}
-              {!published && (
-                <div className="font-mono sm:text-xs text-[0.6rem] leading-none absolute top-2 right-2 sm:w-8 sm:h-8 w-6 h-6 dark:bg-gray-800 bg-white rounded-full flex items-center justify-center border dark:border-transparent border-gray-200">
-                  {i + 1}
-                </div>
-              )}
-            </div>
-          </LinkOrDiv>
-        )
-      })}
-    </div>
+                {published && (
+                  <div className="row-span-2 px-5 text-center">
+                    <h4>
+                      <Textfit
+                        aria-hidden
+                        mode="multi"
+                        className="sm:h-[70px] h-[50px] font-medium text-center leading-tight flex items-center justify-center"
+                        max={22}
+                      >
+                        {resource.title}
+                      </Textfit>
+                    </h4>
+                    {resource.instructor && (
+                      <div className="flex items-center justify-center pt-4">
+                        <div className="w-5 h-5 overflow-hidden rounded-full sm:w-7 sm:h-7">
+                          <Image
+                            src={resource.instructor.image}
+                            alt={resource.instructor.name}
+                            width={32}
+                            height={32}
+                            className="rounded-full"
+                          />
+                        </div>
+                        <span className="text-left pl-2 dark:text-indigo-100 text-gray-700 sm:text-sm text-[0.65rem] opacity-80 leading-none">
+                          {resource.instructor.name}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                )}
+                {upcoming && (
+                  <div className="absolute flex items-center justify-center w-full text-xs text-center text-gray-500 lg:bottom-9 sm:bottom-6 bottom-5 sm:text-sm leading-tighter dark:text-gray-300">
+                    Check back tomorrow!
+                    {/* {formatDistanceToNow(calendar[i].date, {addSuffix: true,})} */}
+                  </div>
+                )}
+                {!published && (
+                  <div className="font-mono sm:text-xs text-[0.6rem] leading-none absolute top-2 right-2 sm:w-8 sm:h-8 w-6 h-6 dark:bg-gray-800 bg-white rounded-full flex items-center justify-center border dark:border-transparent border-gray-200">
+                    {i + 1}
+                  </div>
+                )}
+              </div>
+            </LinkOrDiv>
+          )
+        })}
+      </div>
+    </>
+  )
+}
+
+const Header = () => {
+  return (
+    <header className="relative flex flex-col items-center justify-center w-full max-w-screen-xl px-5 py-24 mx-auto text-center sm:py-40">
+      <h3 className="relative z-10 pb-2 text-2xl font-bold leading-none tracking-tight md:text-4xl sm:text-3xl">
+        Holiday Course <br /> Release Extravaganza
+      </h3>
+      <p className="max-w-md pt-2 text-sm text-blue-500 opacity-90 dark:text-pink-200 sm:text-base">
+        We'll be releasing 20 badass courses during the holiday season, that'll
+        help you jumpstart your career in 2022
+      </p>
+      <Image
+        src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1637069708/egghead-next-pages/20-days-of-egghead/bg_2x.png"
+        quality={100}
+        layout="fill"
+        objectFit="cover"
+        objectPosition="50% 50%"
+        alt=""
+        aria-hidden
+        className="pointer-events-none sm:opacity-100 opacity-20"
+      />
+    </header>
   )
 }
 

--- a/src/lib/holiday-sale.ts
+++ b/src/lib/holiday-sale.ts
@@ -1,0 +1,40 @@
+import CourseGrid from 'components/pages/20-days-of-egghead/course-grid'
+import {sanityClient} from 'utils/sanity-client'
+import {CardResource} from 'types'
+import groq from 'groq'
+
+const holidaySaleOn = process.env.NEXT_PUBLIC_EOY_SALE
+
+export type HolidaySaleProps = {
+  data: CardResource
+}
+
+async function loadHolidayCourses() {
+  const data = await sanityClient.fetch(
+    groq`
+            *[slug.current == $slug][0]{
+              title,
+              resources[]->{
+                'id': _id,
+                title,
+                'slug': slug.current,
+                image,
+                path,
+                'instructor': collaborators[]->[role == 'instructor'][0]{
+                  title,
+                  'slug': person->slug.current,
+                  'name': person->name,
+                  'path': person->website,
+                  'twitter': person->twitter,
+                  'image': person->image.url
+                },
+              }
+            }
+          `,
+    {slug: '20-days-of-egghead'},
+  )
+
+  return data
+}
+
+export {holidaySaleOn, loadHolidayCourses, CourseGrid}

--- a/src/pages/20-days.tsx
+++ b/src/pages/20-days.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react'
-import groq from 'groq'
-import Image from 'next/image'
 import {NextSeo} from 'next-seo'
 import {CardResource} from 'types'
 import {GetServerSideProps} from 'next'
-import {sanityClient} from 'utils/sanity-client'
 import CourseGrid from 'components/pages/20-days-of-egghead/course-grid'
+import {loadHolidayCourses} from 'lib/holiday-sale'
 
 type EOYSale2021PageProps = {
   data: CardResource
@@ -18,25 +16,6 @@ const EOYSale2021Page: React.FC<EOYSale2021PageProps> & {getLayout?: any} = ({
     <>
       <NextSeo noindex={true} title={'20 days of egghead'} />
       <div className="dark:bg-gray-900 bg-gray-50">
-        <header className="relative flex flex-col items-center justify-center w-full max-w-screen-xl px-5 py-24 mx-auto text-center sm:py-40">
-          <h3 className="relative z-10 pb-2 text-2xl font-bold leading-none tracking-tight md:text-4xl sm:text-3xl">
-            Holiday Course <br /> Release Extravaganza
-          </h3>
-          <p className="max-w-md pt-2 text-sm text-blue-500 opacity-90 dark:text-pink-200 sm:text-base">
-            We'll be releasing 20 badass courses during the holiday season,
-            that'll help you jumpstart your career in 2022
-          </p>
-          <Image
-            src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1637069708/egghead-next-pages/20-days-of-egghead/bg_2x.png"
-            quality={100}
-            layout="fill"
-            objectFit="cover"
-            objectPosition="50% 50%"
-            alt=""
-            aria-hidden
-            className="pointer-events-none sm:opacity-100 opacity-20"
-          />
-        </header>
         <div className="container px-3">
           <CourseGrid data={data} />
         </div>
@@ -47,36 +26,8 @@ const EOYSale2021Page: React.FC<EOYSale2021PageProps> & {getLayout?: any} = ({
 
 export default EOYSale2021Page
 
-async function loadResource(slug: string) {
-  const data = await sanityClient.fetch(
-    groq`
-          *[slug.current == $slug][0]{
-            title,
-            resources[]->{
-              'id': _id,
-              title,
-              'slug': slug.current,
-              image,
-              path,
-              'instructor': collaborators[]->[role == 'instructor'][0]{
-                title,
-                'slug': person->slug.current,
-                'name': person->name,
-                'path': person->website,
-                'twitter': person->twitter,
-                'image': person->image.url
-              },
-            }
-          }
-        `,
-    {slug},
-  )
-
-  return data
-}
-
 export const getServerSideProps: GetServerSideProps = async ({res, params}) => {
-  const data = await loadResource('20-days-of-egghead')
+  const data = await loadHolidayCourses()
 
   return {
     props: {

--- a/src/pages/curated-topics.tsx
+++ b/src/pages/curated-topics.tsx
@@ -137,7 +137,7 @@ const Jumbotron: React.FC<any> = ({data}) => {
   const resource = data.resources[0]
   return (
     <ResourceLink location="jumbotron" path={resource.path} className="group">
-      <header className="md:aspect-w-16 md:aspect-h-6 relative rounded-b-lg text-white ">
+      <header className="md:aspect-w-16 md:aspect-h-6 relative h-full rounded-b-lg text-white ">
         <div className="flex items-center justify-center relative z-10 md:pb-16 pb-32 md:px-0 px-5 md:pt-0 pt-10">
           <div className="w-full max-w-screen-md flex md:flex-row flex-col items-center justify-center md:text-left text-center ">
             <div
@@ -192,6 +192,7 @@ const Jumbotron: React.FC<any> = ({data}) => {
           alt=""
           src={data.image}
           layout="fill"
+          priority={true}
           quality={100}
           className="pointer-events-none md:object-contain object-cover"
         />

--- a/src/pages/curated-topics.tsx
+++ b/src/pages/curated-topics.tsx
@@ -1,0 +1,354 @@
+import React, {FunctionComponent} from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import find from 'lodash/find'
+import isEmpty from 'lodash/isEmpty'
+import get from 'lodash/get'
+import {track} from 'utils/analytics'
+import axios from 'utils/configured-axios'
+import {CardResource} from 'types'
+import {
+  VerticalResourceCard,
+  ResourceLink,
+} from 'components/card/new-vertical-resource-card'
+import PlayIcon from 'components/pages/courses/play-icon'
+import {CourseGrid} from 'lib/holiday-sale'
+import Grid from 'components/grid'
+import groq from 'groq'
+import {sanityClient} from 'utils/sanity-client'
+import {loadHolidayCourses, holidaySaleOn} from 'lib/holiday-sale'
+import {useRouter} from 'next/router'
+import {Form, Formik} from 'formik'
+import {NextSeo} from 'next-seo'
+import ReactMarkdown from 'react-markdown'
+
+const CuratedTopics: FunctionComponent<any> = ({data, holidayCourses}) => {
+  const location = 'home landing'
+  const jumbotron = find(data.sections, {slug: 'jumbotron'})
+  const ogImage = get(jumbotron, 'resources[0].ogImage')
+
+  return (
+    <>
+      <NextSeo
+        // canonical={process.env.NEXT_PUBLIC_DEPLOYMENT_URL}
+        openGraph={{
+          images: [
+            {
+              url: ogImage
+                ? ogImage
+                : 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png',
+            },
+          ],
+        }}
+      />
+      <div className="dark:bg-gray-900 bg-gray-100">
+        {!isEmpty(holidayCourses) ? (
+          <div className="container">
+            <CourseGrid data={holidayCourses} />
+          </div>
+        ) : (
+          <div className="md:container">
+            <Jumbotron data={jumbotron} />
+          </div>
+        )}
+        <div className="container">
+          <main className="sm:pt-16 pt-8">
+            {data.sections
+              .filter((s: any) => s.slug !== 'jumbotron')
+              .map((section: any, i: number) => {
+                return section.slug === 'topics' ? (
+                  <Topics data={section} />
+                ) : (
+                  <section className="pb-16" key={section.id}>
+                    {!section.image && !section.description ? (
+                      // simple section
+                      <div className="flex w-full pb-6 items-center justify-between">
+                        <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+                          {section.title}
+                        </h2>
+                      </div>
+                    ) : (
+                      // section with image and description
+                      <div className="flex md:flex-row flex-col md:items-start items-center justify-center w-full mb-5 pb-8">
+                        {section.image && (
+                          <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
+                            <Image
+                              aria-hidden
+                              src={section.image}
+                              quality={100}
+                              width={320}
+                              height={320}
+                              alt=""
+                            />
+                          </div>
+                        )}
+                        <div>
+                          <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
+                            {section.title}
+                          </h2>
+                          {section.description && (
+                            <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700">
+                              {section.description}
+                            </ReactMarkdown>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                    <Grid>
+                      {section.resources.map((resource: CardResource) => {
+                        return (
+                          <VerticalResourceCard
+                            key={resource.id}
+                            resource={resource}
+                            location={location}
+                          />
+                        )
+                      })}
+                    </Grid>
+                    {section.path && (
+                      <div className="flex justify-end mt-3">
+                        <Link href={section.path} passHref>
+                          <a className="flex items-center text-sm px-4 py-3 border-b-2 dark:border-gray-800 bg-transparent  border-gray-200 border-opacity-70 dark:hover:bg-gray-800 dark:hover:bg-opacity-50 opacity-80 hover:opacity-100 transition-all ease-in-out duration-200 group">
+                            Browse all{' '}
+                            <span
+                              className="pl-1 group-hover:translate-x-1 transition-all ease-in-out duration-200"
+                              aria-hidden
+                            >
+                              →
+                            </span>
+                          </a>
+                        </Link>
+                      </div>
+                    )}
+                  </section>
+                )
+              })}
+            <Search />
+          </main>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default CuratedTopics
+
+const Jumbotron: React.FC<any> = ({data}) => {
+  const resource = data.resources[0]
+  return (
+    <ResourceLink location="jumbotron" path={resource.path} className="group">
+      <header className="md:aspect-w-16 md:aspect-h-6 relative rounded-b-lg text-white ">
+        <div className="flex items-center justify-center relative z-10 md:pb-16 pb-32 md:px-0 px-5 md:pt-0 pt-10">
+          <div className="w-full max-w-screen-md flex md:flex-row flex-col items-center justify-center md:text-left text-center ">
+            <div
+              aria-hidden
+              className="flex-shrink-0 relative flex items-center justify-center lg:max-w-none md:max-w-[220px] max-w-[180px] p-5"
+            >
+              <Image
+                src={resource.image}
+                alt={resource.title}
+                width={240}
+                height={240}
+                quality={100}
+                loading="eager"
+                priority
+                className="group-hover:scale-95 group-hover:opacity-90 transition-all ease-in-out duration-300"
+              />
+              <div
+                aria-hidden
+                className="absolute flex items-center justify-center group-hover:opacity-100 opacity-0 group-hover:scale-100 scale-0 transition-all ease-in-out duration-300 w-10 h-10 rounded-full bg-white bg-opacity-80 shadow-smooth"
+              >
+                <PlayIcon className="w-4 text-black" />
+              </div>
+            </div>
+            <div className="md:pl-10">
+              <p className="uppercase font-mono text-xs pb-1 opacity-80">
+                Fresh Course
+              </p>
+              <h1 className="md:pt-0 pt-5 leading-tighter lg:text-3xl sm:text-2xl text-xl tracking-tight font-bold">
+                {resource.title}
+              </h1>
+              <div className="flex items-center md:justify-start justify-center py-4">
+                <div className="flex items-center justify-center rounded-full overflow-hidden">
+                  <Image
+                    aria-hidden
+                    alt={resource.instructor.name}
+                    src={resource.instructor.image}
+                    width={32}
+                    height={32}
+                  />
+                </div>
+                <p className="pl-2 text-sm opacity-80 leading-none">
+                  <span className="sr-only">{resource.type} by </span>
+                  {resource.instructor.name}
+                </p>
+              </div>
+              <p className="opacity-80 text-sm">{resource.description}</p>
+            </div>
+          </div>
+        </div>
+        <Image
+          aria-hidden
+          alt=""
+          src={data.image}
+          layout="fill"
+          quality={100}
+          className="pointer-events-none md:object-contain object-cover"
+        />
+      </header>
+    </ResourceLink>
+  )
+}
+
+const Search = () => {
+  const router = useRouter()
+  return (
+    <div className="pt-8 pb-24 flex flex-col items-center w-full">
+      <Image
+        src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1637330011/egghead-next-pages/home-page/monocle-eggo.png"
+        alt=""
+        aria-hidden
+        width={200}
+        height={200}
+      />
+
+      <Formik
+        initialValues={{
+          query: '',
+        }}
+        onSubmit={(values) => {
+          if (isEmpty(values.query)) {
+            router.push(`/q`)
+            track('clicked search icon with no query', {
+              location: 'home',
+            })
+          } else {
+            router.push(`/q?q=${values.query?.split(' ').join('+')}`)
+            track('searched for query', {
+              query: values.query,
+              location: 'home',
+            })
+          }
+        }}
+      >
+        {({values, handleChange}) => {
+          return (
+            <Form role="search" className="w-full">
+              <h2 className="text-center lg:text-2xl sm:text-xl text-lg font-medium leading-tighter pb-8">
+                What are you going to learn today?
+              </h2>
+              <div className="max-w-lg w-full mx-auto relative flex items-center">
+                <input
+                  name="query"
+                  value={values.query}
+                  onChange={handleChange}
+                  type="search"
+                  placeholder={`React, TypeScript, AWS, CSS...`}
+                  autoComplete="off"
+                  className="w-full py-4 px-5 pr-16 lg:text-lg sm:text-base text-sm rounded-lg dark:bg-gray-1000 border dark:border-gray-800 bg-white border-transparent focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-400"
+                />
+                <button
+                  type="submit"
+                  className="sm:text-base text-sm absolute px-5 text-white right-0 bg-gradient-to-t from-blue-600 to-blue-500 h-full rounded-r-lg transition-all ease-in-out duration-200"
+                >
+                  Search egghead
+                </button>
+              </div>
+            </Form>
+          )
+        }}
+      </Formik>
+    </div>
+  )
+}
+
+const Topics: React.FC<{data: any}> = ({data}) => {
+  const {topics} = data
+  return (
+    <div className="sm:pt-10 sm:pb-32 pt-0 pb-16">
+      <h2 className="text-center lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-6">
+        {data.title}
+      </h2>
+      <div className="grid lg:grid-cols-8 sm:grid-cols-4 grid-cols-3 xl:gap-5 gap-3 max-w-screen-lg mx-auto">
+        {topics?.map(({path, title, slug, image}: any) => {
+          return (
+            <Link href={path}>
+              <a
+                className="flex flex-col items-center hover:shadow-smooth justify-center px-5 py-8 rounded-lg dark:bg-gray-800 dark:bg-opacity-60 dark:hover:bg-opacity-100 hover:bg-white ease-in-out transition-all duration-200"
+                onClick={() => {
+                  track('clicked home page topic', {
+                    topic: title,
+                  })
+                  axios.post(`/api/topic`, {
+                    topic: slug,
+                    amount: 1,
+                  })
+                }}
+              >
+                <div className="sm:w-auto w-8">
+                  {image && (
+                    <Image
+                      aria-hidden
+                      src={image}
+                      width={48}
+                      height={48}
+                      alt={title}
+                    />
+                  )}
+                </div>
+                <h3 className="sm:text-base text-sm text-center sm:pt-3 pt-2">
+                  {title}
+                </h3>
+              </a>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-home-page"][0]{
+    title,
+    'sections': resources[]{
+      'id': _id,
+      title,
+      'slug': slug.current,
+      image,
+      path,
+      description,
+      'topics': resources[]{
+        'id': _id,
+        title,
+        path,
+        image,
+      },
+      resources[]->{
+        'id': _id,
+        title,
+        'name': type,
+        'description': summary,
+        path,
+        image,
+        images,
+        'ogImage': images[label == 'og-image'][0].url,
+        'instructor': collaborators[]->[role == 'instructor'][0]{
+            'name': person->name,
+            'image': person->image.url
+            },
+        }
+    }
+  }`
+
+export async function getStaticProps() {
+  const data = await sanityClient.fetch(homepageQuery)
+
+  const holidayCourses = holidaySaleOn ? await loadHolidayCourses() : {}
+
+  return {
+    props: {
+      holidayCourses,
+      data,
+    },
+  }
+}

--- a/src/pages/curated-topics.tsx
+++ b/src/pages/curated-topics.tsx
@@ -21,6 +21,7 @@ import {useRouter} from 'next/router'
 import {Form, Formik} from 'formik'
 import {NextSeo} from 'next-seo'
 import ReactMarkdown from 'react-markdown'
+import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 
 const CuratedTopics: FunctionComponent<any> = ({data, holidayCourses}) => {
   const location = 'home landing'
@@ -95,15 +96,25 @@ const CuratedTopics: FunctionComponent<any> = ({data, holidayCourses}) => {
                       </div>
                     )}
                     <Grid>
-                      {section.resources.map((resource: CardResource) => {
-                        return (
-                          <VerticalResourceCard
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
-                      })}
+                      {section.resources.map(
+                        (resource: CardResource, i: number) => {
+                          // if there are only 3 resources, the first one will use HorizontalResourceCard
+                          return section.resources.length === 3 && i === 0 ? (
+                            <HorizontalResourceCard
+                              className="col-span-2"
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          ) : (
+                            <VerticalResourceCard
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                        },
+                      )}
                     </Grid>
                     {section.path && (
                       <div className="flex justify-end mt-3">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ const IndexPage: FunctionComponent = ({homePageData}: any) => {
           ],
         }}
       />
-      <main className="pt-8 bg-gray-50 dark:bg-gray-900">
+      <main className="bg-gray-50 dark:bg-gray-900">
         <div className="container">
           <Home homePageData={homePageData} />
         </div>
@@ -46,7 +46,7 @@ export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "what
       'name': type,
       'description': summary,
     	path,
-      'byline': meta,
+      byline,
     	image,
       'background': images[label == 'banner-image-blank'][0].url,
       'featureCardBackground': images[label == 'feature-card-background'][0].url,
@@ -63,11 +63,20 @@ export const whatsNewQuery = groq`*[_type == 'resource' && slug.current == "what
   },
 	'secondary': resources[slug.current == 'new-page-secondary-resource-collection'][0]{
     resources[]{
-      'name': type,
       title,
+      'name': type,
+      'description': summary,
       path,
       byline,
       image,
+      'instructor': collaborators[]->[role == 'instructor'][0]{
+        title,
+        'slug': person->slug.current,
+        'name': person->name,
+        'path': person->website,
+        'twitter': person->twitter,
+        'image': person->image.url
+  		},
     }
   },
 }`

--- a/studio/deskStructure.js
+++ b/studio/deskStructure.js
@@ -3,6 +3,7 @@ import blog from './src/structure/blog'
 import caseStudies from './src/structure/caseStudies'
 import portfolio from './src/structure/portfolio'
 import feature from './src/structure/feature'
+import pages from './src/structure/pages'
 
 const hiddenDocTypes = (listItem) =>
   ![
@@ -26,4 +27,5 @@ export default () =>
       portfolio,
       feature,
       caseStudies,
+      pages,
     ])

--- a/studio/src/structure/pages.js
+++ b/studio/src/structure/pages.js
@@ -1,0 +1,14 @@
+import S from '@sanity/desk-tool/structure-builder'
+import {GoBook} from 'react-icons/go'
+
+const pages = S.listItem()
+  .title('Pages')
+  .icon(GoBook)
+  .child(
+    S.documentList()
+      .schemaType('resource')
+      .title('Page')
+      .filter('_type == "resource" && type == "landing-page"'),
+  )
+
+export default pages


### PR DESCRIPTION
This creates following Sanity driven page under `/curated-topics`.
[Preview →](https://egghead-io-nextjs-j1pqfc7u4-eggheadio1.vercel.app/curated-topics)

| Dark mode  | Light mode |
| ------------- | ------------- |
| ![dark mode screenshot](https://user-images.githubusercontent.com/25487857/142656618-de6a25b5-6cf1-4d17-9480-676140e9fbde.png) | ![light mode screenshot](https://user-images.githubusercontent.com/25487857/142656746-b086ef66-5acf-4cbc-8fad-66be02f25069.png) |


Add, sort, or remove whole page sections with Sanity.
<img src="https://user-images.githubusercontent.com/25487857/142657140-b5b6e57c-f805-442d-a321-2fdc670ae007.png" width="300" alt="sanity screenshot">


<img src="https://media.giphy.com/media/l0Exl2gzkfMptFOGA/giphy-downsized.gif" width="200" alt="yo">