### PR TITLE
Map over topics directly

### DIFF
--- a/src/components/pages/confirm/membership/index.tsx
+++ b/src/components/pages/confirm/membership/index.tsx
@@ -92,7 +92,7 @@ const PopularTopics: React.FC = () => {
         Start with one of these popular topics
       </h4>
       <ul className="grid sm:grid-cols-4 grid-cols-2 gap-3">
-        {topics.resources.map((topic: any) => (
+        {topics.map((topic: any) => (
           <li key={topic.path}>
             <Link href={topic.path}>
               <a className="px-6 pt-6 pb-5 rounded-lg dark:bg-gray-800 bg-white dark:hover:bg-gray-700 hover:shadow-lg border dark:border-transparent border-gray-200 border-opacity-50 flex flex-col items-center justify-center">


### PR DESCRIPTION
This was causing these error pages: https://eggheadio.slack.com/archives/G01CAT0P9TL/p1637675498223700

![topics](https://media4.giphy.com/media/RJhac1GXoluliNFsF4/giphy.gif?cid=d1fd59abxjefxv5myj0itnqkn7hm51pddm5458gau6hz9p24&rid=giphy.gif&ct=g)
