### PR TITLE
fix: turn CDN off for Sanity client w/ token

### DIFF
--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -64,7 +64,7 @@ type SanityCourse = {
 const sanityClient = client({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
-  useCdn: true,
+  useCdn: false,
   token: process.env.SANITY_EDITOR_TOKEN,
 })
 


### PR DESCRIPTION
I've been seeing a warning in my development logs that you can't set
`useCdn` to true while also using a `token`. I confirmed this in the
docs (https://www.sanity.io/help/js-client-cdn-configuration) as well.
Since this instace of the Sanity Client always has a token, we should
set `useCdn` to false. As the warning put it, we don't want to cache
private data in the CDN.

![cache](https://media2.giphy.com/media/h4aUqWa5RZVVpBuZCJ/giphy.gif?cid=d1fd59ab7gwp6g4g145dahpcx4d52po6jq138m0xhlk8edli&rid=giphy.gif&ct=g)
