### PR TITLE
Proof of concept for an instructor dropdown on the Course Builder page

### DIFF
--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -8,6 +8,7 @@ import {GetServerSideProps} from 'next'
 import {getAbilityFromToken} from 'server/ability'
 import groq from 'groq'
 import {sanityClient} from 'utils/sanity-client'
+import {useViewer} from 'context/viewer-context'
 
 const SIGNING_URL = `/api/aws/sign-s3`
 
@@ -76,6 +77,7 @@ const fileUploadReducer = (state: any, action: any) => {
 const Upload: React.FC<{instructors: Instructor[]}> = ({instructors}) => {
   const [state, dispatch] = React.useReducer(fileUploadReducer, {files: []})
   const uploaderRef = React.useRef(null)
+  const {ability} = useViewer()
 
   return (
     <div>
@@ -127,21 +129,25 @@ const Upload: React.FC<{instructors: Instructor[]}> = ({instructors}) => {
           </div>
         )
       })}
-      <h2>Insructor</h2>
-      {/* we can use a more featureful select component here that allows for search and displaying an image thumbnail. This is a proof of concept. */}
-      <select>
-        {instructors.map(
-          ({
-            externalId,
-            person,
-          }: {
-            externalId: string
-            person: {name: string}
-          }) => {
-            return <option value={externalId}>{person['name']}</option>
-          },
-        )}
-      </select>
+      {ability.can('upload', 'Video.WithInstructor') ? (
+        <>
+          <h2>Insructor</h2>
+          {/* we can use a more featureful select component here that allows for search and displaying an image thumbnail. This is a proof of concept. */}
+          <select>
+            {instructors.map(
+              ({
+                externalId,
+                person,
+              }: {
+                externalId: string
+                person: {name: string}
+              }) => {
+                return <option value={externalId}>{person['name']}</option>
+              },
+            )}
+          </select>
+        </>
+      ) : null}
     </div>
   )
 }

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -15,7 +15,7 @@ const SIGNING_URL = `/api/aws/sign-s3`
 type FileUpload = {file: File; percent: number; message: string}
 
 type Instructor = {
-  externalId: string
+  eggheadInstructorId: string
   person: {
     _id: string
     name: string
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps = async function ({req}) {
             name,
             'image': image.url,
           },
-        externalId,
+        eggheadInstructorId,
       }`
 
     const instructors: Instructor[] = await sanityClient.fetch(instructorQuery)
@@ -75,9 +75,14 @@ const fileUploadReducer = (state: any, action: any) => {
 }
 
 const Upload: React.FC<{instructors: Instructor[]}> = ({instructors}) => {
+  // TODO: rename this reducer variables
   const [state, dispatch] = React.useReducer(fileUploadReducer, {files: []})
   const uploaderRef = React.useRef(null)
-  const {ability} = useViewer()
+  const {viewer} = useViewer()
+
+  const [courseInstructorId, setCourseInstructorId] = React.useState<string>(
+    viewer?.instructor_id || instructors[0]?.eggheadInstructorId,
+  )
 
   return (
     <div>
@@ -129,25 +134,26 @@ const Upload: React.FC<{instructors: Instructor[]}> = ({instructors}) => {
           </div>
         )
       })}
-      {ability.can('upload', 'Video.WithInstructor') ? (
-        <>
-          <h2>Insructor</h2>
-          {/* we can use a more featureful select component here that allows for search and displaying an image thumbnail. This is a proof of concept. */}
-          <select>
-            {instructors.map(
-              ({
-                externalId,
-                person,
-              }: {
-                externalId: string
-                person: {name: string}
-              }) => {
-                return <option value={externalId}>{person['name']}</option>
-              },
-            )}
-          </select>
-        </>
-      ) : null}
+      <h2>Insructor</h2>
+      {/* we can use a more featureful select component here that allows for search and displaying an image thumbnail. This is a proof of concept. */}
+      <select
+        value={courseInstructorId}
+        onChange={(e) => {
+          setCourseInstructorId(e.target.value)
+        }}
+      >
+        {instructors.map(
+          ({
+            eggheadInstructorId,
+            person,
+          }: {
+            eggheadInstructorId: string
+            person: {name: string}
+          }) => {
+            return <option value={eggheadInstructorId}>{person['name']}</option>
+          },
+        )}
+      </select>
     </div>
   )
 }

--- a/src/server/ability.ts
+++ b/src/server/ability.ts
@@ -3,8 +3,8 @@ import {intersection, isString} from 'lodash'
 import {loadCurrentViewerRoles} from '../lib/viewer'
 
 type Actions = 'manage' | 'upload'
-type Subjects = 'Video' | 'Video.WithInstructor' | 'all'
-export type Roles = 'admin' | 'editor' | 'publisher'
+type Subjects = 'Video' | 'all'
+export type Roles = 'admin' | 'editor' | 'publisher' | 'instructor'
 type AppAbility = Ability<[Actions, Subjects]>
 
 export async function getAbilityFromToken(token: string) {
@@ -23,11 +23,15 @@ function defineAbilityFor(viewerRoles: Roles[]) {
     can('manage', 'all') // read-write access to everything
   }
 
+  // Not ready for this yet, but once the uploader is opened up to Instructors,
+  // this is roughly what permissions will look like.
+  // if (includesRoles(viewerRoles, ['instructor'])) {
+  //   can('upload', 'Video')
+  //   cannot('upload', 'Video', ['instructor_id'])
+  // }
+
   if (includesRoles(viewerRoles, ['editor', 'publisher'])) {
-    can('upload', 'Video')
-    // note: an instructor wouldn't have this ability, so they'd only get the
-    // choice to upload as themselves.
-    can('upload', 'Video.WithInstructor')
+    can('upload', 'Video', ['instructor_id'])
   }
 
   return build()

--- a/src/server/ability.ts
+++ b/src/server/ability.ts
@@ -3,7 +3,7 @@ import {intersection, isString} from 'lodash'
 import {loadCurrentViewerRoles} from '../lib/viewer'
 
 type Actions = 'manage' | 'upload'
-type Subjects = 'Video' | 'all'
+type Subjects = 'Video' | 'Video.WithInstructor' | 'all'
 export type Roles = 'admin' | 'editor' | 'publisher'
 type AppAbility = Ability<[Actions, Subjects]>
 
@@ -25,6 +25,9 @@ function defineAbilityFor(viewerRoles: Roles[]) {
 
   if (includesRoles(viewerRoles, ['editor', 'publisher'])) {
     can('upload', 'Video')
+    // note: an instructor wouldn't have this ability, so they'd only get the
+    // choice to upload as themselves.
+    can('upload', 'Video.WithInstructor')
   }
 
   return build()


### PR DESCRIPTION
- Load instructors for assigning to course upload
- Add specialized role for selecting instructor

We still separately need to get instructor IDs synced in Sanity. This PR helps highlight the user-facing need for those IDs to be available.


https://user-images.githubusercontent.com/694063/158635825-68fbd139-a808-4c14-b3fe-75e5e2dedcc2.mp4



![course upload](https://media4.giphy.com/media/5wWf7HapUvpOumiXZRK/giphy.gif?cid=d1fd59abuz0l068c1quwtdklm23ygbczeqft7x77xqolryox&rid=giphy.gif&ct=g)