### PR TITLE
Allow PPP to be applied instead of default

### DIFF
--- a/src/machines/commerce-machine.ts
+++ b/src/machines/commerce-machine.ts
@@ -139,7 +139,14 @@ export const commerceMachine = createMachine<
               },
             },
           },
-          withDefaultCoupon: {},
+          withDefaultCoupon: {
+            on: {
+              APPLY_PPP_COUPON: {
+                actions: 'applyPPPCoupon',
+                target: '#loadingPrices',
+              },
+            },
+          },
           withoutCoupon: {
             on: {
               APPLY_PPP_COUPON: {


### PR DESCRIPTION
If the default coupon was being applied, then the absence of an event
for applying PPP was making the PPP checkbox not work.

I missed adding this event when I incorporated default coupons into the commerce machine.

![hot deals](https://media3.giphy.com/media/BIr9mnsmPGaSwqIisk/giphy.gif?cid=d1fd59abyxba919quuevsxh1t19q61u0m66l885opv5lm0am&rid=giphy.gif&ct=g)


