### PR TITLE
Add default value for `productionProcessState` on Courses

### DIFF
--- a/studio/schemas/objects/production-process-state.js
+++ b/studio/schemas/objects/production-process-state.js
@@ -3,6 +3,7 @@ export default {
   title: 'Production Process State',
   type: 'string',
   initialValue: 'new',
+  validation: (Rule) => Rule.required(),
   options: {
     list: [
       {

--- a/studio/schemas/objects/production-process-state.js
+++ b/studio/schemas/objects/production-process-state.js
@@ -2,6 +2,7 @@ export default {
   name: 'productionProcessState',
   title: 'Production Process State',
   type: 'string',
+  initialValue: 'new',
   options: {
     list: [
       {


### PR DESCRIPTION
- feat: default value of new for prodProcessState

Using the `initialValue` option to set a default value for new documents
using the `productionProcessState` field.
https://www.sanity.io/docs/initial-value-templates#f21ca49a29ae

The default value for any new Course/Resource should be `new`.
https://roamresearch.com/#/app/egghead/page/-lU988n8C

- feat: require prodProcessState to be set

Use a Sanity validation to require that the `productionProcessState`
field is set to something besides a blank value.
https://www.sanity.io/docs/validation

---

At the moment, I'm putting a `NO MERGE` tag on this. Until I've had a chance to run the Playlist State Migration against production, I don't want this validation enforced. Otherwise it would prevent save on a bunch of courses.

- [x] Playlist state migration has been run against production

---

![default](https://media1.giphy.com/media/3oEdv3yyWiMAtYlopq/giphy.gif?cid=d1fd59ablhys3xhutb2iv77k6nq22czrmvdpd69443wvra7m&rid=giphy.gif&ct=g)
