### PR TITLE
Include Ability object on viewer context

### DIFF
--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -211,7 +211,7 @@ function useAuthedViewer() {
       refreshUser: auth.refreshUser,
       ability,
     }),
-    [viewer, loading],
+    [viewer, loading, authToken],
   )
 
   return values

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -205,7 +205,7 @@ function useAuthedViewer() {
       setSession: auth.setSession, // TODO: This isn't exported in auth, so isn't available here.
       handleAccessTokenAuthentication: handleAccessTokenAuthentication,
       isAuthenticated: () => auth.isAuthenticated(),
-      authToken: authToken,
+      authToken,
       requestSignInEmail: (email: any) => auth.requestSignInEmail(email),
       loading,
       refreshUser: auth.refreshUser,

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -30,10 +30,10 @@ const fileUploadReducer = (state: any, action: any) => {
 
 const Upload: React.FC = () => {
   const [state, dispatch] = React.useReducer(fileUploadReducer, {files: []})
-  const {viewer} = useViewer()
+  const {ability} = useViewer()
   const uploaderRef = React.useRef(null)
 
-  return viewer?.s3_signing_url ? (
+  return ability.can('upload', 'Video') ? (
     <div>
       <ReactS3Uploader
         ref={uploaderRef}

--- a/src/server/ability.ts
+++ b/src/server/ability.ts
@@ -1,4 +1,4 @@
-import {AbilityBuilder, Ability} from '@casl/ability'
+import {AbilityBuilder, Ability, defineAbility} from '@casl/ability'
 import {intersection, isString} from 'lodash'
 import {loadCurrentViewerRoles} from '../lib/viewer'
 
@@ -40,3 +40,8 @@ export function includesRoles(
   // check if at least one role overlaps
   return intersection(roles, rolesToCheck).length > 0
 }
+
+// this can be used as a default/initial ability object while waiting for
+// viewer roles to be loaded. It's an `ability` with no permissions. Sort of
+// like the Null Object pattern.
+export const canDoNothingAbility = defineAbility(() => {})


### PR DESCRIPTION
Then use that ability in a React component to check if the current
viewer has authorization to use the `/upload` endpoint.

There is no need to pull in `@casl/react` at this point. It is easier to include the `ability` object on the `viewer` context. The `viewer` context is already broadly available, so these ability checks can happen in any component now.

![john malkovich](https://media0.giphy.com/media/3oriO6HIlQ4fD6JY9a/giphy.gif?cid=d1fd59ab5tra09bwdufiwjtq6ftzkquxxcs91yi7777n22i0&rid=giphy.gif&ct=g)
