### PR TITLE
feat: implement opensearch link

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Egghead</ShortName>
+  <Description>Search Egghead</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://egghead.io/favicon.ico</Image>
+  <Url type="text/html" method="get" template="https://egghead.io/q?q={searchTerms}&amp;ref=opensearch" />
+  <moz:SearchForm>https://egghead.io/q</moz:SearchForm>
+</OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-  <ShortName>Egghead</ShortName>
-  <Description>Search Egghead</Description>
+  <ShortName>egghead</ShortName>
+  <Description>Search egghead</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Image width="16" height="16" type="image/x-icon">https://egghead.io/favicon.ico</Image>
   <Url type="text/html" method="get" template="https://egghead.io/q?q={searchTerms}&amp;ref=opensearch" />

--- a/src/next-seo.json
+++ b/src/next-seo.json
@@ -2,6 +2,14 @@
   "title": "Build the portfolio you need to be a badass web developer.",
   "titleTemplate": "%s | egghead.io",
   "description": "egghead is your source for the Badass Portfolio Projects you need to climb the career ladder as a modern web developer.",
+  "additionalLinkTags": [
+    {
+      "rel": "search",
+      "type": "application/opensearchdescription+xml",
+      "href": "/opensearch.xml",
+      "title": "Egghead"
+    }
+  ],
   "additionalMetaTags": [
     {"property": "author", "content": "eggheadio"},
     {

--- a/src/next-seo.json
+++ b/src/next-seo.json
@@ -7,7 +7,7 @@
       "rel": "search",
       "type": "application/opensearchdescription+xml",
       "href": "/opensearch.xml",
-      "title": "Egghead"
+      "title": "egghead"
     }
   ],
   "additionalMetaTags": [


### PR DESCRIPTION
Hi! 👋🏽 

I was looking at how to implement this today and noticed egghead.io doesn't have it.
If it's intentional, feel free to close this PR. If not, here's a proposed implementation.

I followed GitHub's implementation, with a `ref` query parameter. Let me know if you'd prefer to remove it.
Let me know if you'd prefer to have a dynamically generated file with `NEXT_PUBLIC_DEPLOYMENT_URL` instead of hardcoding https://egghead.io.

My screen recording app is not working, so here are some screenshots.
The weird URL is because I had a tunnel running my local environment to test the feature.

<details>
<summary>Chrome - works out-of-the-box</summary>

![Screenshot 2022-01-24 at 17 56 46](https://user-images.githubusercontent.com/13774309/150831638-01a1241f-6eef-4a57-bb23-eea70c730512.png)
![Screenshot 2022-01-24 at 17 56 53](https://user-images.githubusercontent.com/13774309/150831643-5826cb29-d23d-45aa-9ab5-ab98a76db058.png)
![Screenshot 2022-01-24 at 17 57 05](https://user-images.githubusercontent.com/13774309/150831647-4ae34e81-aba9-4065-89fa-3fd871c2c921.png)
![Screenshot 2022-01-24 at 18 10 21](https://user-images.githubusercontent.com/13774309/150831648-5843b38f-9ea3-4c27-a891-7e44f37c1eca.png)

</details>

<details>
<summary>Firefox - one needs to add the site as a search engine</summary>

![Screenshot 2022-01-24 at 18 11 33](https://user-images.githubusercontent.com/13774309/150831885-3296ce45-d07c-42be-90ac-90aca02697d4.png)
![Screenshot 2022-01-24 at 18 11 49](https://user-images.githubusercontent.com/13774309/150831889-99e4874d-6ffb-45f1-be89-ba5464014ad1.png)
![Screenshot 2022-01-24 at 18 12 00](https://user-images.githubusercontent.com/13774309/150831894-a43b6489-0b14-4f9c-bb28-dbdf7fa3fe3f.png)
![Screenshot 2022-01-24 at 18 12 14](https://user-images.githubusercontent.com/13774309/150831895-320fd789-eb76-4671-a001-f19063b84b8d.png)

</details>
