### PR TITLE
feat: Add topics to course builder 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -152,4 +152,5 @@ export type ParityCouponMessageProps = {
 export type CourseData = {
   title: string
   collaboratorId?: string
+  topicIds: string[]
 }


### PR DESCRIPTION
This PR adds a topic field to the course builder form and supports creating courses with topics in the Sanity create API route

## TODO 
- Support selecting multiple topics
- Add topics to each of a new course's lessons

In collaboration with @jbranchaud

![insanity](https://media1.giphy.com/media/J4rpqkbXewevF725qO/giphy.gif?cid=01d288b0f42vhhl66eni70cql2q2maipexdwdhn2kmvc29yw&rid=giphy.gif&ct=g)
