### PR TITLE
chore(sale): adjust wording

### DIFF
--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -24,8 +24,7 @@ import {
   MenuIcon,
   XIcon,
 } from '@heroicons/react/solid'
-import {holidaySaleOn} from 'lib/holiday-sale'
-import HolidaySaleHeaderBanner from 'components/cta/holiday-sale/header-banner'
+import SaleHeaderBanner from 'components/cta/sale/header-banner'
 import {MazePattern} from './images'
 import {isMember} from 'utils/is-member'
 
@@ -213,10 +212,9 @@ const Header: FunctionComponent = () => {
 
   return (
     <>
-      {holidaySaleOn &&
-        !viewer?.is_pro &&
+      {!viewer?.is_pro &&
         !viewer?.is_instructor &&
-        router.pathname !== '/pricing' && <HolidaySaleHeaderBanner />}
+        router.pathname !== '/pricing' && <SaleHeaderBanner />}
       <nav
         aria-label="header"
         className="relative h-12 text-sm border-b border-gray-100 dark:bg-gray-900 dark:border-gray-800 print:hidden dark:text-white text-gray-1000"

--- a/src/components/cta/sale/header-banner.tsx
+++ b/src/components/cta/sale/header-banner.tsx
@@ -4,7 +4,7 @@ import {track} from 'utils/analytics'
 import {useCommerceMachine} from 'hooks/use-commerce-machine'
 import get from 'lodash/get'
 
-const HolidaySaleHeaderBanner = () => {
+const SaleHeaderBanner = () => {
   const {state} = useCommerceMachine()
   const appliedCoupon = get(state.context.pricingData, 'applied_coupon')
   const percentOff = Math.round(appliedCoupon?.coupon_discount * 100)
@@ -13,25 +13,33 @@ const HolidaySaleHeaderBanner = () => {
     <Link href="/pricing">
       <a
         onClick={() => {
-          track('clicked holiday banner', {
-            category: 'holiday-sale',
-            label: 'holiday-sale-header-banner',
+          track('clicked flash sale banner', {
+            category: 'flash-sale',
+            label: 'flash-sale-header-banner',
           })
         }}
         className="group"
       >
         <div className="bg-gradient-to-r text-white sm:px-2 pl-2 sm:text-sm text-xs from-blue-500 to-indigo-500 flex justify-center">
           <div className="py-1 pr-3 leading-tight">
-            <span aria-hidden="true">🌟</span> Holiday Sale:{' '}
+            <span role="img" aria-hidden="true">
+              🌟
+            </span>{' '}
+            Flash Sale:{' '}
             <span>
-              Save {percentOff}% on egghead membership
+              Save <strong>{percentOff}%</strong> on egghead membership
               {appliedCoupon.coupon_expires_at &&
-                ' for limited time only'}. <span aria-hidden="true">💫</span>
+                ' for limited time only'}.{' '}
+              <span role="img" aria-hidden="true">
+                💫
+              </span>
             </span>
           </div>
-          <div className="flex items-center py-px px-2 bg-white dark:bg-opacity-100 bg-opacity-90 text-blue-600 flex-shrink-0">
+          <div className="flex items-center py-px px-2 dark:bg-white bg-black dark:bg-opacity-100 bg-opacity-20 dark:text-blue-600 text-white flex-shrink-0">
             <span className="pr-1 font-medium">Become a Member</span>{' '}
-            <span aria-hidden>→</span>
+            <span role="img" aria-hidden="true">
+              →
+            </span>
           </div>
         </div>
       </a>
@@ -39,4 +47,4 @@ const HolidaySaleHeaderBanner = () => {
   ) : null
 }
 
-export default HolidaySaleHeaderBanner
+export default SaleHeaderBanner

--- a/src/components/pages/landing/footer/index.tsx
+++ b/src/components/pages/landing/footer/index.tsx
@@ -147,7 +147,7 @@ const PricingCta = () => {
             appliedCoupon?.coupon_expires_at && (
               <div className="max-w-xs w-full mx-auto">
                 <Countdown
-                  label="Holiday sale – Price goes up in:"
+                  label="Flash sale – Price goes up in:"
                   date={fromUnixTime(appliedCoupon.coupon_expires_at)}
                 />
               </div>

--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -236,7 +236,7 @@ const SelectPlanNew: React.FunctionComponent<SelectPlanProps> = ({
         <PlanTitle>{currentPlan?.name}</PlanTitle>
         {!isPPP && appliedCoupon?.coupon_expires_at && !pricesLoading && (
           <Countdown
-            label="Holiday sale – Price goes up in:"
+            label="Flash sale – Price goes up in:"
             date={fromUnixTime(appliedCoupon.coupon_expires_at)}
           />
         )}

--- a/src/lib/sale.ts
+++ b/src/lib/sale.ts
@@ -3,7 +3,7 @@ import {sanityClient} from 'utils/sanity-client'
 import {CardResource} from 'types'
 import groq from 'groq'
 
-const holidaySaleOn = process.env.NEXT_PUBLIC_EOY_SALE
+const saleOn = process.env.NEXT_PUBLIC_FLASH_SALE
 
 export type HolidaySaleProps = {
   data: CardResource
@@ -37,4 +37,4 @@ async function loadHolidayCourses() {
   return data
 }
 
-export {holidaySaleOn, loadHolidayCourses, CourseGrid}
+export {saleOn, loadHolidayCourses, CourseGrid}

--- a/src/pages/20-days.tsx
+++ b/src/pages/20-days.tsx
@@ -3,7 +3,7 @@ import {NextSeo} from 'next-seo'
 import {CardResource} from 'types'
 import {GetServerSideProps} from 'next'
 import CourseGrid from 'components/pages/20-days-of-egghead/course-grid'
-import {loadHolidayCourses} from 'lib/holiday-sale'
+import {loadHolidayCourses} from 'lib/sale'
 
 type EOYSale2021PageProps = {
   data: CardResource

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent} from 'react'
-import {loadHolidayCourses, holidaySaleOn} from 'lib/holiday-sale'
+import {loadHolidayCourses, saleOn} from 'lib/sale'
 import {sanityClient} from 'utils/sanity-client'
 import Home from 'components/pages/home'
 import {NextSeo} from 'next-seo'
@@ -77,7 +77,7 @@ const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-hom
 
 export async function getStaticProps() {
   const data = await sanityClient.fetch(homepageQuery)
-  const holidayCourses = holidaySaleOn ? await loadHolidayCourses() : {}
+  const holidayCourses = saleOn ? await loadHolidayCourses() : {}
 
   return {
     props: {


### PR DESCRIPTION
- change wording from holiday sale to flash sale
- don't require env flag and only depend on coupon presence for displaying header banner

<img src="https://user-images.githubusercontent.com/25487857/159655214-6e91f6f5-a7c5-479c-8d6d-8b4969f221c7.jpg" alt="screenshot">

<img src="https://media.giphy.com/media/n1TMbCu6k6gNVnz9eF/giphy.gif" width="150" alt="gif">
