### PR TITLE
Add shared props interface for Parity Coupon Msg

### DIFF
--- a/src/components/pages/lessons/overlay/small-parity-coupon-message.tsx
+++ b/src/components/pages/lessons/overlay/small-parity-coupon-message.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react'
-import {Coupon} from 'types'
-
-type SmallParityCouponMessage = {
-  coupon: Coupon
-  countryName: string
-  onApply: () => void
-  onDismiss: () => void
-  isPPP?: boolean
-  isLoading?: boolean
-}
+import {ParityCouponMessageProps} from 'interfaces/parity_coupon_message'
 
 const SmallParityCouponMessage = ({
   coupon,
@@ -17,7 +8,7 @@ const SmallParityCouponMessage = ({
   onDismiss,
   isPPP,
   isLoading,
-}: SmallParityCouponMessage) => {
+}: ParityCouponMessageProps) => {
   const percentOff = coupon && Math.round(coupon.coupon_discount * 100)
   const [showFlag, setShowFlag] = React.useState<boolean>(false)
 

--- a/src/components/pricing/parity-coupon-message.tsx
+++ b/src/components/pricing/parity-coupon-message.tsx
@@ -1,17 +1,5 @@
 import * as React from 'react'
-import {Coupon} from 'types'
-
-type ParityCouponMessage = {
-  coupon: Coupon
-  countryName: string
-  onApply: () => void
-  onDismiss: () => void
-  isPPP?: boolean
-  reduced?: boolean
-}
-
-// TODO: Is ParityCouponMessage defined in a couple different places?
-// Also, SmallParityCouponMessage
+import {ParityCouponMessageProps} from 'interfaces/parity_coupon_message'
 
 const ParityCouponMessage = ({
   coupon,
@@ -20,7 +8,7 @@ const ParityCouponMessage = ({
   onDismiss,
   isPPP,
   reduced,
-}: ParityCouponMessage) => {
+}: ParityCouponMessageProps & {reduced?: boolean}) => {
   const percentOff = coupon && Math.round(coupon.coupon_discount * 100)
   const [showFlag, setShowFlag] = React.useState<boolean>(false)
 

--- a/src/interfaces/parity_coupon_message.ts
+++ b/src/interfaces/parity_coupon_message.ts
@@ -1,0 +1,10 @@
+import {Coupon} from 'types'
+
+export interface ParityCouponMessageProps {
+  coupon: Coupon
+  countryName: string
+  onApply: () => void
+  onDismiss: () => void
+  isPPP?: boolean
+  isLoading?: boolean
+}


### PR DESCRIPTION
Move duplicated props interface into a shared file for both of the Parity Coupon Message components.

![interface](https://media2.giphy.com/media/N37lx3iquKxqInHu4X/giphy.gif?cid=d1fd59abu2vjtxp5b61tjuoxjzwwjprwl17x7pp3eqqcptgv&rid=giphy.gif&ct=g)