### PR TITLE
update remix page to include custom og-image

### DIFF
--- a/src/components/card/topic-page-horizontal-resource-card.tsx
+++ b/src/components/card/topic-page-horizontal-resource-card.tsx
@@ -12,7 +12,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import {track} from 'utils/analytics'
 import {get, isEmpty} from 'lodash'
-import {CardResource} from 'types'
+import {TopicPageCourse} from 'types'
 import {Textfit} from 'react-textfit'
 import ReactMarkdown from 'react-markdown'
 import cx from 'classnames'
@@ -31,13 +31,8 @@ const Button: React.FC<{
   )
 }
 
-type CardPageCardResource = CardResource & {
-  cta?: string
-  meta?: string
-}
-
 const HorizontalResourceCard: React.FC<{
-  resource: CardPageCardResource
+  resource: TopicPageCourse
   location?: string
   describe?: boolean
   className?: string

--- a/src/components/card/topic-page-horizontal-resource-card.tsx
+++ b/src/components/card/topic-page-horizontal-resource-card.tsx
@@ -12,11 +12,16 @@ import Image from 'next/image'
 import Link from 'next/link'
 import {track} from 'utils/analytics'
 import {get, isEmpty} from 'lodash'
-import {TopicPageCourse} from 'types'
+import {CardResource} from 'types'
 import {Textfit} from 'react-textfit'
 import ReactMarkdown from 'react-markdown'
 import cx from 'classnames'
 import truncate from 'lodash/truncate'
+
+type CardPageCardResource = CardResource & {
+  cta?: string
+  meta?: string
+}
 
 const Button: React.FC<{
   path: string
@@ -32,7 +37,7 @@ const Button: React.FC<{
 }
 
 const HorizontalResourceCard: React.FC<{
-  resource: TopicPageCourse
+  resource: CardPageCardResource
   location?: string
   describe?: boolean
   className?: string

--- a/src/components/search/curated/remix/index.tsx
+++ b/src/components/search/curated/remix/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {NextSeo} from 'next-seo'
 import Image from 'next/image'
 import groq from 'groq'
-import {TopicPageCourse} from 'types'
+import {CardResource} from 'types'
 import {HorizontalResourceCard} from 'components/card/topic-page-horizontal-resource-card'
 
 type TopicPage = {
@@ -21,8 +21,13 @@ enum ResourceOrder {
 }
 
 type TopicPageCourses = {
-  [ResourceOrder.primary]: TopicPageCourse
-  [ResourceOrder.second]: TopicPageCourse
+  [ResourceOrder.primary]: CardPageCardResource
+  [ResourceOrder.second]: CardPageCardResource
+}
+
+type CardPageCardResource = CardResource & {
+  cta?: string
+  meta?: string
 }
 
 const SearchRemix = ({topic}: TopicPage) => {

--- a/src/components/search/curated/remix/index.tsx
+++ b/src/components/search/curated/remix/index.tsx
@@ -2,13 +2,36 @@ import React from 'react'
 import {NextSeo} from 'next-seo'
 import Image from 'next/image'
 import groq from 'groq'
+import {TopicPageCourse} from 'types'
 import {HorizontalResourceCard} from 'components/card/topic-page-horizontal-resource-card'
 
-const SearchRemix = ({topic}: any) => {
+type TopicPage = {
+  topic: {
+    title: string
+    description: string
+    ogImage?: string
+    image: string
+    courses: TopicPageCourses
+  }
+}
+
+enum ResourceOrder {
+  primary = 'primary',
+  second = 'second',
+}
+
+type TopicPageCourses = {
+  [ResourceOrder.primary]: TopicPageCourse
+  [ResourceOrder.second]: TopicPageCourse
+}
+
+const SearchRemix = ({topic}: TopicPage) => {
   const location = 'Remix Topic Page'
   const description = `Build your Developer Portfolio and climb the engineering career ladder with in-depth Remix resources.`
   const title = `In-Depth Remix Resources for ${new Date().getFullYear()}`
-
+  const ogImage = topic.ogImage
+    ? topic.ogImage
+    : 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1654105781/egghead-next-pages/remix/og-image-remix-page.png'
 
   return (
     <div>
@@ -26,7 +49,7 @@ const SearchRemix = ({topic}: any) => {
           site_name: 'egghead',
           images: [
             {
-              url: `https://og-image-react-egghead.vercel.app/topic/remix`,
+              url: ogImage,
             },
           ],
         }}
@@ -53,6 +76,7 @@ export const remixPageQuery = groq`
 *[_type == 'resource' && slug.current == "remix-landing-page"][0]{
   title,
   description,
+  "ogImage": images[label == 'og-image'][0].url,
   "image": images[label == "remix-glowing-logo"][0].url,
   "courses": resources[slug.current == "featured-courses"][0]{
     "primary": resources[slug.current == "primary-course"][0]{

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,16 @@ export type CardResource = Resource & {
   url?: string
 }
 
+export type TopicPageCourse = {
+  byline: string
+  description: string
+  cta: string
+  meta: string
+  title: string
+  image: string
+  path: string
+}
+
 export type LessonResource = Resource & {
   media_url: string
   thumb_url: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,16 +21,6 @@ export type CardResource = Resource & {
   url?: string
 }
 
-export type TopicPageCourse = {
-  byline: string
-  description: string
-  cta: string
-  meta: string
-  title: string
-  image: string
-  path: string
-}
-
 export type LessonResource = Resource & {
   media_url: string
   thumb_url: string


### PR DESCRIPTION
This updates the Remix landing page with a custom og-image. 

Also added the ability to further update the og-image from sanity. Set an image with label `og-image` in sanity to override current image.

Current og image: 
![current og image](https://res.cloudinary.com/dg3gyk0gu/image/upload/v1654105781/egghead-next-pages/remix/og-image-remix-page.png)

![custom og-image](https://media1.giphy.com/media/yLki3B7QNOJkQ/giphy.gif?cid=1927fc1bqv7ca1bryhpegyzit3uv2xy3vt1mkuleenosgvhw&rid=giphy.gif&ct=g)