### PR TITLE
fix: correct typos in "Writing for egghead" page

### DIFF
--- a/src/pages/write-for-egghead/index.mdx
+++ b/src/pages/write-for-egghead/index.mdx
@@ -24,7 +24,7 @@ Plus, it's great for egghead and the hundreds of thousands of folks that visit t
 ## What you need to know
 
 1. The best articles answer a question or fill in a gap. They are the ones that come up at the top of a google search and immediately help somebody get their job done or learn something new.
-2. We want to learn about your learned experience and knowledge. We firmly believe in the philosphy of "teach everything you know" and learning in public.
+2. We want to learn about your learned experience and knowledge. We firmly believe in the philosophy of "teach everything you know" and learning in public.
 
 The articles we are looking for help people **solve real problems** in their actual lives as web developers. They usually demonstrate and explain something in your voice and share your experience.
 
@@ -38,7 +38,7 @@ Anyone can write for egghead, you just need to let us know you're up for it <spa
 
 egghead is a site built to be useful for web developers. We cater to an intermediate to advanced audience, but also appreciate the fundamentals of our craft. We want to learn from you and your experience, so the things that are exciting or interesting to you are probably exciting and interesting to other web developers.
 
-We aren't interested in publishing click-bait or trying to game the system with SEO. We are interested in deep topics that bring value and clarity to the folks that read them.
+We aren't interested in publishing clickbait or trying to game the system with SEO. We are interested in deep topics that bring value and clarity to the folks that read them.
 
 ### Articles about React
 
@@ -56,9 +56,9 @@ There's _so much to explore_ beyond just React, of course, and we are very inter
 
 <ProseSection>
 
-For the most part, we are interested in the written equivelant of egghead lessons, so if you'd like to understand more about our underlying philosophy and how we think about teaching on the internet, checkout [our in-depth guide on how to egghead](https://howtoegghead.com/instructor).
+For the most part, we are interested in the written equivalent of egghead lessons, so if you'd like to understand more about our underlying philosophy and how we think about teaching on the internet, check out [our in-depth guide on how to egghead](https://howtoegghead.com/instructor).
 
-In fact, writing articles for egghead is a direct path to creating screencast lessons and courses on egghead, so if that is interesting for you please keep it in mind as well!
+In fact, writing articles for egghead is a direct path to creating screencast lessons and courses on egghead, so if that is interesting for you, please keep it in mind as well!
 
 </ProseSection>
 
@@ -131,13 +131,13 @@ _Show, don't tell._ This is the bedrock of how we approach teaching
 
 ## Examples of Great articles
 
-These are some amazing examples that set the bar for what is possible with written tutotials for web developers.
+These are some amazing examples that set the bar for what is possible with written tutorials for web developers.
 
 - [Full-Bleed Layout Using CSS Grid](https://joshwcomeau.com/css/full-bleed/) by Josh Comeau
 - [Authorization and Authentication for Everyone](https://dev.to/kimmaida/authorization-and-authentication-for-everyone-27j3) by Kim Maida
 - [Creating a Gauge in React](https://wattenberger.com/blog/gauge) by Amelia Wattenberger
 
-These authors are seasoned pros, and we don't expect every article to clear the bar, but we think you should be aable to "dream big" and we will help you execute on that vision.
+These authors are seasoned pros, and we don't expect every article to clear the bar, but we think you should be able to "dream big" and we will help you execute on that vision.
 
 We are here to collaborate on your ideas!
 
@@ -145,7 +145,7 @@ We are here to collaborate on your ideas!
 
 We pay a flat rate for each article. The compensation amount is adjusted to the meatiness of the article. Long, in-depth articles that require deep research are compensated more than shorter, snappier articles.
 
-The amount of compensation will vary from article to article and depends on many factors including how audacious the scope of the work is, the level of time and research invloved to produce the article, as well as other factors like audience reach and industry expertise of the author.
+The amount of compensation will vary from article to article and depends on many factors including how audacious the scope of the work is, the level of time and research involved to produce the article, as well as other factors like audience reach and industry expertise of the author.
 
 We only pay for articles that are published!
 


### PR DESCRIPTION
I was reading the page and noticed a few small things.