### PR TITLE
Fix role checking logic to compare multiple roles

### DIFF
--- a/src/server/__tests__/ability.test.ts
+++ b/src/server/__tests__/ability.test.ts
@@ -1,0 +1,19 @@
+import {hasRoles} from '../ability'
+
+test('returns true for a single matching role', () => {
+  const user = {roles: ['publisher']}
+
+  expect(hasRoles(user, 'publisher')).toBe(true)
+})
+
+test('returns true if at least one role matches', () => {
+  const user = {roles: ['publisher']}
+
+  expect(hasRoles(user, ['editor', 'publisher'])).toBe(true)
+})
+
+test('returns false if no role matches', () => {
+  const user = {roles: ['publisher', 'editor']}
+
+  expect(hasRoles(user, 'admin')).toBe(false)
+})

--- a/src/server/ability.ts
+++ b/src/server/ability.ts
@@ -1,5 +1,6 @@
 import {AbilityBuilder, Ability} from '@casl/ability'
 import {loadCurrentUser} from 'lib/users'
+import {intersection, isString} from 'lodash'
 
 type Actions = 'manage' | 'upload'
 type Subjects = 'Video' | 'all'
@@ -14,13 +15,28 @@ function defineAbilityFor(user: any) {
   // AbilityBuilder https://casl.js.org/v5/en/guide/define-rules#ability-builder-class
   const {can, build} = new AbilityBuilder<AppAbility>(Ability)
 
-  if (user.roles?.includes('admin')) {
+  if (hasRoles(user, 'admin')) {
     can('manage', 'all') // read-write access to everything
   }
 
-  if (user.roles?.includes('editor', 'publisher')) {
+  if (hasRoles(user, ['editor', 'publisher'])) {
     can('upload', 'Video')
   }
 
   return build()
+}
+
+function hasRoles(user: any, rolesToCheck: string | string[]) {
+  // ensure rolesToCheck is an array
+  let rolesToCheckArray: string[]
+  if (isString(rolesToCheck)) {
+    rolesToCheckArray = [rolesToCheck]
+  } else {
+    rolesToCheckArray = rolesToCheck
+  }
+
+  const userRoles = user?.roles || []
+
+  // check if at least one role overlaps
+  return intersection(userRoles, rolesToCheckArray).length > 0
 }

--- a/src/server/ability.ts
+++ b/src/server/ability.ts
@@ -26,7 +26,7 @@ function defineAbilityFor(user: any) {
   return build()
 }
 
-function hasRoles(user: any, rolesToCheck: string | string[]) {
+export function hasRoles(user: any, rolesToCheck: string | string[]) {
   // ensure rolesToCheck is an array
   let rolesToCheckArray: string[]
   if (isString(rolesToCheck)) {


### PR DESCRIPTION
JavaScript's `includes` cannot compare multiple values on the right side
in the way we were trying to do.

```javascript
['user', 'publisher'].includes('editor', 'publisher')
//=> false
```

Instead, I've replaced that with a small utility function `hasRoles`
that handles the logic of comparing a single role or multiple roles to
the user's list of roles.

```javascript
hasRoles(user, ['editor', 'publisher'])
//=> true
```

![ability check](https://media0.giphy.com/media/1zkpNWClKdgLOMyAMT/giphy.gif?cid=d1fd59ab90swbsx4he9puwlw3x4w25m9l2eg566fm68kw9sy&rid=giphy.gif&ct=g)
