### PR TITLE
Clarify that PPP doesn't stack w/ other discounts

### DIFF
--- a/src/components/pricing/parity-coupon-message.tsx
+++ b/src/components/pricing/parity-coupon-message.tsx
@@ -45,6 +45,9 @@ const ParityCouponMessage = ({
           <ul className="mt-2 ml-4 list-disc">
             <li>Downloads and bonuses are not included.</li>
             <li>
+              The discount is not valid in conjunction with other promotions.
+            </li>
+            <li>
               Members-only content will only be available while browsing from{' '}
               {countryName}.
             </li>
@@ -85,6 +88,11 @@ const ParityCouponMessage = ({
           </div>
         )}
       </div>
+      {reduced && (
+        <p className="mt-4 text-sm text-gray-600">
+          *The discount is not valid in conjunction with other promotions.
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Here is what this looks like on the Pricing page and the Home page respectively.

As for the Inline Lesson Checkout CTA, I wasn't sure how to fit this extra messaging in. If we want it there, we'll have to think about how best to accommodate that info.

<img width="821" alt="CleanShot 2021-11-29 at 13 56 09@2x" src="https://user-images.githubusercontent.com/694063/143936651-f317cf60-283a-48c1-aee1-2a46918bbd97.png">

<img width="747" alt="CleanShot 2021-11-29 at 13 58 50@2x" src="https://user-images.githubusercontent.com/694063/143936670-f40b9226-b652-45e0-a29b-48589a066db4.png">

![restriction](https://media4.giphy.com/media/xjvzluZ4z40kNtaS8g/giphy.gif?cid=d1fd59abnlv7gl40bh2ric0h8fi51o7qsjhu8g02nok4pii6&rid=giphy.gif&ct=g)
