### PR TITLE
refactor: move production process state to object

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -22,37 +22,9 @@ export default {
       },
     },
     {
-      name: 'state',
-      title: 'State',
-      type: 'string',
-      options: {
-        list: [
-          {
-            title: 'new',
-            value: 'new',
-          },
-          {
-            title: 'drafting',
-            value: 'drafting',
-          },
-          {
-            title: 'published',
-            value: 'published',
-          },
-          {
-            title: 'content review',
-            value: 'contentReview',
-          },
-          {
-            title: 'pre release',
-            value: 'preRelease',
-          },
-          {
-            title: 'retired',
-            value: 'retired',
-          },
-        ],
-      },
+      name: 'productionProcessState',
+      title: 'Production Process State',
+      type: 'productionProcessState',
     },
     {
       name: 'description',

--- a/studio/schemas/documents/resource.js
+++ b/studio/schemas/documents/resource.js
@@ -126,38 +126,10 @@ export default {
       },
     },
     {
-      name: 'state',
-      title: 'State',
-      type: 'string',
+      name: 'productionProcessState',
+      title: 'Production Process State',
+      type: 'productionProcessState',
       hidden: ({document}) => document.type !== 'course',
-      options: {
-        list: [
-          {
-            title: 'new',
-            value: 'new',
-          },
-          {
-            title: 'drafting',
-            value: 'drafting',
-          },
-          {
-            title: 'published',
-            value: 'published',
-          },
-          {
-            title: 'content review',
-            value: 'contentReview',
-          },
-          {
-            title: 'pre-release',
-            value: 'preRelease',
-          },
-          {
-            title: 'retired',
-            value: 'retired',
-          },
-        ],
-      },
     },
     {
       name: 'challengeRating',

--- a/studio/schemas/objects/production-process-state.js
+++ b/studio/schemas/objects/production-process-state.js
@@ -1,0 +1,33 @@
+export default {
+  name: 'productionProcessState',
+  title: 'Production Process State',
+  type: 'string',
+  options: {
+    list: [
+      {
+        title: 'new',
+        value: 'new',
+      },
+      {
+        title: 'drafting',
+        value: 'drafting',
+      },
+      {
+        title: 'published',
+        value: 'published',
+      },
+      {
+        title: 'content review',
+        value: 'contentReview',
+      },
+      {
+        title: 'pre release',
+        value: 'preRelease',
+      },
+      {
+        title: 'retired',
+        value: 'retired',
+      },
+    ],
+  },
+}

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -32,6 +32,7 @@ import excerptPortableText from './objects/excerpt-portable-text'
 import bodyPortableText from './objects/body-portable-text'
 import mainImage from './objects/main-image'
 import seo from './objects/seo'
+import productionProcessState from './objects/production-process-state'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -47,6 +48,7 @@ export default createSchema({
     link,
     cta,
     ctaPlug,
+    productionProcessState,
     // The following are document types which will appear
     // in the studio.
     resource,


### PR DESCRIPTION
Use an exportable schema object to define the Production Process states
in a single place.

Also, use the name of 'Production Process State' instead of just 'State'
which is ambiguous.

Renames are much more involved when there is live data that needs to be migrated to the renaming field, so I'm trying to get this change in before we've started to use it.

More details: https://roamresearch.com/#/app/egghead/page/RgkwDbkAz

## Next Steps

- Write a migration to backfill these states from the egghead-rails DB (https://github.com/eggheadio/egghead-rails/pull/5001)

![production process](https://media3.giphy.com/media/OeChpMekaySHBPITJ8/giphy.gif?cid=d1fd59abh4ycgitnkw7xx6xaniuie6razzw5dx8arsyll5qk&rid=giphy.gif&ct=g)