### PR TITLE
Wire Stripe, CIO, and Mixpanel together for analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "mdast-util-to-markdown": "^0.6.5",
     "mdx-bundler": "^5.2.1",
     "micro": "^9.3.4",
+    "mixpanel": "^0.16.0",
     "mixpanel-browser": "^2.41.0",
     "next": "^12.1.0",
     "next-compose-plugins": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "shortid": "^2.2.16",
     "simplebar-react": "^2.3.5",
     "slugify": "^1.6.0",
-    "stripe": "^8.170.0",
+    "stripe": "^9.8.0",
     "swr": "^0.5.5",
     "tailwindcss": "^3.0.13",
     "tailwindcss-autofill": "^0.1.0",

--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -1,6 +1,15 @@
+import axios from 'axios'
 import {buffer} from 'micro'
+import mixpanel from 'mixpanel-browser'
 import type {NextApiRequest, NextApiResponse} from 'next'
+import {track} from 'utils/analytics'
 import {stripe} from '../../../utils/stripe'
+
+const CIO_BASE_URL = `https://beta-api.customer.io/v1/api/`
+
+const cioAxios = axios.create({
+  baseURL: CIO_BASE_URL,
+})
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || ''
 
@@ -17,8 +26,35 @@ const stripeWebhookHandler = async (
     try {
       event = stripe.webhooks.constructEvent(buf, sig as string, webhookSecret)
 
-      if (event.type === 'checkout.session.completed') {
-        console.log('stripe webhook handler', {event})
+      let stripeCustomerId = event.data.object.customer
+
+      let stripeCustomer = await stripe.customers.retrieve(stripeCustomerId)
+
+      // if(typeof stripeCustomer === Customer)
+      let stripeEmail = stripeCustomer
+
+      await cioAxios
+        .get(`/customers/${stripeEmail}`, {
+          headers: {
+            Authorization: `Bearer ${process.env.CUSTOMER_IO_APPLICATION_API_KEY}`,
+          },
+        })
+        .then(({data}: {data: any}) => data.customer)
+        .catch((error: any) => {
+          console.error(error)
+        })
+
+      if (event.type === 'customer.subscription.created') {
+        // if running sale we would want to check for that but the regular case it's pro or PPP
+        let type = !event.data.object.discount ? 'pro' : 'PPP'
+
+        // how should we grab the current user? is there a pattern for this
+        let mixpanelCustomer = mixpanel.identify()
+
+        mixpanel.people.set({
+          type: type,
+          interval: event.data.object.plan.interval,
+        })
 
         res.status(200).send(`This works!`)
       } else {

--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -103,6 +103,19 @@ const stripeWebhookHandler = async (
         mixpanel.people.set(cioCustomer.id, {
           subscriptionStatus: stripeSubscription.status,
         })
+      } else if (event.type === 'customer.subscription.deleted') {
+        const stripeCustomer = await stripe.customers.retrieve(
+          event.data.object.customer,
+        )
+        const cioCustomer = await getCIO(getCustomerEmail(stripeCustomer))
+
+        mixpanel.track('Subscription Canceled', {
+          distinct_id: cioCustomer.id,
+        })
+
+        mixpanel.people.set(cioCustomer.id, {
+          subscriptionStatus: 'canceled',
+        })
       } else if (event.type === 'customer.subscription.created') {
         // this types it as a Stripe.Subscription instead of any
         const stripeSubscription = await stripe.subscriptions.retrieve(

--- a/yarn.lock
+++ b/yarn.lock
@@ -18267,10 +18267,17 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.10.0, qs@^6.10.1, qs@^6.5.1, qs@^6.6.0:
+qs@^6.10.0, qs@^6.10.1, qs@^6.5.1:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.10.3:
+  version "6.10.5"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.5.tgz#974715920a80ff6a262264acd2c7e6c2a53282b4"
+  integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
   dependencies:
     side-channel "^1.0.4"
 
@@ -20654,13 +20661,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^8.170.0:
-  version "8.170.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-8.170.0.tgz#5b2a84673663bf5029bd8a7c62eda945700d3ecb"
-  integrity sha512-1fM9K+WHCHIGAurcf5UYqqUP7LRR+FBcjx4JA+MoH4YqH6/Bi2Xm50O0lMbf3C/iuUg+tuGlFzeqVBsnqIZuEA==
+stripe@^9.8.0:
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-9.8.0.tgz#c1707dbcacde8f27fe32d2ee9de87844026938c2"
+  integrity sha512-6trh3w4U2wRAvXdh2ilHxky/nWP7aFMGvQX0Ga2eCMAqQwYGOBkBT0ZxT3V+wWruOB1svpuOO6ixpMQif0bnIw==
   dependencies:
     "@types/node" ">=8.1.0"
-    qs "^6.6.0"
+    qs "^6.10.3"
 
 style-loader@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13117,7 +13117,7 @@ https-browserify@1.0.0, https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@5, https-proxy-agent@^5.0.0:
+https-proxy-agent@5, https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
   integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
@@ -16072,6 +16072,13 @@ mixpanel-browser@^2.41.0:
   version "2.41.0"
   resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.41.0.tgz#d49753b4e4a7e6ddd18c126be4a917fff4ce3039"
   integrity sha512-IEuc9cH44hba9a3KEyulXINLn+gpFqluBDo7xiTk1h3j111dmmsctaE6tUzZYxgGLVqeNhTpsccdliOeX24Wlw==
+
+mixpanel@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/mixpanel/-/mixpanel-0.16.0.tgz#83a1a0ee04784cdb89ff4d2b433c9821727efeb7"
+  integrity sha512-+FeBnpO48tChYvw9LDB4YAaW7fTER56ZOQcx69EaC0NpoYC/M50vTrWWjhqtZt/x0V4h4BEml+5GWJjA1djbcA==
+  dependencies:
+    https-proxy-agent "5.0.0"
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
@jbranchaud and I paired on this first commit to start egghead 2022 core metrics. This starts tracking when users sign up for a subscription by updating the user profile in mixpanel. 

One thing I'm unsure about this approach is if we also need to send a `track` call to build reports with it. That will be something to test out.

Specifically, this tracks the `customer.subscription.created` event in Stripe. Subsequent PR's for `customer.subscription.updated` and `customer.subscription.deleted` will be added to track all the data coming from stripe. `customer.subscription` looks like the best set of events to track that has the data that we need.

![Josh and I raising our hands to the roof](https://media.giphy.com/media/IwAZ6dvvvaTtdI8SD5/giphy.gif)