### PR TITLE
Add new Sanity schema for video lessons

### DIFF
--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -1,0 +1,94 @@
+export default {
+  name: 'lesson',
+  type: 'document',
+  title: 'Lesson',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Title',
+      description: 'Titles should be catchy, descriptive, and not too long',
+      validation: (Rule) =>
+        Rule.custom((field, context) =>
+          context.document.status &&
+          context.document.status === 'published' &&
+          (field === undefined || field.length < 1)
+            ? 'Must have a title to publish'
+            : true,
+        ),
+    },
+    {
+      name: 'slug',
+      type: 'slug',
+      title: 'Slug',
+      validation: (Rule) => Rule.required(),
+      description:
+        'Some frontends will require a slug to be set to be able to show the post',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+    },
+    {
+      title: 'AWS Filename (URL)',
+      name: 'awsFilename',
+      type: 'url',
+    },
+    {
+      name: 'description',
+      type: 'markdown',
+      title: 'Description',
+      description:
+        'This can be used to provide a short description of the lesson.',
+    },
+    {
+      name: 'softwareLibraries',
+      description: 'Versioned Software Libraries',
+      title: 'NPM or other Dependencies',
+      type: 'array',
+      of: [
+        {
+          type: 'versioned-software-library',
+        },
+      ],
+    },
+    {
+      name: 'collaborators',
+      description:
+        'Humans that worked on this resource and get credit for the effort.',
+      title: 'Collaborators',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'collaborator'}],
+        },
+      ],
+    },
+    {
+      title: 'Status',
+      name: 'status',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Needs Review', value: 'needs-review'},
+          {title: 'Approved', value: 'approved'},
+          {title: 'Published', value: 'published'},
+          {title: 'Archived', value: 'archived'},
+        ],
+      },
+    },
+    {
+      title: 'Access Level',
+      name: 'accessLevel',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Free', value: 'free'},
+          {title: 'Pro', value: 'pro'},
+        ],
+        layout: 'radio',
+      },
+    },
+  ],
+}

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -20,6 +20,7 @@ import ctaPlug from './plugs/ctaPlug'
 import imageUrl from './objects/image-url'
 import stringList from './objects/string-list'
 import post from './documents/post'
+import lesson from './documents/lesson'
 import caseStudy from './documents/caseStudy'
 import category from './documents/category'
 import authorReference from './objects/author-reference'
@@ -53,6 +54,7 @@ export default createSchema({
     bigIdea,
     stringList,
     post,
+    lesson,
     caseStudy,
     category,
     authorReference,


### PR DESCRIPTION
This PR focuses on the "we'll first need to add a `Lessons` model to the Sanity schema" section below. This is a first draft of what the schema could look like and enough information to get us started building the uploader into egghead-next.

In collaboration with @Creeland 

https://roamresearch.com/#/app/egghead/page/hacbeqr_-

- Sanity-First Approach to Lesson Uploader
    - The `/upload` page gets the video file(s) uploaded to S3 and provides URLs as a result.
    - Collect some initial metadata on that page such as Title, Description, and Instructor.
    - On Submit, send the lesson (S3 url and metadata) directly to Sanity.
        - Include some kind of 'pending review' status tag as well.
        - To do this, we'll first need to add a `Lessons` model to the Sanity schema.
            - Do this under `egghead-next/studio/schema`
            - The `posts` model might be a good starting reference point. It sounds like `resources` is generally more complicated / too flexible for what we are going for right now.
            - What attributes should `Lessons` have?
        - Look at Zac's scripts for examples of how to `POST` a new record to Sanity.
            - https://github.com/zacjones93/egghead-kenv/blob/main/scripts/sanity-create-course.js
    - From there, staff can go into Sanity Studio to make adjustments to the uploaded Lessons.
    - This approach has a few advantages:
        - It starts with Sanity which is where we want all content to be living.
        - It hopefully makes the upload process lighter, just get the content in Sanity and S3 to start.
        - It holds off on publishing activities that have monetary costs tied to them, like producing transcriptions. These publishing processes can be put off until the Lessons/Playlists are ready to be published.
    - Then what?
        - Eventually there could be a 'publish' button in Sanity Studio that kicks off everything needed to put the playlist in a live, published state.
        - Will the person who originally uploaded the lessons be able to make further updates, add on more lessons, etc.?
            - To do this in `egghead-next` and with Sanity as the backing store implies permission checking and authorization against Sanity.
            - How do we ask Sanity, "does this egghead-next user have permission to PATCH changes to this lesson through the Sanity API?"


![schema](https://media3.giphy.com/media/l3vQWGNC8JZOKQT9S/giphy.gif?cid=d1fd59abfa6vkbhwtz4xpf092hfgwd13wo1v7yo0mr95gk36&rid=giphy.gif&ct=g)