### PR TITLE
Add state and data handling for default coupon

### DIFF
--- a/src/machines/__tests__/commerce-machine.test.ts
+++ b/src/machines/__tests__/commerce-machine.test.ts
@@ -43,6 +43,67 @@ const pricingResponseWithPPPAvailable = {
   ],
 }
 
+const pricingResponseWithDefaultApplied = {
+  mode: 'individual',
+  quantity: 1,
+  applied_coupon: {
+    coupon_discount: 0.5,
+    coupon_code: 'QJVIXHB6',
+    coupon_expires_at: 1639814399,
+    default: true,
+    coupon_region_restricted: false,
+  },
+  coupon_code_errors: [],
+  available_coupons: {
+    default: {
+      coupon_discount: 0.5,
+      coupon_code: 'QJVIXHB6',
+      coupon_expires_at: 1639814399,
+      default: true,
+      coupon_region_restricted: false,
+    },
+    ppp: {
+      coupon_discount: 0.6,
+      coupon_code: 'Y48OGYPR',
+      coupon_expires_at: 1637662621,
+      default: false,
+      price_message: 'Restricted Regional Pricing (BR)',
+      coupon_region_restricted: true,
+      coupon_region_restricted_to: 'BR',
+      coupon_region_restricted_to_name: 'Brazil',
+    },
+  },
+  plans: [
+    {
+      name: 'Monthly',
+      price: 25,
+      interval: 'month',
+      interval_count: 1,
+      stripe_price_id: 'price_monthly_id',
+      price_discounted: 12,
+      price_savings: 13,
+    },
+    {
+      name: 'Quarterly',
+      price: 70,
+      interval: 'month',
+      interval_count: 3,
+      stripe_price_id: 'price_quarterly_id',
+      price_discounted: 35,
+      price_savings: 35,
+    },
+    {
+      name: 'Yearly',
+      price: 250,
+      interval: 'year',
+      interval_count: 1,
+      stripe_price_id: 'price_yearly_id',
+      price_discounted: 125,
+      price_savings: 125,
+    },
+  ],
+}
+
 test('it starts fetching pricing immediately', () => {
   const commerceService = interpret(commerceMachine)
 
@@ -140,6 +201,27 @@ test('it can apply PPP coupon when available', async () => {
   // TODO: Update the machine to set the priceId once pricing data loads. It
   // doesn't make sense for it to be undefined once it is in `pricesLoaded`.
   expect(commerceService.state.context.priceId).toEqual(undefined)
+})
+
+test('it recognizes an applied default coupon', async () => {
+  const mockedCommerceMachine = commerceMachine.withConfig({
+    services: {
+      fetchPricingData: async (_context) => {
+        return Promise.resolve(pricingResponseWithDefaultApplied)
+      },
+    },
+  })
+
+  const commerceService = interpret(mockedCommerceMachine)
+
+  commerceService.start()
+
+  await sleep(0)
+
+  // expect(commerceService.state.context.priceId).toEqual(undefined)
+  expect(commerceService.state.context.couponToApply?.couponCode).toEqual(
+    'QJVIXHB6',
+  )
 })
 
 test('it switches price without going back to loadingPrices', () => {

--- a/src/machines/commerce-machine.ts
+++ b/src/machines/commerce-machine.ts
@@ -19,9 +19,12 @@ export type Coupon = {
 }
 
 export type PricingData = {
-  applied_coupon: string
+  applied_coupon: {
+    coupon_code: string
+  }
   available_coupons: {
-    ppp: Coupon | undefined
+    ppp?: Coupon
+    default?: Coupon
   }
   coupon_code_errors: string[]
   mode: 'individual' | 'team'
@@ -31,7 +34,7 @@ export type PricingData = {
 
 type CouponToApply = {
   couponCode: string
-  couponType: 'ppp' | 'other'
+  couponType: 'ppp' | 'default'
 }
 
 const findAvailablePPPCoupon = (pricingData: PricingData) => {
@@ -122,6 +125,10 @@ export const commerceMachine = createMachine<
           checkingCouponStatus: {
             always: [
               {target: 'withPPPCoupon', cond: 'pricingIncludesPPPCoupon'},
+              {
+                target: 'withDefaultCoupon',
+                cond: 'pricingIncludesDefaultCoupon',
+              },
               {target: 'withoutCoupon'},
             ],
           },
@@ -133,6 +140,7 @@ export const commerceMachine = createMachine<
               },
             },
           },
+          withDefaultCoupon: {},
           withoutCoupon: {
             on: {
               APPLY_PPP_COUPON: {
@@ -163,7 +171,42 @@ export const commerceMachine = createMachine<
         (_, event) => {
           if (event.type !== 'done.invoke.fetchPricingDataService') return {}
 
-          return {pricingData: event.data}
+          const extractAppliedDefaultCoupon = (
+            pricingData: PricingData,
+          ): {couponToApply: CouponToApply} | {} => {
+            // check if there is a site-wide/'default' coupon available
+            const availableDefaultCoupon =
+              pricingData?.available_coupons?.default
+
+            // check if there is a site-wide/'default' coupon being applied
+            const appliedCoupon = pricingData?.applied_coupon
+
+            if (isEmpty(availableDefaultCoupon) && isEmpty(appliedCoupon)) {
+              return {}
+            }
+
+            // if a site-wide/'default' coupon is being applied, set that as the
+            // `couponToApply` in the machine context. The CouponToApply is
+            // needed when transitioning to the Stripe Checkout Session.
+            if (
+              availableDefaultCoupon?.coupon_code === appliedCoupon?.coupon_code
+            ) {
+              return {
+                couponToApply: {
+                  couponCode: appliedCoupon.coupon_code,
+                  couponType: 'default',
+                },
+              }
+            }
+
+            // no applied default coupon found
+            return {}
+          }
+
+          return {
+            pricingData: event.data,
+            ...extractAppliedDefaultCoupon(event.data),
+          }
         },
         // TODO: Move the `priceId` update from the downstream component up
         // this machine.
@@ -202,6 +245,9 @@ export const commerceMachine = createMachine<
     guards: {
       pricingIncludesPPPCoupon: (context) => {
         return context?.couponToApply?.couponType === 'ppp'
+      },
+      pricingIncludesDefaultCoupon: (context) => {
+        return context?.couponToApply?.couponType === 'default'
       },
       priceHasBeenSelected: (context) => {
         return !isEmpty(context.priceId)

--- a/src/machines/commerce-machine.ts
+++ b/src/machines/commerce-machine.ts
@@ -181,7 +181,8 @@ export const commerceMachine = createMachine<
             // check if there is a site-wide/'default' coupon being applied
             const appliedCoupon = pricingData?.applied_coupon
 
-            if (isEmpty(availableDefaultCoupon) && isEmpty(appliedCoupon)) {
+            // no applied default coupon found
+            if (isEmpty(availableDefaultCoupon) || isEmpty(appliedCoupon)) {
               return {}
             }
 
@@ -199,7 +200,7 @@ export const commerceMachine = createMachine<
               }
             }
 
-            // no applied default coupon found
+            // the applied coupon is not the site-wide/'default'
             return {}
           }
 


### PR DESCRIPTION
We were 95% of the way there with site-wide/default coupons. The only thing that was missing was to set the default coupon as the `couponToApply` so that it gets passed to the Stripe Checkout Session.

Without this PR, the pricing page displays the discounted price from the default coupon, but the Stripe Checkout Session shows a full-price subscription.

![big sale](https://media4.giphy.com/media/U44lFA2incxbIwfJy1/giphy.gif?cid=d1fd59abtjwrzv6mtgv1ylspuxqqna9lo5sprgbm4yvevug3&rid=giphy.gif&ct=g)