### PR TITLE
refactor: consolidate cio_id constants to config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
 export const ACCESS_TOKEN_KEY = 'eh_token_2020_11_22'
 export const EGGHEAD_USER_COOKIE_KEY = 'eh_user'
 export const CIO_IDENTIFIER_KEY = 'cio_id'
+export const CIO_CUSTOMER_OBJECT_KEY = 'cio_customer'

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,2 +1,3 @@
 export const ACCESS_TOKEN_KEY = 'eh_token_2020_11_22'
 export const EGGHEAD_USER_COOKIE_KEY = 'eh_user'
+export const CIO_IDENTIFIER_KEY = 'cio_id'

--- a/src/hooks/use-cio.tsx
+++ b/src/hooks/use-cio.tsx
@@ -3,8 +3,7 @@ import axios from 'axios'
 import queryString from 'query-string'
 import {get, isEmpty} from 'lodash'
 import cookie from 'utils/cookies'
-
-export const CIO_KEY = 'cio_id'
+import {CIO_IDENTIFIER_KEY} from 'config'
 
 export const cioIdentify = async (id: string, options?: any) => {
   if (id) {
@@ -30,13 +29,13 @@ export const CioProvider: React.FunctionComponent = ({children}) => {
   React.useEffect(() => {
     if (typeof window !== 'undefined') {
       const queryParams = queryString.parse(window.location.search)
-      const cioSubscriberId = get(queryParams, CIO_KEY)
-      if (cioSubscriberId) delete queryParams[CIO_KEY]
+      const cioSubscriberId = get(queryParams, CIO_IDENTIFIER_KEY)
+      if (cioSubscriberId) delete queryParams[CIO_IDENTIFIER_KEY]
 
       const updatedParamns = queryString.stringify(queryParams)
 
       if (!isEmpty(cioSubscriberId)) {
-        cookie.set(CIO_KEY, cioSubscriberId)
+        cookie.set(CIO_IDENTIFIER_KEY, cioSubscriberId)
         setTimeout(() => {
           window.history.replaceState(
             null,

--- a/src/pages/api/cio/identify/[id].ts
+++ b/src/pages/api/cio/identify/[id].ts
@@ -1,7 +1,7 @@
 import {NextApiRequest, NextApiResponse} from 'next'
 import getTracer from 'utils/honeycomb-tracer'
 import {setupHttpTracing} from 'utils/tracing-js/dist/src'
-import {CIO_KEY} from 'hooks/use-cio'
+import {CIO_IDENTIFIER_KEY} from 'config'
 import {sleep} from '../../../../utils/sleep'
 
 const serverCookie = require('cookie')
@@ -37,7 +37,7 @@ const cioIdentify = async (req: NextApiRequest, res: NextApiResponse) => {
         {headers},
       )
 
-      const cioCookie = serverCookie.serialize(CIO_KEY, id, {
+      const cioCookie = serverCookie.serialize(CIO_IDENTIFIER_KEY, id, {
         secure: process.env.NODE_ENV === 'production',
         path: '/',
         maxAge: 31556952,

--- a/src/pages/api/topic.tsx
+++ b/src/pages/api/topic.tsx
@@ -2,19 +2,12 @@ import {NextApiRequest, NextApiResponse} from 'next'
 import {ACCESS_TOKEN_KEY} from 'utils/auth'
 import getTracer from 'utils/honeycomb-tracer'
 import {setupHttpTracing} from 'utils/tracing-js/dist/src/index'
-import {CIO_KEY} from '../../hooks/use-cio'
+import {getTokenFromCookieHeaders} from 'utils/parse-server-cookie'
 
 const serverCookie = require('cookie')
 const axios = require('axios')
 
 const tracer = getTracer('topic-api')
-
-function getTokenFromCookieHeaders(serverCookies: string) {
-  const parsedCookie = serverCookie.parse(serverCookies)
-  const eggheadToken = parsedCookie[ACCESS_TOKEN_KEY] || ''
-  const cioId = parsedCookie[CIO_KEY] || parsedCookie['_cioid'] || ''
-  return {cioId, eggheadToken, loginRequired: eggheadToken.length <= 0}
-}
 
 const CIO_BASE_URL = `https://beta-api.customer.io/v1/api/`
 

--- a/src/pages/signup/[topic].tsx
+++ b/src/pages/signup/[topic].tsx
@@ -8,6 +8,7 @@ import {setupHttpTracing} from '../../utils/tracing-js/dist/src'
 import getTracer from '../../utils/honeycomb-tracer'
 import {loadCio} from '../../lib/customer'
 import serverCookie from 'cookie'
+import {CIO_IDENTIFIER_KEY} from 'config'
 
 const tracer = getTracer('signup-topic-page')
 
@@ -47,8 +48,9 @@ export const getServerSideProps: GetServerSideProps = async function ({
   try {
     if (req.cookies.customer) {
       customer = JSON.parse(req.cookies.customer)
-    } else if (query.cio_id || req.cookies.cio_id) {
-      const cio_id = query.cio_id ?? req.cookies.cio_id
+    } else if (query[CIO_IDENTIFIER_KEY] || req.cookies[CIO_IDENTIFIER_KEY]) {
+      const cio_id =
+        query[CIO_IDENTIFIER_KEY] ?? req.cookies[CIO_IDENTIFIER_KEY]
       customer = await loadCio(cio_id as string, req.cookies.customer)
     }
   } catch (e) {

--- a/src/server/customer-io-cookies.ts
+++ b/src/server/customer-io-cookies.ts
@@ -1,7 +1,8 @@
 import {NextResponse} from 'next/server'
-import {CIO_IDENTIFIER_KEY as CIO_COOKIE_KEY} from '../config'
-
-export const CIO_CUSTOMER_OBJECT_KEY = 'cio_customer'
+import {
+  CIO_IDENTIFIER_KEY as CIO_COOKIE_KEY,
+  CIO_CUSTOMER_OBJECT_KEY,
+} from '../config'
 
 export function clearCustomerCookie(res: NextResponse) {
   res.cookies.delete(CIO_COOKIE_KEY, {

--- a/src/server/customer-io-cookies.ts
+++ b/src/server/customer-io-cookies.ts
@@ -1,6 +1,6 @@
 import {NextResponse} from 'next/server'
+import {CIO_IDENTIFIER_KEY as CIO_COOKIE_KEY} from '../config'
 
-export const CIO_COOKIE_KEY = 'cio_id'
 export const CIO_CUSTOMER_OBJECT_KEY = 'cio_customer'
 
 export function clearCustomerCookie(res: NextResponse) {

--- a/src/server/process-customer-cookies.ts
+++ b/src/server/process-customer-cookies.ts
@@ -2,12 +2,12 @@ import {NextRequest, NextResponse} from 'next/server'
 import {ACCESS_TOKEN_KEY, EGGHEAD_USER_COOKIE_KEY} from '../config'
 import {loadUser} from '../lib/current-user'
 import {
-  CIO_COOKIE_KEY,
   CIO_CUSTOMER_OBJECT_KEY,
   cioCustomerIsMember,
   clearCustomerCookie,
   setCustomerCookie,
 } from './customer-io-cookies'
+import {CIO_IDENTIFIER_KEY as CIO_COOKIE_KEY} from '../config'
 import {loadCio} from '../lib/customer'
 import {clearUserCookie, setUserCookie} from './egghead-user-cookies'
 

--- a/src/server/process-customer-cookies.ts
+++ b/src/server/process-customer-cookies.ts
@@ -2,12 +2,14 @@ import {NextRequest, NextResponse} from 'next/server'
 import {ACCESS_TOKEN_KEY, EGGHEAD_USER_COOKIE_KEY} from '../config'
 import {loadUser} from '../lib/current-user'
 import {
-  CIO_CUSTOMER_OBJECT_KEY,
   cioCustomerIsMember,
   clearCustomerCookie,
   setCustomerCookie,
 } from './customer-io-cookies'
-import {CIO_IDENTIFIER_KEY as CIO_COOKIE_KEY} from '../config'
+import {
+  CIO_IDENTIFIER_KEY as CIO_COOKIE_KEY,
+  CIO_CUSTOMER_OBJECT_KEY,
+} from '../config'
 import {loadCio} from '../lib/customer'
 import {clearUserCookie, setUserCookie} from './egghead-user-cookies'
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -5,10 +5,10 @@ import get from 'lodash/get'
 import cookie from './cookies'
 import * as serverCookie from 'cookie'
 import getAccessTokenFromCookie from './get-access-token-from-cookie'
-import {CIO_KEY} from '../hooks/use-cio'
 import {
   ACCESS_TOKEN_KEY as CONFIG_ACCESS_TOKEN,
   EGGHEAD_USER_COOKIE_KEY,
+  CIO_IDENTIFIER_KEY,
 } from '../config'
 
 const http = axios.create()
@@ -93,7 +93,7 @@ export default class Auth {
         localStorage.setItem(VIEWING_AS_USER_KEY, get(user, 'email'))
 
         if (user.contact_id) {
-          cookie.set(CIO_KEY, user.contact_id)
+          cookie.set(CIO_IDENTIFIER_KEY, user.contact_id)
         }
 
         cookie.set(ACCESS_TOKEN_KEY, data.access_token.token, {
@@ -247,7 +247,7 @@ export default class Auth {
           }
           if (data) identify(data)
           if (data.contact_id) {
-            cookie.set(CIO_KEY, data.contact_id)
+            cookie.set(CIO_IDENTIFIER_KEY, data.contact_id)
           }
           localStorage.setItem(USER_KEY, JSON.stringify(data))
           cookie.set(EGGHEAD_USER_COOKIE_KEY, JSON.stringify(data), {

--- a/src/utils/get-cio-id-from-cookie.ts
+++ b/src/utils/get-cio-id-from-cookie.ts
@@ -1,13 +1,13 @@
 import cookies from './cookies'
-import {CIO_KEY} from '../hooks/use-cio'
+import {CIO_IDENTIFIER_KEY} from 'config'
 
 const getCioIdFromCookie = () => {
-  if (!CIO_KEY) return false
-  let token = cookies.get(CIO_KEY) || cookies.get('_cioid')
+  if (!CIO_IDENTIFIER_KEY) return false
+  let token = cookies.get(CIO_IDENTIFIER_KEY) || cookies.get('_cioid')
   if (token && token !== 'undefined') {
     return token
   } else if (typeof localStorage !== 'undefined') {
-    return localStorage.getItem(CIO_KEY) ?? false
+    return localStorage.getItem(CIO_IDENTIFIER_KEY) ?? false
   }
 
   return false

--- a/src/utils/parse-server-cookie.ts
+++ b/src/utils/parse-server-cookie.ts
@@ -1,9 +1,10 @@
 import {ACCESS_TOKEN_KEY} from './auth'
 import serverCookie from 'cookie'
+import {CIO_IDENTIFIER_KEY} from 'config'
 
 export function getTokenFromCookieHeaders(serverCookies: string) {
   const parsedCookie = serverCookie.parse(serverCookies)
   const eggheadToken = parsedCookie[ACCESS_TOKEN_KEY] || ''
-  const cioId = parsedCookie['_cioid'] || parsedCookie['cio_id'] || ''
+  const cioId = parsedCookie['_cioid'] || parsedCookie[CIO_IDENTIFIER_KEY] || ''
   return {cioId, eggheadToken, loginRequired: eggheadToken.length <= 0}
 }


### PR DESCRIPTION
We had `cio_id` floating around as a magic string in several modules. This consolidates it to a single value that can be imported from `config`.

![cio](https://media1.giphy.com/media/nlJgJxq8kn2mL0frKt/giphy.gif?cid=d1fd59ab8fmxfzmszhvp4cogiynwhn0630szfv3v2d890htx&rid=giphy.gif&ct=g)