### PR TITLE
Spike out batch uploader for Course Builder

### DIFF
--- a/src/components/upload/video-uploader.tsx
+++ b/src/components/upload/video-uploader.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import ReactS3Uploader from 'react-s3-uploader'
+import {getAuthorizationHeader} from 'utils/auth'
+import uuid from 'shortid'
+import fileExtension from 'file-extension'
+
+const SIGNING_URL = `/api/aws/sign-s3`
+
+const VideoUploader = ({
+  dispatch,
+  setLessonMetadata,
+}: {
+  dispatch: Function
+  setLessonMetadata: Function
+}) => {
+  const uploaderRef = React.useRef(null)
+
+  return (
+    <ReactS3Uploader
+      class="hidden"
+      ref={uploaderRef}
+      multiple
+      //if we set this to `false` we can list all the files and
+      //call `uploaderRef.current.uploadFile()` when we are ready
+      autoUpload={true}
+      signingUrl={SIGNING_URL}
+      // @ts-ignore
+      signingUrlHeaders={getAuthorizationHeader()}
+      accept="video/*"
+      scrubFilename={(fullFilename) => {
+        // filename with no extension
+        const filename = fullFilename.replace(/\.[^/.]+$/, '')
+        // remove stuff s3 hates
+        const scrubbed = `${filename}-${uuid.generate()}`
+          .replace(/[^\w\d_\-.]+/gi, '')
+          .toLowerCase()
+        // rebuild it as a fresh new thing
+        return `${scrubbed}.${fileExtension(fullFilename)}`
+      }}
+      preprocess={(file, next) => {
+        dispatch({
+          type: 'add',
+          fileUpload: {
+            file,
+            percent: 0,
+            message: 'waiting to upload',
+          },
+        })
+
+        next(file)
+      }}
+      onProgress={(percent, message, file) => {
+        dispatch({type: 'progress', file, percent, message})
+      }}
+      onError={(message) => console.log(message)}
+      onFinish={(signResult, file) => {
+        const fileUrl = signResult.signedUrl.split('?')[0]
+        setLessonMetadata((prevState: Array<object>) => [
+          ...prevState,
+          {
+            title: file.name,
+            fileMetadata: {fileName: file.name, signedUrl: fileUrl},
+          },
+        ])
+      }}
+    />
+  )
+}
+
+export default VideoUploader

