### PR TITLE
Run pro status check for auth'd user on pricing

### DIFF
--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -40,6 +40,7 @@ const about = [
   {
     path: '/pricing',
     label: 'Pricing',
+    nonMemberRequired: true,
   },
   {
     path: 'https://store.egghead.io/',
@@ -77,7 +78,10 @@ const FooterNavigation: FunctionComponent = () => {
   const {viewer} = useViewer()
   const filterViewerRequired = (items: any[]) => {
     return reject(items, (item) => {
-      return item.viewerRequired && !viewer
+      return (
+        (item.viewerRequired && !viewer) ||
+        (item.nonMemberRequired && viewer.is_pro)
+      )
     })
   }
   return (

--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -80,7 +80,7 @@ const FooterNavigation: FunctionComponent = () => {
     return reject(items, (item) => {
       return (
         (item.viewerRequired && !viewer) ||
-        (item.nonMemberRequired && viewer.is_pro)
+        (item.nonMemberRequired && viewer?.is_pro)
       )
     })
   }

--- a/src/pages/pricing/_middleware.ts
+++ b/src/pages/pricing/_middleware.ts
@@ -10,8 +10,10 @@ export async function middleware(req: NextRequest) {
   const cioId =
     req.cookies[CIO_COOKIE_KEY] || req.nextUrl.searchParams.get(CIO_COOKIE_KEY)
 
+  const eggheadAccessToken = req.cookies[ACCESS_TOKEN_KEY]
+
   // if there's a cookie or a token they are logged in
-  let status = cioId || req.cookies[ACCESS_TOKEN_KEY] ? 'identified' : 'anon'
+  let status = cioId || eggheadAccessToken ? 'identified' : 'anon'
 
   switch (status) {
     case 'anon':
@@ -27,9 +29,14 @@ export async function middleware(req: NextRequest) {
             customer?.attributes?.instructor,
           ].includes('true')
 
+          const loggedInMember = isMember && eggheadAccessToken
+
           switch (true) {
-            case isMember:
+            case loggedInMember:
               response = NextResponse.rewrite('user')
+              break
+            case isMember:
+              response = NextResponse.rewrite('login')
               break
             default:
               response = NextResponse.next()

--- a/src/pages/pricing/_middleware.ts
+++ b/src/pages/pricing/_middleware.ts
@@ -1,0 +1,53 @@
+import {NextRequest, NextResponse} from 'next/server'
+import {ACCESS_TOKEN_KEY} from '../../config'
+import {loadCio} from '../../lib/customer'
+
+const CIO_COOKIE_KEY = 'cio_id'
+
+export async function middleware(req: NextRequest) {
+  let response = NextResponse.next()
+
+  const cioId =
+    req.cookies[CIO_COOKIE_KEY] || req.nextUrl.searchParams.get(CIO_COOKIE_KEY)
+
+  // if there's a cookie or a token they are logged in
+  let status = cioId || req.cookies[ACCESS_TOKEN_KEY] ? 'identified' : 'anon'
+
+  switch (status) {
+    case 'anon':
+      response = NextResponse.next()
+      break
+    case 'identified':
+      if (cioId) {
+        try {
+          const customer = await loadCio(cioId, req.cookies['customer'])
+
+          const isMember = [
+            customer?.attributes?.pro,
+            customer?.attributes?.instructor,
+          ].includes('true')
+
+          switch (true) {
+            case isMember:
+              response = NextResponse.rewrite('user')
+              break
+            default:
+              response = NextResponse.next()
+          }
+
+          if (customer) {
+            response.cookie('customer', JSON.stringify(customer))
+          }
+
+          response.cookie(CIO_COOKIE_KEY, cioId)
+        } catch (_e) {
+          response = NextResponse.next()
+        }
+      }
+      break
+    default:
+      response = NextResponse.next()
+  }
+
+  return response
+}

--- a/src/pages/pricing/_middleware.ts
+++ b/src/pages/pricing/_middleware.ts
@@ -29,14 +29,14 @@ export async function middleware(req: NextRequest) {
             customer?.attributes?.instructor,
           ].includes('true')
 
-          const loggedInMember = isMember && eggheadAccessToken
+          const loggedInMember = Boolean(isMember && eggheadAccessToken)
 
           switch (true) {
             case loggedInMember:
-              response = NextResponse.rewrite('user')
+              response = NextResponse.rewrite('/user')
               break
             case isMember:
-              response = NextResponse.rewrite('login')
+              response = NextResponse.rewrite('/login')
               break
             default:
               response = NextResponse.next()


### PR DESCRIPTION
We are seeing users from time to time that land on the pricing page not
realizing they still have remaining time on their cancelled
subscription, who then try to subscribe anew. They end up on the Stripe
Checkout Session and are able to create a new subscription. We should
instead halt them at the pricing page and direct them to support for any
adjustments they need to make.

This PR adds the Pro Status Check for signed in users on the pricing widget so that they don't accidentally purchase a second subscription. It also uses vercel middleware to prevent an already subscribed user from landing on pricing. Instead it shuffles them over to the login page or their user page. It hides the pricing link from the footer as well.

https://user-images.githubusercontent.com/694063/147281430-7736cc51-d3b5-47ea-b5a2-8e8b68df65c3.mp4


![pro access](https://media0.giphy.com/media/yWzLQO6sW5Bh1BdJQN/giphy.gif?cid=d1fd59abj2vrwu4yirdbdzxh92etwf0y233vzrc88oukulu7&rid=giphy.gif&ct=g)