### PR TITLE
Use `&` to combine reference type into Array type

### DIFF
--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -21,11 +21,11 @@ type SanityReference = {
   _ref: string
 }
 
-type SanityReferenceArray = Array<{
-  _key: string
-  _type: 'reference'
-  _ref: string
-}>
+type SanityReferenceArray = Array<
+  {
+    _key: string
+  } & SanityReference
+>
 
 type SanityVideoResource = {
   _type: 'videoResource'


### PR DESCRIPTION
@Creeland we were wondering yesterday if there was a way to have `SanityReferenceArray` use the `SanityReference` type so that it didn't have to duplicate the individual type attributes. Looks like we can do it this way.

![type](https://media3.giphy.com/media/xUA7b8wrPKmCltD89W/giphy.gif?cid=d1fd59abldv0ucd10m89j7esh6blhofdlmxhn3z9jk5nptq3&rid=giphy.gif&ct=g)