### PR TITLE
Separate Course and Overlay components from Lessons page

### DIFF
--- a/src/components/pages/lessons/course.tsx
+++ b/src/components/pages/lessons/course.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import Link from 'next/link'
+import {track} from 'utils/analytics'
+import Image from 'next/image'
+
+const Course: React.FC<{
+  course: {
+    title: string
+    square_cover_480_url: string
+    slug: string
+    path: string
+  }
+  currentLessonSlug: string
+}> = ({course, currentLessonSlug}) => {
+  return course ? (
+    <div>
+      <div className="flex items-center">
+        <Link href={course.path}>
+          <a className="relative flex-shrink-0 block w-12 h-12 lg:w-20 lg:h-20">
+            <Image
+              src={course.square_cover_480_url}
+              alt={`illustration for ${course.title}`}
+              layout="fill"
+            />
+          </a>
+        </Link>
+        <div className="ml-2 lg:ml-4">
+          <h4 className="mb-px text-xs font-semibold text-gray-700 uppercase dark:text-gray-100">
+            Course
+          </h4>
+          <Link href={course.path}>
+            <a
+              onClick={() => {
+                track(`clicked open course`, {
+                  lesson: currentLessonSlug,
+                })
+              }}
+              className="hover:underline"
+            >
+              <h3 className="font-bold leading-tighter 2xl:text-lg">
+                {course.title}
+              </h3>
+            </a>
+          </Link>
+        </div>
+      </div>
+    </div>
+  ) : null
+}
+
+export default Course

--- a/src/components/pages/lessons/overlays.tsx
+++ b/src/components/pages/lessons/overlays.tsx
@@ -4,6 +4,7 @@ import {first, get} from 'lodash'
 import axios from 'utils/configured-axios'
 import {track} from 'utils/analytics'
 import specialLessons from './special-lessons'
+import {CIOSubscriber} from 'hooks/use-cio'
 
 import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
@@ -22,7 +23,7 @@ type OverlaysProps = {
   viewer: object
   videoService: {send: Function}
   lessonView: {collection_progress: {rate_url: string}}
-  subscriber: {id: string; attributes?: {learner_score: string}}
+  subscriber?: CIOSubscriber
   cioIdentify: Function
 }
 

