### PR TITLE
Allow publisher to edit metadata of lessons *while* videos are uploading

### DIFF
--- a/src/components/upload/video-uploader.tsx
+++ b/src/components/upload/video-uploader.tsx
@@ -3,10 +3,11 @@ import ReactS3Uploader from 'react-s3-uploader'
 import {getAuthorizationHeader} from 'utils/auth'
 import uuid from 'shortid'
 import fileExtension from 'file-extension'
+import {DispatchFunction} from 'hooks/use-file-upload-reducer'
 
 const SIGNING_URL = `/api/aws/sign-s3`
 
-const VideoUploader = ({dispatch}: {dispatch: Function}) => {
+const VideoUploader = ({dispatch}: {dispatch: DispatchFunction}) => {
   const uploaderRef = React.useRef(null)
 
   return (

--- a/src/components/upload/video-uploader.tsx
+++ b/src/components/upload/video-uploader.tsx
@@ -6,13 +6,7 @@ import fileExtension from 'file-extension'
 
 const SIGNING_URL = `/api/aws/sign-s3`
 
-const VideoUploader = ({
-  dispatch,
-  setLessonMetadata,
-}: {
-  dispatch: Function
-  setLessonMetadata: Function
-}) => {
+const VideoUploader = ({dispatch}: {dispatch: Function}) => {
   const uploaderRef = React.useRef(null)
 
   return (
@@ -55,13 +49,7 @@ const VideoUploader = ({
       onError={(message) => console.log(message)}
       onFinish={(signResult, file) => {
         const fileUrl = signResult.signedUrl.split('?')[0]
-        setLessonMetadata((prevState: Array<object>) => [
-          ...prevState,
-          {
-            title: file.name,
-            fileMetadata: {fileName: file.name, signedUrl: fileUrl},
-          },
-        ])
+        dispatch({type: 'finalize', file, fileUrl})
       }}
     />
   )

--- a/src/hooks/__tests__/use-file-upload-reducer.test.ts
+++ b/src/hooks/__tests__/use-file-upload-reducer.test.ts
@@ -4,7 +4,7 @@ import useFileUploadReducer from '../use-file-upload-reducer'
 test('it initializes with no files]', () => {
   const {result} = renderHook(() => useFileUploadReducer([]))
 
-  const [state, dispatch] = result.current
+  const [state, _dispatch] = result.current
 
   expect(state).toEqual({files: []})
 })
@@ -12,9 +12,8 @@ test('it initializes with no files]', () => {
 test('it can add a file upload', () => {
   const {result} = renderHook(() => useFileUploadReducer([]))
 
-  let [state, dispatch] = result.current
-
-  expect(state).toEqual({files: []})
+  const initialState = result.current[0]
+  expect(initialState).toEqual({files: []})
 
   const file: File = {name: 'fake-file.txt'} as File
 
@@ -25,10 +24,11 @@ test('it can add a file upload', () => {
   }
 
   act(() => {
+    const dispatch = result.current[1]
     dispatch({type: 'add', fileUpload})
   })
 
-  let stateWithFile = result.current[0]
+  const stateWithFile = result.current[0]
 
   expect(stateWithFile).toEqual({files: [fileUpload]})
 })
@@ -36,9 +36,8 @@ test('it can add a file upload', () => {
 test('it can update progress of a file upload', () => {
   const {result} = renderHook(() => useFileUploadReducer([]))
 
-  let [state, dispatch] = result.current
-
-  expect(state).toEqual({files: []})
+  const initialState = result.current[0]
+  expect(initialState).toEqual({files: []})
 
   const file: File = {name: 'fake-file.txt'} as File
 
@@ -49,6 +48,7 @@ test('it can update progress of a file upload', () => {
   }
 
   act(() => {
+    const dispatch = result.current[1]
     dispatch({type: 'add', fileUpload})
   })
 
@@ -67,14 +67,14 @@ test('it can update progress of a file upload', () => {
 test('it ignores progress for an unknown file', () => {
   const {result} = renderHook(() => useFileUploadReducer([]))
 
-  const [state, dispatch] = result.current
-
-  expect(state).toEqual({files: []})
+  const initialState = result.current[0]
+  expect(initialState).toEqual({files: []})
 
   const unknownFile: File = {name: 'unknown-file.txt'} as File
 
   // calling progress with an unknown file does nothing
   act(() => {
+    const dispatch = result.current[1]
     dispatch({
       type: 'progress',
       file: unknownFile,
@@ -91,9 +91,8 @@ test('it ignores progress for an unknown file', () => {
 test('it can add the signedUrl when finalizing', () => {
   const {result} = renderHook(() => useFileUploadReducer([]))
 
-  let [state, dispatch] = result.current
-
-  expect(state).toEqual({files: []})
+  const initialState = result.current[0]
+  expect(initialState).toEqual({files: []})
 
   const file: File = {name: 'fake-file.txt'} as File
 
@@ -104,6 +103,7 @@ test('it can add the signedUrl when finalizing', () => {
   }
 
   act(() => {
+    const dispatch = result.current[1]
     dispatch({type: 'add', fileUpload})
   })
 

--- a/src/hooks/__tests__/use-file-upload-reducer.test.ts
+++ b/src/hooks/__tests__/use-file-upload-reducer.test.ts
@@ -1,0 +1,127 @@
+import {renderHook, act} from '@testing-library/react-hooks'
+import useFileUploadReducer from '../use-file-upload-reducer'
+
+test('it initializes with no files]', () => {
+  const {result} = renderHook(() => useFileUploadReducer([]))
+
+  const [state, dispatch] = result.current
+
+  expect(state).toEqual({files: []})
+})
+
+test('it can add a file upload', () => {
+  const {result} = renderHook(() => useFileUploadReducer([]))
+
+  let [state, dispatch] = result.current
+
+  expect(state).toEqual({files: []})
+
+  const file: File = {name: 'fake-file.txt'} as File
+
+  const fileUpload = {
+    file,
+    percent: 0,
+    message: 'waiting to upload',
+  }
+
+  act(() => {
+    dispatch({type: 'add', fileUpload})
+  })
+
+  let stateWithFile = result.current[0]
+
+  expect(stateWithFile).toEqual({files: [fileUpload]})
+})
+
+test('it can update progress of a file upload', () => {
+  const {result} = renderHook(() => useFileUploadReducer([]))
+
+  let [state, dispatch] = result.current
+
+  expect(state).toEqual({files: []})
+
+  const file: File = {name: 'fake-file.txt'} as File
+
+  const fileUpload = {
+    file,
+    percent: 0,
+    message: 'waiting to upload',
+  }
+
+  act(() => {
+    dispatch({type: 'add', fileUpload})
+  })
+
+  act(() => {
+    const dispatch = result.current[1]
+    dispatch({type: 'progress', file, percent: 1, message: 'In progress'})
+  })
+
+  const stateWithFileProgress = result.current[0]
+
+  expect(stateWithFileProgress).toEqual({
+    files: [{file, percent: 1, message: 'In progress'}],
+  })
+})
+
+test('it ignores progress for an unknown file', () => {
+  const {result} = renderHook(() => useFileUploadReducer([]))
+
+  const [state, dispatch] = result.current
+
+  expect(state).toEqual({files: []})
+
+  const unknownFile: File = {name: 'unknown-file.txt'} as File
+
+  // calling progress with an unknown file does nothing
+  act(() => {
+    dispatch({
+      type: 'progress',
+      file: unknownFile,
+      percent: 1,
+      message: 'Ignored',
+    })
+  })
+
+  const newState = result.current[0]
+
+  expect(newState).toEqual({files: []})
+})
+
+test('it can add the signedUrl when finalizing', () => {
+  const {result} = renderHook(() => useFileUploadReducer([]))
+
+  let [state, dispatch] = result.current
+
+  expect(state).toEqual({files: []})
+
+  const file: File = {name: 'fake-file.txt'} as File
+
+  const fileUpload = {
+    file,
+    percent: 0,
+    message: 'waiting to upload',
+  }
+
+  act(() => {
+    dispatch({type: 'add', fileUpload})
+  })
+
+  act(() => {
+    const dispatch = result.current[1]
+    dispatch({type: 'progress', file, percent: 1, message: 'In progress'})
+  })
+
+  const fileUrl = 'http://s3:bucket/video.mp4'
+
+  act(() => {
+    const dispatch = result.current[1]
+    dispatch({type: 'finalize', file, fileUrl})
+  })
+
+  const finalizedState = result.current[0]
+
+  expect(finalizedState).toEqual({
+    files: [{file, percent: 1, message: 'In progress', signedUrl: fileUrl}],
+  })
+})

--- a/src/hooks/use-file-upload-reducer.tsx
+++ b/src/hooks/use-file-upload-reducer.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import find from 'lodash/find'
+
+// TODO: add `id` for finding instead of `file`
+type FileUpload = {
+  file: File
+  percent: number
+  message: string
+  signedUrl?: string
+}
+
+type FileUploadReducerState = {files: FileUpload[]}
+
+type Action = {
+  type: 'add' | 'progress' | 'finalize'
+}
+
+type Actions = {
+  add: {
+    fileUpload: FileUpload
+  }
+  progress: FileUpload
+  finalize: {
+    file: FileUpload['file']
+    fileUrl: string
+  }
+}
+
+type ReducerAction = {
+  [ActionType in keyof Actions]: {
+    type: ActionType
+  } & Actions[ActionType]
+}[keyof Actions]
+
+const fileUploadReducer = (
+  state: FileUploadReducerState,
+  action: ReducerAction,
+): FileUploadReducerState => {
+  let upload = undefined
+
+  switch (action.type) {
+    case 'add':
+      return {files: [...state.files, action.fileUpload]}
+    case 'progress':
+      upload = find<FileUpload>(
+        state.files,
+        (fileUpload) => fileUpload.file === action.file,
+      )
+      if (upload) {
+        upload.percent = action.percent
+        upload.message = action.message
+        upload.file = action.file
+      }
+
+      return {files: [...state.files]}
+    case 'finalize':
+      upload = find<FileUpload>(
+        state.files,
+        (fileUpload) => fileUpload.file === action.file,
+      )
+
+      if (upload) {
+        upload.signedUrl = action.fileUrl
+      }
+
+      return {files: [...state.files]}
+    default:
+      throw new Error()
+  }
+}
+
+export type DispatchFunction = (arg0: ReducerAction) => void
+
+const useFileUploadReducer = (
+  files: FileUpload[],
+): [FileUploadReducerState, DispatchFunction] => {
+  const [fileUploadState, dispatch] = React.useReducer(fileUploadReducer, {
+    files: [],
+  })
+
+  return [fileUploadState, dispatch]
+}
+
+export default useFileUploadReducer

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -11,6 +11,7 @@ import axios from 'axios'
 import VideoUploader from 'components/upload/video-uploader'
 import _find from 'lodash/find'
 import {CourseData} from 'types'
+import useFileUploadReducer from 'hooks/use-file-upload-reducer'
 
 type FileUpload = {
   file: File
@@ -90,40 +91,6 @@ export const getServerSideProps: GetServerSideProps = async function ({req}) {
   }
 }
 
-const fileUploadReducer = (state: any, action: any) => {
-  let upload = undefined
-
-  switch (action.type) {
-    case 'add':
-      return {files: [...state.files, action.fileUpload]}
-    case 'progress':
-      upload = find<FileUpload>(
-        state.files,
-        (fileUpload) => fileUpload.file === action.file,
-      )
-      if (upload) {
-        upload.percent = action.percent
-        upload.message = action.message
-        upload.file = action.file
-      }
-
-      return {files: [...state.files]}
-    case 'finalize':
-      upload = find<FileUpload>(
-        state.files,
-        (fileUpload) => fileUpload.file === action.file,
-      )
-
-      if (upload) {
-        upload.signedUrl = action.fileUrl
-      }
-
-      return {files: [...state.files]}
-    default:
-      throw new Error()
-  }
-}
-
 const UploadWrapper = ({
   instructors,
   topics,
@@ -165,9 +132,7 @@ const Upload: React.FC<
   const {instructors, topics, ...formikProps} = props
 
   const {values, setFieldValue, isSubmitting} = formikProps
-  const [fileUploadState, dispatch] = React.useReducer(fileUploadReducer, {
-    files: [],
-  })
+  const [fileUploadState, dispatch] = useFileUploadReducer([])
   const {viewer} = useViewer()
 
   const [courseInstructorId, setCourseInstructorId] = React.useState<string>(

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -337,7 +337,10 @@ const Upload: React.FC<
                   htmlFor={`lessons.${i}.title`}
                   className="block text-sm font-medium text-gray-700"
                 >
-                  Title
+                  Title{' '}
+                  <span className="text-gray-400">
+                    ({lesson.fileMetadata.fileName})
+                  </span>
                 </label>
                 <Field
                   className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -322,37 +322,33 @@ const Upload: React.FC<
               </label>
             </div>
           </div>
-          {fileUploadState.files.map((file) => {
-            if (file.percent < 100) {
-              return (
-                <div>
-                  {file.file.name} - {file.message} - {file.percent}%
-                </div>
-              )
-            } else {
-              return null
-            }
+          {values.lessons.map((lesson, i) => {
+            const uploadState = find(
+              fileUploadState.files,
+              (file) => file.file.name === lesson.fileMetadata.fileName,
+            )
+            return (
+              <div className="space-y-1">
+                <p className="block text-xs font-medium text-gray-600 uppercase">
+                  Lesson ({i + 1}/{values.lessons.length})
+                  {uploadState?.percent && ` - ${uploadState?.percent}%`}
+                </p>
+                <label
+                  htmlFor={`lessons.${i}.title`}
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Title
+                </label>
+                <Field
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  name={`lessons.${i}.title`}
+                />
+                <p className="mt-2 text-center text-sm text-gray-600">
+                  Signed URL: {lesson.fileMetadata.signedUrl || 'processing...'}
+                </p>
+              </div>
+            )
           })}
-          {values.lessons.map((lesson, i) => (
-            <div className="space-y-1">
-              <p className="block text-xs font-medium text-gray-600 uppercase">
-                Lesson ({i + 1}/{values.lessons.length})
-              </p>
-              <label
-                htmlFor={`lessons.${i}.title`}
-                className="block text-sm font-medium text-gray-700"
-              >
-                Title
-              </label>
-              <Field
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                name={`lessons.${i}.title`}
-              />
-              <p className="mt-2 text-center text-sm text-gray-600">
-                {lesson.fileMetadata.signedUrl}
-              </p>
-            </div>
-          ))}
           <div>
             <button
               className={`group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${

--- a/yarn.lock
+++ b/yarn.lock
@@ -5364,16 +5364,16 @@
     react-use "^17.2.4"
 
 "@testing-library/dom@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.0.0.tgz#2bb994393c566aae021db86dd263ba06e8b71b38"
-  integrity sha512-Ym375MTOpfszlagRnTMO+FOfTt6gRrWiDOWmEnWLu9OvwCPOWtK6i5pBHmZ07wUJiQ7wWz0t8+ZBK2wFo2tlew==
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.6"
+    dom-accessibility-api "^0.5.9"
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
@@ -5401,12 +5401,13 @@
     react-error-boundary "^3.1.0"
 
 "@testing-library/react@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.0.0.tgz#9aeb2264521522ab9b68f519eaf15136148f164a"
-  integrity sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
 
 "@tippyjs/react@^4.2.5":
   version "4.2.5"
@@ -5813,6 +5814,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@<18.0.0":
+  version "17.0.17"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
+  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react-dom@^17.0.9":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
@@ -5855,6 +5863,15 @@
   version "17.0.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.5.tgz#3d887570c4489011f75a3fc8f965bf87d09a1bea"
   integrity sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
+  integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -7273,6 +7290,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -10173,6 +10195,11 @@ dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
   integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5364,16 +5364,16 @@
     react-use "^17.2.4"
 
 "@testing-library/dom@^8.0.0":
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
-  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.0.0.tgz#2bb994393c566aae021db86dd263ba06e8b71b38"
+  integrity sha512-Ym375MTOpfszlagRnTMO+FOfTt6gRrWiDOWmEnWLu9OvwCPOWtK6i5pBHmZ07wUJiQ7wWz0t8+ZBK2wFo2tlew==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
+    aria-query "^4.2.2"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
+    dom-accessibility-api "^0.5.6"
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
@@ -5401,13 +5401,12 @@
     react-error-boundary "^3.1.0"
 
 "@testing-library/react@^12.0.0":
-  version "12.1.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
-  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.0.0.tgz#9aeb2264521522ab9b68f519eaf15136148f164a"
+  integrity sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
-    "@types/react-dom" "<18.0.0"
 
 "@tippyjs/react@^4.2.5":
   version "4.2.5"
@@ -5814,13 +5813,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0":
-  version "17.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
-  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
-  dependencies:
-    "@types/react" "^17"
-
 "@types/react-dom@^17.0.9":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
@@ -5863,15 +5855,6 @@
   version "17.0.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.5.tgz#3d887570c4489011f75a3fc8f965bf87d09a1bea"
   integrity sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17":
-  version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
-  integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -7290,11 +7273,6 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
-
-aria-query@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
-  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -10195,11 +10173,6 @@ dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
   integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==
-
-dom-accessibility-api@^0.5.9:
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
-  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2:
   version "0.2.0"


### PR DESCRIPTION
This was one of the **big** takeaways from our walkthrough of the Course Builder with Zac. As soon as he tried uploading a real instructor video, we saw a big flaw in our original spike. The upload takes a while. You need to be able to edit metadata while the upload is being processed or else you are stuck doing nothing for minutes.

This PR does some refactoring and improved typing to facilitate the actual change in the uploader UI. It also adds some tests for the `useFileUploadReducer` hook.

### Refactorings

- First, moves the `fileUploadReducer` and its `useReducer` into a custom `useFileUploadReducer`.
- Replace a lot of the `any`s with comprehensive types that make the reducer easier to work with.
- Add a few `renderHook` tests to exercise core behavior of `useFileUploadReducer`

### Changes

- Make the `VideoUploader` component work completely with just the reducer's `dispatch` function, don't pass in the `setLessonMetadata` (this makes the component a little more predictable to work with)
- Adjust the `useEffect` that syncs the file upload data into the Formik lesson state so that the files are immediately available so that input fields can be edited while file uploads are still being processed.

![uploading](https://media4.giphy.com/media/00ECf99y9SaiHt8gFt/giphy.gif?cid=d1fd59abqw4y5gc9b5rv71qldstedwpjqejw8po1iuiebbzf&rid=giphy.gif&ct=g)
