### PR TITLE
feat: require one or the other URL to be set

### DIFF
--- a/studio/schemas/documents/videoResource.js
+++ b/studio/schemas/documents/videoResource.js
@@ -1,3 +1,5 @@
+import isEmpty from 'lodash/isEmpty'
+
 export default {
   name: 'videoResource',
   title: 'Video Resource',
@@ -13,12 +15,27 @@ export default {
       name: 'originalVideoUrl',
       title: 'Original Video URL',
       type: 'url',
-      validation: (Rule) => Rule.required(),
+      validation: (Rule) =>
+        Rule.custom((originalVideoUrl, context) => {
+          if (isEmpty(originalVideoUrl) && isEmpty(context.document.hslUrl)) {
+            return 'Either "Original Video URL" or "HSL URL" must be set.'
+          }
+
+          return true
+        }),
     },
     {
       name: 'hslUrl',
       title: 'HSL URL',
       type: 'url',
+      validation: (Rule) =>
+        Rule.custom((hslUrl, context) => {
+          if (isEmpty(hslUrl) && isEmpty(context.document.originalVideoUrl)) {
+            return 'Either "HSL URL" or "Original Video URL" must be set.'
+          }
+
+          return true
+        }),
     },
   ],
   preview: {


### PR DESCRIPTION
This replaces the required validation on `originalVideoUrl` with a pair
of validations that require one or other of `originalVideoUrl` and
`hslUrl` to be set. We are going to need one or the other, but we don't
always have both.

When a video is first imported via the Course Builder, we only have the
`originalVideoUrl`.

When a Course and its consistent lessons and video resources are
imported from egghead-rails, it is going to have an `hslUrl`, but not an
`originalVideoUrl`.

This should address the issue @zacjones93 was running into earlier today with a Course import script.


https://user-images.githubusercontent.com/694063/180513517-8a704bec-9e9a-46f7-8fa1-619d0ff34c83.mp4

![validate](https://media1.giphy.com/media/OWtpNt0fbvwLeKbHcB/giphy.gif?cid=d1fd59abwrrrhpw35c4ah0pstmg8pczl7krjuyuvlpqfgcty&rid=giphy.gif&ct=g)