--- a/src/components/pages/lessons/overlays.tsx
+++ b/src/components/pages/lessons/overlays.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react'
+import {VideoResource} from 'types'
+import {first, get} from 'lodash'
+import axios from 'utils/configured-axios'
+import {track} from 'utils/analytics'
+import specialLessons from './special-lessons'
+
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
+
+import RateCourseOverlay from 'components/pages/lessons/overlay/rate-course-overlay'
+import RecommendNextStepOverlay from 'components/pages/lessons/overlay/recommend-next-step-overlay'
+import GoProCtaOverlay from 'components/pages/lessons/overlay/go-pro-cta-overlay'
+import WatchFullCourseCtaOverlay from 'components/pages/lessons/overlay/watch-full-course-cta-overlay'
+import WatchNextLessonCtaOverlay from 'components/pages/lessons/overlay/watch-next-lesson-cta-overlay'
+import EmailCaptureCtaOverlay from 'components/pages/lessons/overlay/email-capture-cta-overlay'
+
+type OverlaysProps = {
+  lessonSend: Function
+  lessonState: {matches: Function}
+  lesson: VideoResource
+  nextLesson: any
+  viewer: object
+  videoService: {send: Function}
+  lessonView: {collection_progress: {rate_url: string}}
+  subscriber: {id: string; attributes?: {learner_score: string}}
+  cioIdentify: Function
+}
+
+const Overlays: React.FC<OverlaysProps> = ({
+  lessonSend,
+  lessonState,
+  lesson,
+  nextLesson,
+  viewer,
+  videoService,
+  lessonView,
+  subscriber,
+  cioIdentify,
+}) => {
+  const {slug, tags = []} = lesson
+  const primaryTag = get(first(tags), 'name', 'javascript')
+
+  return (
+    <>
+      {lessonState.matches('joining') && (
+        <OverlayWrapper>
+          <EmailCaptureCtaOverlay lesson={lesson} technology={primaryTag} />
+        </OverlayWrapper>
+      )}
+      {lessonState.matches('subscribing') && (
+        <OverlayWrapper>
+          <GoProCtaOverlay
+            lesson={lesson}
+            viewLesson={() => {
+              lessonSend({
+                type: 'LOAD',
+                lesson: lesson,
+                viewer,
+              })
+              // TODO: Make sure this is working as expected
+              videoService.send({
+                type: 'LOAD_RESOURCE',
+                resource: lesson,
+              })
+            }}
+          />
+        </OverlayWrapper>
+      )}
+      {lessonState.matches('pitchingCourse') && (
+        <OverlayWrapper>
+          <WatchFullCourseCtaOverlay
+            lesson={lesson}
+            onClickRewatch={() => {
+              lessonSend('VIEW')
+              videoService.send({type: 'PLAY'})
+            }}
+          />
+        </OverlayWrapper>
+      )}
+      {lessonState.matches('showingNext') && (
+        <OverlayWrapper>
+          <WatchNextLessonCtaOverlay
+            lesson={lesson}
+            nextLesson={nextLesson}
+            ctaContent={specialLessons[lesson.slug]}
+            onClickRewatch={() => {
+              lessonSend('VIEW')
+              videoService.send({type: 'PLAY'})
+            }}
+          />
+        </OverlayWrapper>
+      )}
+      {lessonState.matches('rating') && (
+        <OverlayWrapper>
+          <RateCourseOverlay
+            course={lesson.collection}
+            onRated={(review) => {
+              axios
+                .post(lessonView.collection_progress.rate_url, review)
+                .then(() => {
+                  const comment = get(review, 'comment.comment')
+                  const prompt = get(review, 'comment.context.prompt')
+
+                  if (review) {
+                    // TODO: the `course: slug` is referencing the lesson slug.
+                    // Is that an error or is the naming just a little
+                    // confusing?
+                    track('rated course', {
+                      course: slug,
+                      rating: review.rating,
+                      ...(comment && {comment}),
+                      ...(!!prompt && {prompt}),
+                    })
+                    if (subscriber) {
+                      const currentScore =
+                        Number(subscriber.attributes?.learner_score) || 0
+                      cioIdentify(subscriber.id, {
+                        learner_score: currentScore + 20,
+                      })
+                    }
+                  }
+                })
+                .finally(() => {
+                  setTimeout(() => {
+                    lessonSend('RECOMMEND')
+                  }, 1500)
+                })
+            }}
+          />
+        </OverlayWrapper>
+      )}
+      {lessonState.matches('recommending') && (
+        <OverlayWrapper>
+          <RecommendNextStepOverlay lesson={lesson} />
+        </OverlayWrapper>
+      )}
+    </>
+  )
+}
+
+export default Overlays

