### PR TITLE
fix: add consistent style to course callout on blog pages

### DIFF
--- a/src/components/mdx/course.tsx
+++ b/src/components/mdx/course.tsx
@@ -12,11 +12,13 @@ type CourseWidgetProps = {
 const CourseWidget: FunctionComponent<CourseWidgetProps> = ({slug}) => {
   const {data} = useSWR(slug, loadCourse)
 
+  console.log(data)
+
   return data?.path ? (
-    <section>
+    <section className="bg-gray-100 dark:bg-gray-800 bg-opacity-60 rounded p-8 mt-4">
       <Link href={data.path}>
         <a
-          className="flex items-center space-x-3"
+          className="flex sm:flex-row flex-col items-center justify-center sm:space-x-3"
           onClick={() => {
             track(`clicked course widget`, {
               slug: data.slug,
@@ -25,15 +27,26 @@ const CourseWidget: FunctionComponent<CourseWidgetProps> = ({slug}) => {
         >
           <img
             alt="illustration"
-            className="w-32"
+            className="w-40 sm:mr-4"
             src={data.square_cover_480_url}
           />
-          <div>
-            <p className="text-lg">{data.title}</p>
+          <div className="flex flex-col mt-4 items-center text-center sm:items-start sm:justify-start sm:text-left">
+            <span className="uppercase font-medium sm:text-[0.65rem] text-[0.55rem] pb-1 text-gray-700 dark:text-indigo-100 opacity-60">
+              Course
+            </span>
+            <p className="text-lg font-bold">{data.title}</p>
+            <p className="mt-4">{data.summary}</p>
+            <div className="flex flex-row gap-2 my-4">
+              <img
+                className="w-7 h-7 overflow-hidden flex-shrink-0 rounded-full lg:w-7 lg:h-7"
+                alt={`${data.instructor.full_name}  profile picture`}
+                src={data.instructor.avatar_url}
+              />
+              <p>{data.instructor.full_name}</p>
+            </div>
           </div>
         </a>
       </Link>{' '}
-      by {data.instructor.full_name}
     </section>
   ) : null
 }

--- a/src/components/mdx/course.tsx
+++ b/src/components/mdx/course.tsx
@@ -12,8 +12,6 @@ type CourseWidgetProps = {
 const CourseWidget: FunctionComponent<CourseWidgetProps> = ({slug}) => {
   const {data} = useSWR(slug, loadCourse)
 
-  console.log(data)
-
   return data?.path ? (
     <section className="bg-gray-100 dark:bg-gray-800 bg-opacity-60 rounded p-8 mt-4">
       <Link href={data.path}>


### PR DESCRIPTION
I was looking at our SEO and noticed our top blog post had a course CTA component on it. It looked like it could use some clean up so I added some styles to match similar course CTAs.

Primarily for: https://egghead.io/blog/intercepting-network-requests-in-cypress

![painting](https://media4.giphy.com/media/4y6DqPvlICp5S/giphy.gif?cid=1927fc1bglzjgf8qhlwk3hfcopjdzx67mzc4w8msgy7f4n6q&rid=giphy.gif&ct=g)

## Before
![course call out before](https://user-images.githubusercontent.com/6188161/179829665-d8843f66-8553-400d-a074-e3fe06368eb9.png)

## After
![course call out darkmode](https://user-images.githubusercontent.com/6188161/179829697-701dac17-c166-4757-9855-3f86cb8a33fa.png)
![course call out light mode](https://user-images.githubusercontent.com/6188161/179829701-8c1eaa5f-f9b1-4026-bc94-7f54bc3eee68.png)
![course call out mobile](https://user-images.githubusercontent.com/6188161/179829713-3fa52326-a2db-45f2-a689-21501d2bda0f.png)

