### PR TITLE
Add summary and byline to course schema

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -28,6 +28,28 @@ export default {
       description: 'A full description of the course.',
     },
     {
+      name: 'summary',
+      description: 'Short description, like for a tweet',
+      title: 'Summary',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.max(180),
+      options: {
+        maxLength: 180,
+      },
+    },
+    {
+      name: 'byline',
+      description:
+        'Metadata to display on cards (e.g. "Kent C. Dodds • 2h 29m • Course")',
+      title: 'Byline',
+      type: 'string',
+      validation: (Rule) => Rule.max(90),
+      options: {
+        maxLength: 90,
+      },
+    },
+    {
       name: 'publishedAt',
       description: 'The date this course was published',
       title: 'Published At',


### PR DESCRIPTION
Per Zac's feedback
(https://roamresearch.com/#/app/egghead/page/PLA6OXuJ9)

<img width="688" alt="CleanShot 2022-04-18 at 17 49 54@2x" src="https://user-images.githubusercontent.com/694063/163889538-59edc80d-a524-42ec-b36e-c2dc242d6892.png">


![schema](https://media1.giphy.com/media/QJVhqOoImB3zfHfvj8/giphy.gif?cid=d1fd59abk7zakkr46lq4rc17jrw8muu07qdghyvzz3jki2ca&rid=giphy.gif&ct=g)
