### PR TITLE
feat: add Sanity Studio environment switcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "eslint-plugin-testing-library": "^4.11.0",
     "globby": "^12.0.1",
+    "handlebars": "^4.7.7",
     "husky": "^7.0.1",
     "istanbul-lib-coverage": "^3.0.0",
     "jest": "^27.0.6",

--- a/studio/sanity.json.erb
+++ b/studio/sanity.json.erb
@@ -1,0 +1,46 @@
+{
+  "root": true,
+  "project": {
+    "name": "<%= @project_name %>"
+  },
+  "api": {
+    "projectId": "<%= @project_id %>",
+    "dataset": "<%= @dataset %>"
+  },
+  "plugins": [
+    "@sanity/base",
+    "@sanity/components",
+    "@sanity/default-layout",
+    "@sanity/default-login",
+    "@sanity/desk-tool",
+    "@sanity/vision",
+    "@sanity/google-maps-input",
+    "markdown",
+    "graph-view",
+    "content-calendar",
+    "nyancat-spinner",
+    "asset-source-cloudinary",
+    "@sanity/code-input",
+    "autocomplete-tags",
+    "@sanity/production-preview"
+  ],
+  "env": {
+    "development": {
+      "plugins": ["json-to-docs"]
+    }
+  },
+  "parts": [
+    {
+      "name": "part:@sanity/base/schema",
+      "path": "./schemas/schema"
+    },
+    {
+      "name": "part:@sanity/desk-tool/structure",
+      "path": "./deskStructure.js"
+    },
+    {
+      "implements": "part:@sanity/production-preview/resolve-production-url",
+      "path": "./resolveProductionUrl.js"
+    }
+  ]
+}

