### PR TITLE
Add Podcast seasons and episodes to the schema

### DIFF
--- a/studio/schemas/documents/podcastEpisode.js
+++ b/studio/schemas/documents/podcastEpisode.js
@@ -1,0 +1,145 @@
+/*
+ * Here is an example podcast as stored in egghead-rails:
+
+#<Podcast:0x00007f805f2e74a8
+ id: 390,
+ title: "Accessible Cross-Browser CSS Form Styling with Stephanie Eckles",
+ summary: "Taylor and Stephanie talk about accessibility, the sticking points, and Stephanie's experience with learning about forms. ",
+ media_url: "https://cdn.simplecast.com/audio/11504d19-d225-48ff-9ce0-ef8f15d8ec54/episodes/ab9e263c-ef52-48c9-8e6a-c52b087e852a/audio/f73552ba-0c97-44f6-96a4-def07242f391/default_tc.mp3",
+ image_url: "https://image.simplecastcdn.com/images/dd208eee-4c40-435d-bea7-b94ef1899216/bea12aca-8642-46db-89d9-fad79d6d8159/avatar-for-stephanie-eckles.jpg",
+ related_content: [],
+ created_at: Mon, 22 Feb 2021 13:45:28 CST -06:00,
+ updated_at: Mon, 22 Feb 2021 13:45:29 CST -06:00,
+ slug: "accessible-cross-browser-css-form-styling-with-stephanie-eckles",
+ image_file_name: nil,
+ image_content_type: nil,
+ image_file_size: nil,
+ image_updated_at: nil,
+ simplecast_uid: "ab9e263c-ef52-48c9-8e6a-c52b087e852a",
+ transcript: nil,
+ episode_number: 26,
+ description: nil,
+ published_at: Mon, 22 Feb 2021 13:45:17 CST -06:00,
+ duration: 1064,
+ visibility_state: "indexed",
+ contributors: "Taylor Bell",
+ square_cover_file_name: nil,
+ square_cover_content_type: nil,
+ square_cover_file_size: nil,
+ square_cover_updated_at: nil,
+ square_cover_processing: nil,
+ show_guid: "11504d19-d225-48ff-9ce0-ef8f15d8ec54",
+ row_order: 8388607>
+
+ Questions:
+ - do we need to represent transcripts in this Sanity data model?
+ - do we care about transferring over the `show_guid`?
+ - should the `id` be included as a reference back to egghead-rails DB?
+
+*/
+
+export default {
+  name: 'podcastEpisode',
+  title: 'Podcast Episode',
+  description: 'Podcast Episodes on egghead',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      required: true,
+      description: 'Title for the individual epsiode',
+    },
+    {
+      name: 'byline',
+      description: 'Subheading to the season',
+      title: 'Byline',
+      type: 'string',
+    },
+    {
+      name: 'slug',
+      title: 'episode slug',
+      type: 'slug',
+      description: 'For when you need to refer to your podcast in a url.',
+      options: {
+        source: 'title',
+        slugify: (input) =>
+          input.toLowerCase().replace(/\s+/g, '-').slice(0, 200),
+      },
+    },
+    {
+      name: 'summary',
+      description: 'Short description, like for a tweet',
+      title: 'Summary',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.max(240),
+      options: {
+        maxLength: 240,
+      },
+    },
+    {
+      name: 'description',
+      description: 'Full description, no limits',
+      title: 'Description',
+      type: 'markdown',
+    },
+    {
+      name: 'simplecastUid',
+      description: 'UID for episode in simplecast',
+      title: 'Simplecast UID',
+      type: 'string',
+    },
+    {
+      name: 'mediaUrl',
+      description: 'Media URL for the audio for the episode',
+      title: 'Media URL',
+      type: 'url',
+    },
+    {
+      name: 'imageUrl',
+      description: 'Image URL for the cover art for this season',
+      title: 'Image URL',
+      type: 'url',
+    },
+    {
+      name: 'duration',
+      title: 'Duration',
+      description: 'HH:MM:SS',
+      type: 'string',
+    },
+    {
+      name: 'explicit',
+      type: 'boolean',
+      description:
+        'Do you need to warn parents about the content in this podcast? (You can set this for individual episodes to)',
+    },
+    {
+      name: 'urls',
+      description: 'Links to things.',
+      title: 'External URLs',
+      type: 'array',
+      of: [{type: 'link'}],
+    },
+    {
+      name: 'updatedAt',
+      description: 'The last time this resource was meaningfully updated',
+      title: 'Updated At',
+      type: 'date',
+    },
+    {
+      name: 'publishedAt',
+      description: 'The date this podcast episode was published',
+      title: 'Published At',
+      type: 'date',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'subtitle',
+      description: 'description',
+      media: 'coverArt',
+    },
+  },
+}

