### PR TITLE
[WIP] Lesson upload form

### DIFF
--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -1,0 +1,97 @@
+import axios from 'axios'
+
+import {NextApiRequest, NextApiResponse} from 'next'
+import {isEmpty} from 'lodash'
+import {sanityClient} from 'utils/sanity-client'
+import {getTokenFromCookieHeaders} from 'utils/auth'
+import fetchEggheadUser from 'api/egghead/users/from-token'
+
+function formatLessonAsSanityData(lesson: LessonData): SanityLesson {
+  // do the data munging
+  return {
+    // leave ID blank
+    _type: 'lesson',
+    title: lesson.title,
+    awsFilename: lesson.fileMetadata.signedUrl,
+  }
+}
+
+function formatSanityMutationForLessons(lessons: LessonData[]) {
+  const sanityLessons = lessons.map(formatLessonAsSanityData)
+
+  return {
+    mutations: sanityLessons.map((lesson) => {
+      return {
+        create: {
+          ...lesson,
+        },
+      }
+    }),
+  }
+}
+
+// if (!process.env.EGGHEAD_SUPPORT_BOT_TOKEN) {
+//   throw new Error('no egghead support+bot token found')
+// }
+const createSanityLessons = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  const {eggheadToken} = getTokenFromCookieHeaders(req.headers.cookie as string)
+
+  if (req.method === 'POST') {
+    const eggheadViewer = await fetchEggheadUser(eggheadToken, false)
+
+    // permissions check for creating lessons in Sanity
+    const {is_publisher, is_instructor} = eggheadViewer
+
+    if (!is_publisher && !is_instructor) {
+      res.status(403).end()
+    } else {
+      // create the lessons
+      //
+      const mutationQuery = formatSanityMutationForLessons(req.body.lessons)
+      const sanityResponse = sanityClient
+        .create(mutationQuery)
+        .then(() => {
+          console.log({sanityResponse})
+
+          res.status(200).json({sanityResponse})
+        })
+        .catch((error) => {
+          console.log(error)
+        })
+    }
+
+    // const {lessons} = req.body
+    // if (!emailIsValid(email)) {
+    //   res.status(400).end()
+    // } else {
+    //   const userUrl = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/users/${email}?by_email=true`
+
+    //   const eggheadUser = await axios
+    //     .get(userUrl, {
+    //       headers: {
+    //         Authorization: `Bearer ${process.env.EGGHEAD_SUPPORT_BOT_TOKEN}`,
+    //       },
+    //     })
+    //     .then(({data}) => data)
+
+    //   const hasProAccess =
+    //     !isEmpty(eggheadUser) &&
+    //     (eggheadUser.is_pro || eggheadUser.is_instructor)
+
+    //   const stripeCustomerId = !isEmpty(eggheadUser) &&
+    //     eggheadUser.subscription && {
+    //       stripeCustomerId: eggheadUser.subscription.stripe_customer_id,
+    //     }
+
+    //   res.status(200).json({hasProAccess, ...stripeCustomerId})
+    // }
+  } else {
+    res.statusCode = 404
+    res.end()
+  }
+}
+
+export default createSanityLessons

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -48,6 +48,9 @@ const Upload: React.FC = () => {
   const {viewer} = useViewer()
   const uploaderRef = React.useRef(null)
   // const [fileUrls, setFileUrls] = React.useState<UploadedFile[]>([])
+  const [lessonMetadata, setLessonMetadata] = React.useState<LessonMetadata[]>(
+    [],
+  )
 
   const initialValues: {lessons: LessonMetadata[]} = {lessons: []}
 
@@ -55,6 +58,10 @@ const Upload: React.FC = () => {
     initialValues: initialValues,
     onSubmit: (values, actions) => {},
   })
+
+  React.useEffect(() => {
+    formik.setFieldValue('lessons', lessonMetadata)
+  }, [lessonMetadata])
 
   return viewer?.s3_signing_url ? (
     <div>
@@ -97,10 +104,8 @@ const Upload: React.FC = () => {
         onError={(message) => console.log(message)}
         onFinish={(signResult, file) => {
           const fileUrl = signResult.signedUrl.split('?')[0]
-          // setFileUrls([...fileUrls, {fileName: file.name, signedUrl: fileUrl}])
-          console.log('WITHIN onFinish', formik.values.lessons)
-          formik.setFieldValue('lessons', [
-            ...formik.values.lessons,
+          setLessonMetadata((prevState) => [
+            ...prevState,
             {
               title: file.name,
               fileMetadata: {fileName: file.name, signedUrl: fileUrl},
@@ -108,9 +113,18 @@ const Upload: React.FC = () => {
           ])
         }}
       />{' '}
+      {state.files.map((file) => {
+        if (file.percent < 100) {
+          return (
+            <div>
+              {file.file.name} - {file.message} - {file.percent}
+            </div>
+          )
+        }
+      })}
       {formik.values.lessons.map((lesson) => (
         <div>
-          {lesson.title} - {lesson.fileMetadata.signedUrl}
+          {lesson.title} - {lesson.fileMetadata.signedUrl} -
         </div>
       ))}
     </div>


### PR DESCRIPTION
// Currently, onFinish callback in the Upload component is creating a clojure with formik.values.lessons.
// So when that state is updated, it's spreading an empty array with each update. Causing only the latest upload to be saved

This whole PR is still a WIP as of https://github.com/eggheadio/egghead-next/pull/1046/commits/8e6e997cb10d0fe6376651743d0fbd8be9f8bd3c

It is very close to an end-to-end proof of concept. The `lesson` document type isn't showing up in Sanity Studio yet. Once it is, we should be able to tweak and test what we have here. Upload a video, edit the title, and send directly to Sanity.

![lessons](https://media2.giphy.com/media/l0MYBJzJ7elsmG1K8/giphy.gif?cid=d1fd59ab8ihduln2eb6h5kristd5aaddrxbkivo4dsqqv3xs&rid=giphy.gif&ct=g)