### PR TITLE
Add is_publisher to viewer type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type Viewer = {
   name: string
   is_pro: boolean
   is_instructor: boolean
+  is_publisher: boolean
   can_comment: boolean
   created_at: number
   discord_id: string


### PR DESCRIPTION
This boolean value is now returned by the API and used in the client.

![publisher](https://media0.giphy.com/media/lvnL6wYoupYX2xwnhk/giphy.gif?cid=d1fd59abkrlz6fuz4twkxa3ncr0v2avok8eccl2meke8gldz&rid=giphy.gif&ct=g)