--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -1,0 +1,101 @@
+import {NextApiRequest, NextApiResponse} from 'next'
+import {sanityClient} from 'utils/sanity-client'
+import {getTokenFromCookieHeaders} from 'utils/auth'
+import fetchEggheadUser from 'api/egghead/users/from-token'
+import {nanoid} from 'nanoid'
+
+type LessonData = {
+  title: string
+  fileMetadata: {
+    fileName: string
+    signedUrl: string
+  }
+}
+
+type SanityVideoResource = {
+  _type: string
+  _id: string
+  filename: string
+  originalVideoUrl: string
+}
+
+type SanityLesson = {
+  _type: string
+  title: string
+  resource: {
+    _type: string
+    _ref: string
+  }
+}
+
+async function formatSanityMutationForLessons(lessons: LessonData[]) {
+  let sanityLessons: SanityLesson[] = []
+  let sanityResources: SanityVideoResource[] = []
+
+  lessons.forEach(async (lesson) => {
+    const videoId = await nanoid()
+
+    sanityResources.push({
+      _type: 'videoResource',
+      _id: videoId,
+      filename: lesson.fileMetadata.fileName,
+      originalVideoUrl: lesson.fileMetadata.signedUrl,
+    })
+
+    sanityLessons.push({
+      _type: 'lesson',
+      title: lesson.title,
+      resource: {
+        _type: 'reference',
+        _ref: videoId,
+      },
+    })
+  })
+
+  return {sanityLessons, sanityResources}
+}
+
+const createSanityLessons = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  const {eggheadToken} = getTokenFromCookieHeaders(req.headers.cookie as string)
+
+  if (req.method === 'POST') {
+    const eggheadViewer = await fetchEggheadUser(eggheadToken, false)
+
+    // permissions check for creating lessons in Sanity
+    const {is_publisher, is_instructor} = eggheadViewer
+
+    if (!is_publisher && !is_instructor) {
+      res.status(403).end()
+    } else {
+      let transaction = sanityClient.transaction()
+
+      const {sanityLessons, sanityResources} =
+        await formatSanityMutationForLessons(req.body.lessons)
+
+      sanityResources.forEach((lesson) => {
+        transaction.create(lesson)
+      })
+
+      sanityLessons.forEach((lesson) => {
+        transaction.create(lesson)
+      })
+
+      transaction
+        .commit()
+        .then((sanityRes) => {
+          console.log('Transaction', sanityRes)
+
+          res.status(200).end()
+        })
+        .catch((err) => console.log('ERROR', err))
+    }
+  } else {
+    res.statusCode = 404
+    res.end()
+  }
+}
+
+export default createSanityLessons

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -87,10 +87,7 @@ const fileUploadReducer = (state: any, action: any) => {
 }
 
 const UploadWrapper = ({instructors}: {instructors: Instructor[]}) => {
-  const {viewer} = useViewer()
   const initialValues: FormProps = {lessons: []}
-
-  if (!viewer?.s3_signing_url) return null
 
   return (
     <Formik

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -221,6 +221,7 @@ const Upload: React.FC<FormikProps<FormProps> & {instructors: Instructor[]}> = (
             <label className="block text-sm font-medium text-gray-700">
               Video Files
             </label>
+            {/* Drop zone UI adapted from https://larainfo.com/blogs/tailwind-css-drag-and-drop-file-upload-ui */}
             <div className="max-w-xl">
               <label className="flex justify-center w-full h-32 px-4 transition bg-white border-2 border-gray-300 border-dashed rounded-md appearance-none cursor-pointer hover:border-gray-400 focus:outline-none">
                 <span className="flex items-center space-x-2">

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -266,7 +266,7 @@ const Upload: React.FC<FormikProps<FormProps> & {instructors: Instructor[]}> = (
                 Title
               </label>
               <Field
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
                 name={`lessons.${i}.title`}
               />
               <p className="mt-2 text-center text-sm text-gray-600">

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -35,6 +35,19 @@ export default {
       type: 'url',
     },
     {
+      name: 'resource',
+      description:
+        'Attach a resource to this lesson (Video, Audio, Text, etc.)',
+      title: 'Resource',
+      type: 'reference',
+      to: [
+        {
+          type: 'videoResource',
+          title: 'Video',
+        },
+      ],
+    },
+    {
       name: 'description',
       type: 'markdown',
       title: 'Description',

--- a/studio/schemas/documents/videoResource.js
+++ b/studio/schemas/documents/videoResource.js
@@ -1,0 +1,29 @@
+export default {
+  name: 'videoResource',
+  title: 'Video Resource',
+  type: 'document',
+  fields: [
+    {
+      name: 'filename',
+      title: 'Filename',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'originalVideoUrl',
+      title: 'Original Video URL',
+      type: 'url',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'hslUrl',
+      title: 'HSL URL',
+      type: 'url',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'filename',
+    },
+  },
+}

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -19,6 +19,7 @@ import cta from './objects/cta'
 import ctaPlug from './plugs/ctaPlug'
 import imageUrl from './objects/image-url'
 import stringList from './objects/string-list'
+import videoResource from './documents/videoResource'
 import post from './documents/post'
 import lesson from './documents/lesson'
 import podcastEpisode from './documents/podcastEpisode'
@@ -55,6 +56,7 @@ export default createSchema({
     essentialQuestion,
     bigIdea,
     stringList,
+    videoResource,
     post,
     lesson,
     podcastEpisode,


### PR DESCRIPTION
This is our first pass at the Course Builder. It is a re-interpretation of https://github.com/eggheadio/egghead-next/pull/1051 which I was struggling to integrate with `main` (merge conflicts 😵). It does a few extra things that PR didn't do like including some of the other fields that the Course Builder will need.

This uses some basic styling from Tailwind UI, so it will need a more
intentional design pass later on. There is also plenty of UX that needs
polishing. I intentionally avoided getting sidetracked by most of that
in favor of getting something shippable.

It also includes fields like Course Name and Instructor that aren't used
at the moment, but can be integrated next.

## Video Demo


https://user-images.githubusercontent.com/694063/160882735-205014f1-770a-4165-8dd3-180a6ea7dbc7.mp4




![course builder](https://media0.giphy.com/media/Y99pr27TaofgA/giphy.gif?cid=d1fd59ab4bfmioja6oyyhuah7ynkwru79yyflgc3fsyw5w0t&rid=giphy.gif&ct=g)