--- a/studio/sanity.json.template
+++ b/studio/sanity.json.template
@@ -1,11 +1,11 @@
 {
   "root": true,
   "project": {
-    "name": "<%= @project_name %>"
+    "name": "{{project_name}}"
   },
   "api": {
-    "projectId": "<%= @project_id %>",
-    "dataset": "<%= @dataset %>"
+    "projectId": "{{project_id}}",
+    "dataset": "{{dataset}}"
   },
   "plugins": [
     "@sanity/base",

--- a/studio/set_sanity_env
+++ b/studio/set_sanity_env
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+
+# Updates the `sanity.json` file with environment-specific settings.
+#
+# To switch to the `staging` environment for the studio, run:
+#
+# ```
+# $ SANITY_ENV=staging ./set_sanity_env
+# ```
+#
+# To switch to the `production` environment for the studio, run:
+#
+# ```
+# $ SANITY_ENV=production ./set_sanity_env
+# ```
+#
+# based on https://www.stuartellis.name/articles/erb/
+
+require 'erb'
+
+sanity_env = ENV['SANITY_ENV']
+
+unless ['production', 'staging'].include?(sanity_env)
+  puts "SANITY_ENV must be set to either `production` or `staging`."
+  puts "e.g. `$ SANITY_ENV=staging ./set_sanity_env`"
+  exit 1
+end
+
+# generate sanity.json file based on specified environment
+class SanityJson
+  include ERB::Util
+  attr_accessor :project_name, :project_id, :dataset
+
+  SANITY_ENV_VALUES = {
+    staging: {
+      project_name: "egghead-next-test",
+      project_id: "junsargs",
+      dataset: "production"
+    },
+    production: {
+      project_name: "egghead-next",
+      project_id: "sb1i5dlc",
+      dataset: "production"
+    }
+  }
+
+  def initialize(environment)
+    template_values = SANITY_ENV_VALUES[environment.to_sym]
+
+    @project_name = template_values[:project_name]
+    @project_id = template_values[:project_id]
+    @dataset = template_values[:dataset]
+    @environment = environment
+
+    unless @project_name && @project_id && @dataset
+      raise StandardError, "One of the template values wasn't set."
+    end
+  end
+
+  def render()
+    ERB.new(template).result(binding)
+  end
+
+  def save(file)
+    File.open(file, "w+") do |f|
+      f.write(render)
+    end
+  end
+
+  private
+
+  def template
+    File.read('./sanity.json.erb')
+  end
+end
+
+sanity_json = SanityJson.new(sanity_env)
+sanity_json.save('./sanity.json')

--- a/studio/set_sanity_env
+++ b/studio/set_sanity_env
@@ -1,78 +1,54 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env node
 
-# Updates the `sanity.json` file with environment-specific settings.
-#
-# To switch to the `staging` environment for the studio, run:
-#
-# ```
-# $ SANITY_ENV=staging ./set_sanity_env
-# ```
-#
-# To switch to the `production` environment for the studio, run:
-#
-# ```
-# $ SANITY_ENV=production ./set_sanity_env
-# ```
-#
-# based on https://www.stuartellis.name/articles/erb/
+const fs = require('fs')
+const path = require('path')
+const handlebars = require('handlebars')
 
-require 'erb'
+/*
+ * Determine env-specific data
+ */
 
-sanity_env = ENV['SANITY_ENV']
+const sanityEnvironment = process.env.SANITY_ENV
 
-unless ['production', 'staging'].include?(sanity_env)
-  puts "SANITY_ENV must be set to either `production` or `staging`."
-  puts "e.g. `$ SANITY_ENV=staging ./set_sanity_env`"
-  exit 1
-end
+if (!['production', 'staging'].includes(sanityEnvironment)) {
+  const message = `
+SANITY_ENV must be set to either 'production' or 'staging'.
+e.g. \`$ SANITY_ENV=staging ./set_sanity_env\``
 
-# generate sanity.json file based on specified environment
-class SanityJson
-  include ERB::Util
-  attr_accessor :project_name, :project_id, :dataset
+  console.log(message)
+  process.exit(1)
+}
 
-  SANITY_ENV_VALUES = {
-    staging: {
-      project_name: "egghead-next-test",
-      project_id: "junsargs",
-      dataset: "production"
-    },
-    production: {
-      project_name: "egghead-next",
-      project_id: "sb1i5dlc",
-      dataset: "production"
-    }
-  }
+const SANITY_ENV_VALUES = {
+  staging: {
+    project_name: 'egghead-next-test',
+    project_id: 'junsargs',
+    dataset: 'production',
+  },
+  production: {
+    project_name: 'egghead-next',
+    project_id: 'sb1i5dlc',
+    dataset: 'production',
+  },
+}
 
-  def initialize(environment)
-    template_values = SANITY_ENV_VALUES[environment.to_sym]
+const envSpecificData = SANITY_ENV_VALUES[sanityEnvironment]
 
-    @project_name = template_values[:project_name]
-    @project_id = template_values[:project_id]
-    @dataset = template_values[:dataset]
-    @environment = environment
+/*
+ * Read in and apply the template
+ */
 
-    unless @project_name && @project_id && @dataset
-      raise StandardError, "One of the template values wasn't set."
-    end
-  end
+const templateFilename = path.join(__dirname, 'sanity.json.template')
 
-  def render()
-    ERB.new(template).result(binding)
-  end
+const template = fs.readFileSync(templateFilename, 'utf8')
 
-  def save(file)
-    File.open(file, "w+") do |f|
-      f.write(render)
-    end
-  end
+const templateFunc = handlebars.compile(template)
+const templateObject = templateFunc(envSpecificData)
 
-  private
+const destinationFilename = path.join(__dirname, 'sanity.json')
 
-  def template
-    File.read('./sanity.json.erb')
-  end
-end
+fs.writeFileSync(destinationFilename, templateObject)
 
-sanity_json = SanityJson.new(sanity_env)
-sanity_json.save('./sanity.json')
+const successMessage = `
+The \`sanity.json\` file has been switched to the ${sanityEnvironment} environment.`
+console.log(successMessage)


### PR DESCRIPTION
_Update: this now uses Node and handlebars instead of Ruby and ERB._

The way that we separate both data and schema between staging and
production Sanity is to use separate projects. This is a solution that
we sort of hacked together because there isn't an official way to get
this kind of separation. Because of that, it is tedious to swap out the
staging and production config values when wanting to switch between
those two projects. This script introduces an ERB template that makes it
is to toggle between the environments by running a single command.

The way it works is, based on the environment you provide (either `staging` or `production`), it will generate and overwrite the `sanity.json` file using the ERB template and the environment-specific values.

This is a spike. Ideally we'd find a way to do this in JS/TS. I'm not
sure what the ERB equivalent is in the Node ecosystem.

This is something I had written earlier in the week before the internal discussion on preferring Node tooling for this kinds of scripts. I'd love to discuss how something equivalent to this could be implemented with TS and some templating library in that ecosystem.

![template](https://media3.giphy.com/media/jcxtvm2bsZDH2/giphy.gif?cid=d1fd59abpbt7dn07bkhfvk30qqvpcgthgoj390zqpbafx4bu&rid=giphy.gif&ct=g)