### PR TITLE
More lesson loading changes for Talks pages

### DIFF
--- a/src/pages/talks/[slug].tsx
+++ b/src/pages/talks/[slug].tsx
@@ -16,7 +16,6 @@ import {NextSeo} from 'next-seo'
 import Head from 'next/head'
 import removeMarkdown from 'remove-markdown'
 import {useEnhancedTranscript} from 'hooks/use-enhanced-transcript'
-import cookieUtil from 'utils/cookies'
 
 type LessonProps = {
   initialLesson: any
@@ -37,18 +36,6 @@ const Talk: FunctionComponent<LessonProps> = ({initialLesson}) => {
     },
     services: {
       loadLesson: async () => {
-        if (cookieUtil.get(`egghead-watch-count`)) {
-          setWatchCount(Number(cookieUtil.get(`egghead-watch-count`)))
-        } else {
-          setWatchCount(
-            Number(
-              cookieUtil.set(`egghead-watch-count`, 0, {
-                expires: 15,
-              }),
-            ),
-          )
-        }
-
         console.debug('loading video with auth')
         const loadedLesson = await loadLesson(initialLesson.slug)
         console.debug('authed video loaded', {video: loadedLesson})
@@ -86,6 +73,7 @@ const Talk: FunctionComponent<LessonProps> = ({initialLesson}) => {
 
   if (!lesson) return null
 
+  // TODO: This isn't being used. Can it be removed?
   const playerVisible: boolean = ['playing', 'paused', 'viewing'].some(
     playerState.matches,
   )

--- a/src/pages/talks/[slug].tsx
+++ b/src/pages/talks/[slug].tsx
@@ -73,11 +73,6 @@ const Talk: FunctionComponent<LessonProps> = ({initialLesson}) => {
 
   if (!lesson) return null
 
-  // TODO: This isn't being used. Can it be removed?
-  const playerVisible: boolean = ['playing', 'paused', 'viewing'].some(
-    playerState.matches,
-  )
-
   return (
     <>
       <NextSeo

--- a/src/pages/talks/[slug].tsx
+++ b/src/pages/talks/[slug].tsx
@@ -27,9 +27,8 @@ const VIDEO_MIN_HEIGHT = 480
 const Talk: FunctionComponent<LessonProps> = ({initialLesson}) => {
   const router = useRouter()
   const playerRef = React.useRef(null)
-  const [watchCount, setWatchCount] = React.useState<number>(0)
-  const {viewer, authToken} = useViewer()
-  const [playerState, send] = useMachine(playerMachine, {
+  const {viewer} = useViewer()
+  const [playerState] = useMachine(playerMachine, {
     context: {
       lesson: initialLesson,
       viewer,


### PR DESCRIPTION
@vojtaholik fixed the busted lesson loading logic on the Talks page in this PR: https://github.com/eggheadio/egghead-next/pull/1003

This PR is a second pass over this component to clean up a couple things:
1. Remove the lesson count logic. That wasn't being used on this page before and only makes sense for tracking the number of lessons a user has viewed.
2. Remove an unused player machine state matching statement.

Otherwise, it looks great. Vojta unified the approaches between the lesson and talk pages by ditching the direct SWR call and instead relying on the same `loadLesson` function used by the lesson page.

![unity](https://media0.giphy.com/media/kHZ3KNTkHzg9VzqtQ2/giphy.gif?cid=d1fd59abnr4ltuspe9c47t2pq3eczl2n12vk11pow4kbw04p&rid=giphy.gif&ct=g)
