### PR TITLE
fix: update to new style of Next.js redirects

### DIFF
--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -80,10 +80,12 @@ export const getServerSideProps: GetServerSideProps = async function ({
       params && (await loadBasicLesson(params.slug as string))
 
     if (initialLesson && initialLesson?.slug !== params?.slug) {
-      res.setHeader('Location', initialLesson.path)
-      res.statusCode = 302
-      res.end()
-      return {props: {}}
+      return {
+        redirect: {
+          destination: initialLesson.path,
+          permanent: true,
+        },
+      }
     } else {
       res.setHeader('Cache-Control', 's-maxage=1, stale-while-revalidate')
       return {
@@ -94,10 +96,12 @@ export const getServerSideProps: GetServerSideProps = async function ({
     }
   } catch (e) {
     console.error(e)
-    res.setHeader('Location', '/')
-    res.statusCode = 307
-    res.end()
-    return {props: {}}
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    }
   }
 }
 


### PR DESCRIPTION
In this other PR
(https://github.com/eggheadio/egghead-next/pull/1137/files) we had to
update some redirects from an old style to one that is now supported by
Next.js 12.2
(https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#redirect).
This commit does the same for a couple remaining redirects in the
`lessons/[slug].tsx` page component.

![redirect](https://media2.giphy.com/media/oYyNedGfw8CTq00Whz/giphy.gif?cid=d1fd59abq649luo59z1frmpoejpzrzjtxklhfdb4zpecgz0n&rid=giphy.gif&ct=g)
