### PR TITLE
add flex to align elements when height is small

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -285,7 +285,7 @@ const Search: FunctionComponent<SearchProps> = ({
                   <ScrollElement name="hits" />
                   <Stats searchQuery={searchState.query} />
                   <Hits />
-                  <div className="pb-16 pt-10 bg-gradient-to-t dark:from-gray-1000 dark:to-transparent from-gray-100 to-transparent">
+                  <div className="pb-16 pt-10 flex-grow bg-gradient-to-t dark:from-gray-1000 dark:to-transparent from-gray-100 to-transparent">
                     <Pagination />
                   </div>
                 </main>

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -227,7 +227,7 @@ const Search: FunctionComponent<SearchProps> = ({
               <div className="md:grid flex grid-cols-12 relative gap-3">
                 {RefinementsDesktop()}
                 {RefinementsMobile()}
-                <main className="col-span-10 w-full relative dark:bg-gray-900 bg-gray-50">
+                <main className="col-span-10 flex flex-col w-full relative dark:bg-gray-900 bg-gray-50">
                   <div className="dark:bg-gray-900 bg-white sticky top-0 z-40 shadow-smooth flex items-center w-full border-b dark:border-white border-gray-900 dark:border-opacity-5 border-opacity-5">
                     <SearchBox placeholder={searchBoxPlaceholder} />
                     <div className="border-l dark:border-gray-800 border-gray-100 flex items-center flex-shrink-0 space-x-2 flex-nowrap">

--- a/src/components/search/stats.tsx
+++ b/src/components/search/stats.tsx
@@ -13,7 +13,7 @@ const CustomStats: React.FunctionComponent<CustomStatsProps> = ({
   return !searchQuery || /^\s*$/.test(searchQuery) ? (
     <div />
   ) : (
-    <div className="sm:text-lg flex items-baseline flex-nowrap overflow-hidden max-w-full flex-grow pt-5 px-3">
+    <div className="sm:text-lg flex items-baseline flex-nowrap overflow-hidden max-w-full  pt-5 px-3">
       <div className="font-semibold whitespace-nowrap">
         {nbHits.toLocaleString()} results
       </div>


### PR DESCRIPTION
I noticed when searching for content, if we don't have much to display the search result height makes the page look bad.

Adding flex aligns the pagination component to the bottom of the containing area.

## Before
![element alignment is off](https://user-images.githubusercontent.com/6188161/167163695-39d9018f-aef3-43fb-b081-813c86a8a9a8.png)

## After
![bottom is aligned nicely](https://user-images.githubusercontent.com/6188161/167166438-97ce42ae-6fae-41db-9a6f-04a45571f818.png)

