### PR TITLE
garden hp

### DIFF
--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -65,7 +65,7 @@ const HorizontalResourceCard: React.FC<{
               <h3>{resource.title}</h3>
             </Textfit>
             {resource.description && describe && (
-              <ReactMarkdown className="py-2 prose dark:prose-dark prose-sm dark:text-gray-300 text-gray-700">
+              <ReactMarkdown className="py-2 prose dark:prose-dark prose-sm dark:text-gray-300 text-gray-700 sm:block hidden">
                 {resource.description}
               </ReactMarkdown>
             )}

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -16,9 +16,7 @@ const Home: React.FC<any> = ({data, jumbotron, location}) => {
   return (
     <>
       <div className="md:container">
-        {/* TODO: Switch back after holidays */}
-        {/* <Jumbotron data={jumbotron} /> */}
-        <HolidayReleaseJumbotron />
+        <Jumbotron data={jumbotron} />
       </div>
       <div className="container">
         <main className="sm:pt-16 pt-8">
@@ -66,21 +64,61 @@ const Home: React.FC<any> = ({data, jumbotron, location}) => {
                   <Grid>
                     {section.resources.map(
                       (resource: CardResource, i: number) => {
-                        // if there are only 3 resources, the first one will use HorizontalResourceCard
-                        return section.resources.length === 3 && i === 0 ? (
-                          <HorizontalResourceCard
-                            className="col-span-2"
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        ) : (
-                          <VerticalResourceCard
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
+                        switch (section.resources.length) {
+                          case 3:
+                            return i === 0 ? (
+                              <HorizontalResourceCard
+                                className="col-span-2"
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            ) : (
+                              <VerticalResourceCard
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            )
+                          case 6:
+                            return i === 0 || i === 1 ? (
+                              <HorizontalResourceCard
+                                className="col-span-2"
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            ) : (
+                              <VerticalResourceCard
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            )
+                          case 7:
+                            return i === 0 ? (
+                              <HorizontalResourceCard
+                                className="col-span-2"
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            ) : (
+                              <VerticalResourceCard
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            )
+                          default:
+                            return (
+                              <VerticalResourceCard
+                                key={resource.id}
+                                resource={resource}
+                                location={location}
+                              />
+                            )
+                        }
                       },
                     )}
                   </Grid>
@@ -109,6 +147,9 @@ const Home: React.FC<any> = ({data, jumbotron, location}) => {
                 </section>
               )
             })}
+          <div className="md:container mb-16 rounded-lg dark:bg-gray-800 bg-white dark:bg-opacity-60 bg-opacity-100">
+            <HolidayReleaseJumbotron />
+          </div>
           <Search />
         </main>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,7 +30,7 @@ module.exports = {
     container: {
       center: true,
       padding: {
-        DEFAULT: '1.25rem',
+        DEFAULT: '0.5rem',
         md: '1.5rem',
       },
     },


### PR DESCRIPTION
This PR is adding all courses released during holiday promo into their corresponding sections. It also brings back our jumbotron component highlighting last published course and moves CTA for [20 days](https://egghead.io/20-days) at the bottom of the page. I also added some more logic for handling cards grid based on number of resources in order to get them aligned nicely.

![screenshot](https://user-images.githubusercontent.com/25487857/148217436-c19696bd-54ca-45fb-8859-44b7fd159f32.png)

<img src="https://media.giphy.com/media/C8Xne8iOdX1F2JwqAe/giphy-downsized.gif" width="200" alt="gardening">