### PR TITLE
Add state field to course and resource in sanity

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -44,7 +44,7 @@ export default {
             value: 'contentReview',
           },
           {
-            title: 'pre-release',
+            title: 'pre release',
             value: 'preRelease',
           },
           {

--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -22,6 +22,39 @@ export default {
       },
     },
     {
+      name: 'state',
+      title: 'State',
+      type: 'string',
+      options: {
+        list: [
+          {
+            title: 'new',
+            value: 'new',
+          },
+          {
+            title: 'drafting',
+            value: 'drafting',
+          },
+          {
+            title: 'published',
+            value: 'published',
+          },
+          {
+            title: 'content review',
+            value: 'contentReview',
+          },
+          {
+            title: 'pre-release',
+            value: 'preRelease',
+          },
+          {
+            title: 'retired',
+            value: 'retired',
+          },
+        ],
+      },
+    },
+    {
       name: 'description',
       type: 'markdown',
       title: 'Description',

--- a/studio/schemas/documents/resource.js
+++ b/studio/schemas/documents/resource.js
@@ -126,6 +126,40 @@ export default {
       },
     },
     {
+      name: 'state',
+      title: 'State',
+      type: 'string',
+      hidden: ({document}) => document.type !== 'course',
+      options: {
+        list: [
+          {
+            title: 'new',
+            value: 'new',
+          },
+          {
+            title: 'drafting',
+            value: 'drafting',
+          },
+          {
+            title: 'published',
+            value: 'published',
+          },
+          {
+            title: 'content review',
+            value: 'contentReview',
+          },
+          {
+            title: 'pre-release',
+            value: 'preRelease',
+          },
+          {
+            title: 'retired',
+            value: 'retired',
+          },
+        ],
+      },
+    },
+    {
       name: 'challengeRating',
       description: 'How difficult is this?',
       title: 'Challenge Rating',


### PR DESCRIPTION
This adds a single select field to both of these document types in Sanity. 

Course isn't in use yet but since it will be soon we've added it to its schema. 

![insane](https://media0.giphy.com/media/CKrlUi30dn44w/giphy.gif?cid=01d288b0rk364c7svh99uva02xa18vxlj3jasjywkcqvkow5&rid=giphy.gif&ct=g)