### PR TITLE
fix: move call for gift after check for user token

### DIFF
--- a/src/pages/gifts/claim/[guid].tsx
+++ b/src/pages/gifts/claim/[guid].tsx
@@ -16,8 +16,6 @@ export const getServerSideProps: GetServerSideProps = async function ({
   const {eggheadToken} = getTokenFromCookieHeaders(req.headers.cookie as string)
   const {guid} = query
 
-  const gift = await getGift(guid as string, eggheadToken)
-
   if (!eggheadToken) {
     return {
       props: {
@@ -28,6 +26,8 @@ export const getServerSideProps: GetServerSideProps = async function ({
       },
     }
   }
+
+  const gift = await getGift(guid as string, eggheadToken)
 
   if (gift.claimed) {
     return {


### PR DESCRIPTION
Don't make a call to rails if no token is present.

![bird pushes other bird off branch](https://media.giphy.com/media/VhdO3vOqqJ0PJQt5OA/giphy-downsized-large.gif)