### PR TITLE
Temporary solution for favoring illustrations from Sanity 

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -25,6 +25,9 @@ const courseQuery = groq`
 	"customOgImage": images[label == 'og-image'][0]{
     url
   },
+  "illustration": images[label == 'illustration'][0]{
+    url
+  },
 	'illustrator': collaborators[]->[role == 'illustrator'][0]{
     'name': person->name,
     'image': person->image.url

--- a/src/lib/playlists.ts
+++ b/src/lib/playlists.ts
@@ -290,5 +290,18 @@ export async function loadPlaylist(slug: string, token?: string) {
   const {playlist} = await graphQLClient.request(query, variables)
   const courseMeta = await loadCourseMetadata(playlist.id)
 
+  console.log(courseMeta)
+
+  // This is a temporary hack in order to get an illustration up
+  // for Kent's course: https://egghead.io/courses/up-and-running-with-remix-b82b6bb6
+  // While image uploads are down
+  if (courseMeta?.illustration) {
+    return {
+      ...playlist,
+      ...courseMeta,
+      square_cover_480_url: courseMeta?.illustration.url,
+    }
+  }
+
   return {...playlist, ...courseMeta}
 }


### PR DESCRIPTION
This is being done so that we can add an image to https://egghead.io/courses/up-and-running-with-remix-b82b6bb6 while image uploading is down. 

![bandaid](https://media0.giphy.com/media/ZBnz37p1Ov2gcaME0W/giphy.gif?cid=01d288b0dum8coinssxt3u70udgwym0ixiwnkq62tnzeezbf&rid=giphy.gif&ct=g)