### PR TITLE
fix pricing page font color on dark mode

### DIFF
--- a/src/components/pages/confirm/membership/index.tsx
+++ b/src/components/pages/confirm/membership/index.tsx
@@ -67,7 +67,12 @@ const Support: React.FC = () => {
         <p className="prose dark:prose-dark max-w-none">
           If you have any issues, please email support{' '}
           <strong>
-            <a href="mailto:support@egghead.io">support@egghead.io</a>
+            <a
+              className="prose dark:prose-dark"
+              href="mailto:support@egghead.io"
+            >
+              support@egghead.io
+            </a>
           </strong>{' '}
           and we will help you as soon as possible.
         </p>


### PR DESCRIPTION
- fixes issue not seeing egghead email on confirmation page

## Before
![Build the portfolio you need to be a badass web developer  egghead io 2022-03-28 at 11 44 24 AM](https://user-images.githubusercontent.com/6188161/160436980-c72669cc-11ca-4e25-bbcb-c597fc3a87af.jpg)
## After
![Build the portfolio you need to be a badass web developer  egghead io 2022-03-28 at 11 44 09 AM](https://user-images.githubusercontent.com/6188161/160437028-e3810ac1-9230-4b22-8f92-aebdffe61853.jpg)

![there was light](https://media1.giphy.com/media/h1Hvk7Vp3KKIenIBWK/giphy.gif?cid=1927fc1bz4iswalbo3vk4eossjex8ek0hjwhb78pbzatiu35&rid=giphy.gif&ct=g)