--- a/studio/schemas/documents/podcastSeason.js
+++ b/studio/schemas/documents/podcastSeason.js
@@ -1,0 +1,105 @@
+export default {
+  name: 'podcastSeason',
+  title: 'Podcast Season',
+  description: 'Podcast Seasons on egghead',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      required: true,
+      description:
+        'Remember that if your title is too long, it may be truncated in various podcatchers-',
+    },
+    {
+      name: 'byline',
+      description: 'Subheading to the season',
+      title: 'Byline',
+      type: 'string',
+    },
+    {
+      name: 'slug',
+      title: 'Podcast slug',
+      type: 'slug',
+      description: 'For when you need to refer to your podcast in a url.',
+      options: {
+        source: 'title',
+        slugify: (input) =>
+          input.toLowerCase().replace(/\s+/g, '-').slice(0, 200),
+      },
+    },
+    {
+      name: 'summary',
+      description: 'Short description, like for a tweet',
+      title: 'Summary',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.max(240),
+      options: {
+        maxLength: 240,
+      },
+    },
+    {
+      name: 'description',
+      description: 'Full description, no limits',
+      title: 'Description',
+      type: 'markdown',
+    },
+    {
+      name: 'imageUrl',
+      description: 'Image URL for the cover art for this season',
+      title: 'Image URL',
+      type: 'url',
+    },
+    {
+      name: 'updatedAt',
+      description: 'The last time this resource was meaningfully updated',
+      title: 'Updated At',
+      type: 'date',
+    },
+    {
+      name: 'podcastEpisodes',
+      description: 'The episodes that comprise this season',
+      title: 'Episodes',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'podcastEpisode'}],
+        },
+      ],
+    },
+    {
+      name: 'collaborators',
+      description:
+        'Humans that worked on this season and get credit for the effort.',
+      title: 'Collaborators',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'collaborator'}],
+        },
+      ],
+    },
+    {
+      name: 'softwareLibraries',
+      description: 'Versioned Software Libraries',
+      title: 'NPM or other Dependencies',
+      type: 'array',
+      of: [
+        {
+          type: 'versioned-software-library',
+        },
+      ],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'byline',
+      description: 'description',
+      media: 'imageUrl',
+    },
+  },
+}

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -21,6 +21,8 @@ import imageUrl from './objects/image-url'
 import stringList from './objects/string-list'
 import post from './documents/post'
 import lesson from './documents/lesson'
+import podcastEpisode from './documents/podcastEpisode'
+import podcastSeason from './documents/podcastSeason'
 import caseStudy from './documents/caseStudy'
 import category from './documents/category'
 import authorReference from './objects/author-reference'
@@ -55,6 +57,8 @@ export default createSchema({
     stringList,
     post,
     lesson,
+    podcastEpisode,
+    podcastSeason,
     caseStudy,
     category,
     authorReference,


### PR DESCRIPTION
In collaboration with @zacjones93 

@zacjones93, look this over and let me know what you think. You can also boot up Sanity Studio locally to see how it looks "live".

This adds the concept of a _Podcast Episode_ to Sanity Studio as a transfer target for the podcasts that currently live in `egghead-rails`. It also adds _Podcast Season_ which is a way of organizing a group of episodes into a bucket with additional metadata.

![podcast](https://media2.giphy.com/media/f9SyS82mgPi4vYeppV/giphy.gif?cid=d1fd59abk04whk9kbxo3y38x865u0zu0tf89tdr0jgoh2x08&rid=giphy.gif&ct=g)