### PR TITLE
Remove unused load lessons functions

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -1,29 +1,6 @@
 import {LessonResource} from 'types'
 import {getGraphQLClient} from '../utils/configured-graphql-client'
-import config from './config'
 import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
-
-export async function loadLessons(): Promise<LessonResource[]> {
-  const query = /* GraphQL */ `
-    query getLessons {
-      lessons(per_page: 25) {
-        title
-        slug
-        icon_url
-        instructor {
-          full_name
-          avatar_64_url
-        }
-      }
-    }
-  `
-
-  const graphQLClient = getGraphQLClient()
-
-  const {lessons} = await graphQLClient.request(config.graphQLEndpoint, query)
-
-  return lessons
-}
 
 export async function loadLesson(slug: string, token?: string) {
   const query = /* GraphQL */ `

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -114,31 +114,3 @@ export async function loadLesson(slug: string, token?: string) {
 
   return lesson as LessonResource
 }
-
-export async function loadLessonForUser(slug: string) {
-  const query = /* GraphQL */ `
-    query getLesson($slug: String!) {
-      lesson(slug: $slug) {
-        slug
-        hls_url
-        dash_url
-        transcript_url
-        toggle_favorite_url
-        download_url
-        favorited
-        completed
-      }
-    }
-  `
-
-  const token = getAccessTokenFromCookie()
-  const graphQLClient = getGraphQLClient(token)
-
-  const variables = {
-    slug: slug,
-  }
-
-  const {lesson} = await graphQLClient.request(query, variables)
-
-  return lesson as LessonResource
-}


### PR DESCRIPTION
- cleanup: remove unused loadLessons function

The component that used this function was removed back in August 2020.
It hasn't been used since.
https://github.com/eggheadio/egghead-next/commit/ff184c09e66a66f4b7a9ed0f7aae649962408dc5

Plus we are trying to remove data loading dependence on egghead-rails,
especially for lesson metadata.

- cleanup: remove unused loadLessonForUser function

This function was only used in one place and that was removed back in
February 2021 and replaced with a call to `loadLesson`.
https://github.com/eggheadio/egghead-next/commit/11767d06554c85de203631c30ad0917cd4d11508

![load lesson](https://media0.giphy.com/media/Yxct9CcKveWhW/giphy.gif?cid=d1fd59abohh1f8fyee2syx9x6ap0k8gnj3vp8zbcogxpjvm5&rid=giphy.gif&ct=g)
