### PR TITLE
Add egghead instructor ID as Collaborator attr

### DIFF
--- a/studio/schemas/documents/collaborator.js
+++ b/studio/schemas/documents/collaborator.js
@@ -28,11 +28,15 @@ export default {
       type: 'reference',
       to: [{type: 'person'}],
     },
-
     {
       name: 'externalId',
-      title: 'External ID (egghead contact id)',
+      title: 'External ID (egghead contact id/CIO id)',
       type: 'number',
+    },
+    {
+      name: 'eggheadInstructorId',
+      title: 'egghead Instructor ID',
+      type: 'string',
     },
   ],
   preview: {


### PR DESCRIPTION
This field/attr will be populated by a separate script with the corresponding `instructor.id` value from the Rails db. This `id` will serve as a canonical link between the Sanity CMS aspect of an instructor and their backend representation.

In collaboration with @Creeland 

![instructor](https://media1.giphy.com/media/0A477fjlRXL1n2LVgJ/giphy.gif?cid=d1fd59ab4yg0pwebpf3vv183pxzdzsbza3wswhzvz0d3pzg9&rid=giphy.gif&ct=g)