### PR TITLE
test: add react-hooks testing library w/ example

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@tailwindcss/line-clamp": "^0.3.0",
     "@tailwindcss/typography": "^0.5.0",
     "@tanem/react-nprogress": "^3.0.77",
+    "@testing-library/react-hooks": "^8.0.0",
     "@tippyjs/react": "^4.2.5",
     "@types/isomorphic-fetch": "^0.0.35",
     "@types/mixpanel-browser": "^2.35.7",

--- a/src/hooks/__tests__/use-track-component.test.tsx
+++ b/src/hooks/__tests__/use-track-component.test.tsx
@@ -1,0 +1,23 @@
+import {renderHook, act} from '@testing-library/react-hooks'
+import {useTrackComponent} from '../use-track-component'
+import {track} from 'utils/analytics'
+
+jest.mock('utils/analytics')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('it calls track when it first renders', () => {
+  renderHook(useTrackComponent)
+
+  expect(track).toHaveBeenCalledTimes(1)
+})
+
+test('it does not get called on subsequent renders', () => {
+  const {rerender} = renderHook(useTrackComponent)
+
+  rerender()
+
+  expect(track).toHaveBeenCalledTimes(1)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5392,6 +5392,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz#7d0164bffce4647f506039de0a97f6fcbd20f4bf"
+  integrity sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.0.0.tgz#9aeb2264521522ab9b68f519eaf15136148f164a"
@@ -18471,6 +18479,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-boundary@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
This adds `testing-library/react-hooks` for being able to test custom react hooks.

I included a test for a fairly simple hook to demonstrate how to use it.

The motivation for adding this library is that I need it as part of another PR, but wanted to get it introduced in a less noisy context first.

![hooks](https://media2.giphy.com/media/BkVqfREIvC012/giphy.gif?cid=d1fd59aberuc7a7mon2eo9o1j1tl171y1icbgmdzf5tjzsaz&rid=giphy.gif&ct=g)