--- a/src/components/pages/lessons/special-lessons.ts
+++ b/src/components/pages/lessons/special-lessons.ts
@@ -1,0 +1,48 @@
+const specialLessons: any = {
+  'javascript-3-ways-to-update-the-content-of-an-array-of-objects-with-javascript':
+    {
+      headline: 'Check out these in-depth courses on JavaScript Arrays',
+      linksTo: [
+        {
+          title: 'Understand JavaScript Arrays',
+          isPro: true,
+          path: 'understand-javascript-arrays',
+          type: 'course',
+          imageUrl:
+            'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/432/714/square_480/EGH_JSarrays.png',
+        },
+        {
+          title: 'Reduce Data with Javascript Array#reduce',
+          isPro: true,
+          path: 'reduce-data-with-javascript-array-reduce',
+          type: 'course',
+          imageUrl:
+            'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/432/557/square_480/EGH_ReduceDataJS.png',
+        },
+      ],
+    },
+
+  'javascript-creating-demo-apis-with-json-server': {
+    headline: 'Build better APIs with these in-depth courses',
+    linksTo: [
+      {
+        title: 'Build a Serverless API with Cloudflare Workers',
+        isPro: false,
+        slug: 'build-a-serverless-api-with-cloudflare-workers-d67ca551',
+        type: 'course',
+        imageUrl:
+          'https://d2eip9sf3oo6c2.cloudfront.net/playlists/square_covers/000/441/045/square_480/EGH_cloudflare-workers_424_2x.png',
+      },
+      {
+        title: 'Building an API with Express',
+        isPro: true,
+        slug: 'building-an-api-with-express-f1ea',
+        type: 'course',
+        imageUrl:
+          'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/000/359/square_480/expressjslogo.png',
+      },
+    ],
+  },
+}
+
+export default specialLessons

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -618,13 +618,13 @@ const Lesson: React.FC<LessonProps> = ({
                   viewLesson={() => {
                     send({
                       type: 'LOAD',
-                      lesson: initialLesson,
+                      lesson: lesson,
                       viewer,
                     })
                     // TODO: Make sure this is working as expected
                     videoService.send({
                       type: 'LOAD_RESOURCE',
-                      resource: initialLesson as any,
+                      resource: lesson,
                     })
                   }}
                 />

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -7,6 +7,7 @@ import {useMachine} from '@xstate/react'
 import {Tab, TabList, TabPanel, TabPanels, Tabs} from '@reach/tabs'
 import {lessonMachine} from 'machines/lesson-machine'
 import {useEggheadPlayer} from 'components/EggheadPlayer'
+import Course from 'components/pages/lessons/course'
 import Tags from 'components/pages/lessons/tags'
 import Transcript from 'components/pages/lessons/transcript'
 import {loadBasicLesson, loadLesson} from 'lib/lessons'
@@ -958,48 +959,3 @@ const LessonPage: React.FC<{initialLesson: VideoResource}> = ({
 }
 
 export default LessonPage
-
-const Course: React.FC<{
-  course: {
-    title: string
-    square_cover_480_url: string
-    slug: string
-    path: string
-  }
-  currentLessonSlug: string
-}> = ({course, currentLessonSlug}) => {
-  return course ? (
-    <div>
-      <div className="flex items-center">
-        <Link href={course.path}>
-          <a className="relative flex-shrink-0 block w-12 h-12 lg:w-20 lg:h-20">
-            <Image
-              src={course.square_cover_480_url}
-              alt={`illustration for ${course.title}`}
-              layout="fill"
-            />
-          </a>
-        </Link>
-        <div className="ml-2 lg:ml-4">
-          <h4 className="mb-px text-xs font-semibold text-gray-700 uppercase dark:text-gray-100">
-            Course
-          </h4>
-          <Link href={course.path}>
-            <a
-              onClick={() => {
-                track(`clicked open course`, {
-                  lesson: currentLessonSlug,
-                })
-              }}
-              className="hover:underline"
-            >
-              <h3 className="font-bold leading-tighter 2xl:text-lg">
-                {course.title}
-              </h3>
-            </a>
-          </Link>
-        </div>
-      </div>
-    </div>
-  ) : null
-}


### PR DESCRIPTION
This PR does 3 things:
- Moves the `Course` component into its own file, the dependencies on that were small and clear cut.
- Moves the `specialLessons` data to its own file so that it can be managed apart from the component.
- Extracts an `Overlays` component which makes a clear delineation of what props are depended on for the various overlays. It handles rendering them, removes the `<OverlayWrapper>` duplication, and isolates several imports that `LessonPage` doesn't need.

Even though it is a pile of props being passed to `<Overlays ...>`, it is helpful to know exactly which ones are depended on.

![lesson](https://media2.giphy.com/media/1fnwSUTsHRyGXEYMos/giphy.gif?cid=d1fd59abox7mk9q04mqp077b5cc7t8oou1y84wb1cp1waxja&rid=giphy.gif&ct=g)