### PR TITLE
Refactor Software Lib naming to Topic

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -34,9 +34,9 @@ const courseQuery = groq`
     'avatar_url': person->image.url,
     'slug': person->slug.current
   },
-	'dependencies': softwareLibraries[]{
+	'dependencies': topicTaggings[]{
     version,
-    ...library->{
+    ...topic->{
       description,
       "slug": slug.current,
       path,

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -42,13 +42,13 @@ export default {
         'This can be used to provide a short description of the lesson.',
     },
     {
-      name: 'softwareLibraries',
-      description: 'Versioned Software Libraries',
-      title: 'NPM or other Dependencies',
+      name: 'topicTaggings',
+      description: '(Libraries/Frameworks/Languages/Etc.)',
+      title: 'Topics',
       type: 'array',
       of: [
         {
-          type: 'versioned-software-library',
+          type: 'topic-tagging',
         },
       ],
     },

--- a/studio/schemas/documents/podcastSeason.js
+++ b/studio/schemas/documents/podcastSeason.js
@@ -83,13 +83,13 @@ export default {
       ],
     },
     {
-      name: 'softwareLibraries',
-      description: 'Versioned Software Libraries',
-      title: 'NPM or other Dependencies',
+      name: 'topicTaggings',
+      description: '(Libraries/Frameworks/Languages/Etc.)',
+      title: 'Topics',
       type: 'array',
       of: [
         {
-          type: 'versioned-software-library',
+          type: 'topic-tagging',
         },
       ],
     },

--- a/studio/schemas/documents/post.js
+++ b/studio/schemas/documents/post.js
@@ -82,13 +82,13 @@ export default {
       ],
     },
     {
-      name: 'softwareLibraries',
-      description: 'Versioned Software Libraries',
-      title: 'NPM or other Dependencies',
+      name: 'topicTaggings',
+      description: '(Libraries/Frameworks/Languages/Etc.)',
+      title: 'Topics',
       type: 'array',
       of: [
         {
-          type: 'versioned-software-library',
+          type: 'topic-tagging',
         },
       ],
     },

--- a/studio/schemas/documents/resource.js
+++ b/studio/schemas/documents/resource.js
@@ -344,13 +344,13 @@ export default {
       of: [{type: 'string'}],
     },
     {
-      name: 'softwareLibraries',
-      description: 'Versioned Software Libraries',
-      title: 'NPM or other Dependencies',
+      name: 'topicTaggings',
+      description: '(Libraries/Frameworks/Languages/Etc.)',
+      title: 'Topics',
       type: 'array',
       of: [
         {
-          type: 'versioned-software-library',
+          type: 'topic-tagging',
         },
       ],
     },

--- a/studio/schemas/documents/topic.js
+++ b/studio/schemas/documents/topic.js
@@ -2,8 +2,8 @@ import {MdLibraryBooks as icon} from 'react-icons/md'
 import React from 'react'
 
 export default {
-  name: 'software-library',
-  title: 'software library (dependency)',
+  name: 'topic',
+  title: 'Topic (Libraries/Frameworks/Languages/Etc.)',
   type: 'document',
   icon,
   fields: [
@@ -36,7 +36,7 @@ export default {
       type: 'string',
     },
     {
-      title: 'Link to library',
+      title: 'Link to canonical resource',
       name: 'url',
       type: 'url',
     },

--- a/studio/schemas/objects/topic-tagging.js
+++ b/studio/schemas/objects/topic-tagging.js
@@ -1,27 +1,27 @@
 import React from 'react'
 
 export default {
-  name: 'versioned-software-library',
-  title: 'Versioned Software Library (Dependency)',
+  name: 'topic-tagging',
+  title: 'Topic Tagging',
   type: 'object',
   fields: [
     {
       name: 'version',
-      title: 'Version',
+      title: 'Version (if applicable)',
       type: 'string',
     },
     {
-      name: 'library',
-      title: 'Software Library (Dependency)',
+      name: 'topic',
+      title: 'Topic (Libraries/Frameworks/Languages/Etc.)',
       type: 'reference',
-      to: [{type: 'software-library'}],
+      to: [{type: 'topic'}],
     },
   ],
   preview: {
     select: {
       version: 'version',
-      name: 'library.name',
-      media: 'library.image.url',
+      name: 'topic.name',
+      media: 'topic.image.url',
     },
     prepare(selection) {
       const {version, name, media} = selection

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -7,14 +7,14 @@ import schemaTypes from 'all:part:@sanity/base/schema-type'
 import collaborator from './documents/collaborator'
 import resource from './documents/resource'
 import person from './documents/person'
-import library from './documents/software-library'
+import topic from './documents/topic'
 import bigIdea from './documents/bigIdea'
 import essentialQuestion from './documents/essentialQuestion'
 import blockText from './objects/blockText'
 import blockContent from './objects/blockContent'
 import markdownText from './objects/markdownText'
 import link from './objects/link'
-import versionedLibrary from './objects/versioned-software-library'
+import topicTagging from './objects/topic-tagging'
 import cta from './objects/cta'
 import ctaPlug from './plugs/ctaPlug'
 import imageUrl from './objects/image-url'
@@ -38,7 +38,7 @@ export default createSchema({
   // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
-    versionedLibrary,
+    topicTagging,
     markdownText,
     blockContent,
     blockText,
@@ -51,7 +51,7 @@ export default createSchema({
     imageUrl,
     collaborator,
     person,
-    library,
+    topic,
     essentialQuestion,
     bigIdea,
     stringList,


### PR DESCRIPTION
> “The discussions that you have [with your teammates] about naming have benefits far beyond the work that you are currently doing. They help you and your team develop a common view of what the system is and what it can become.”
> –Working Effectively with Legacy Code

This refactoring is motivated by my efforts to sync all egghead-rails tags into Sanity. We are also in the midst of thinking about and rethinking the schema. This feels like a good chance to reuse existing schema objects as tagging becomes a primary concern of Sanity.

The shift from `Software Libarary` to `Topic` is to be more encompassing
of what can go in this bucket and to better align with the `topic`
context that we've started using in egghead-rails. Things like `a11y`
and `JavaScript` aren't really software libraries. They are however
topics of the different kinds of content provided by egghead.

Then, instead of Versioned Software Libraries, it is `TopicTaggings`.
This name does a couple things in addition to aligning it with the
updated naming of `Topic`.
1) It drops the "Versioned" qualifier since that isn't required and
doesn't make sense for a topic like `a11y`.
2) It suggests that it is a concept to be applied to (or tagged to) a
piece of content.

Open to discussion on this, hence the RFC tag.

![topical](https://media2.giphy.com/media/RJhac1GXoluliNFsF4/giphy.gif?cid=d1fd59ab315kz7qdohfhfn5lyzc7aixf1khar7yn6ox869ld&rid=giphy.gif&ct=g)
