### PR TITLE
feat: load Lesson metadata from Sanity

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -84,11 +84,6 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
           }
         }
       }
-      course {
-        title
-        square_cover_480_url
-        slug
-      }
       tags {
         name
         label

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -1,6 +1,7 @@
 import {LessonResource} from 'types'
 import {getGraphQLClient} from '../utils/configured-graphql-client'
 import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
+import {loadLessonComments} from './lesson-comments'
 
 export async function loadLesson(
   slug: string,
@@ -119,61 +120,3 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
     }
   }
 `
-
-type Comment = {
-  comment: string
-  commentable_id: number
-  commentable_type: string
-  created_at: string
-  id: number
-  is_commentable_owner: boolean
-  state: string
-  user: {
-    avatar_url: string
-    full_name: string
-    instructor: {
-      first_name: string
-    }
-  }
-}
-
-export async function loadLessonComments(
-  slug: string,
-  token?: string,
-): Promise<Comment[]> {
-  token = token || getAccessTokenFromCookie()
-  const graphQLClient = getGraphQLClient(token)
-
-  const variables = {
-    slug: slug,
-  }
-
-  const query = /* GraphQL */ `
-    query getLesson($slug: String!) {
-      lesson(slug: $slug) {
-        comments {
-          comment
-          commentable_id
-          commentable_type
-          created_at
-          id
-          is_commentable_owner
-          state
-          user {
-            avatar_url
-            full_name
-            instructor {
-              first_name
-            }
-          }
-        }
-      }
-    }
-  `
-
-  const {
-    lesson: {comments},
-  } = await graphQLClient.request(query, variables)
-
-  return comments
-}

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -3,106 +3,6 @@ import {getGraphQLClient} from '../utils/configured-graphql-client'
 import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
 
 export async function loadLesson(slug: string, token?: string) {
-  const query = /* GraphQL */ `
-    query getLesson($slug: String!) {
-      lesson(slug: $slug) {
-        slug
-        title
-        description
-        duration
-        next_up_url
-        free_forever
-        path
-        transcript
-        transcript_url
-        subtitles_url
-        hls_url
-        dash_url
-        http_url
-        media_url
-        lesson_view_url
-        thumb_url
-        icon_url
-        download_url
-        staff_notes_url
-        repo_url
-        code_url
-        created_at
-        updated_at
-        published_at
-        collection {
-          ... on Playlist {
-            title
-            slug
-            type
-            square_cover_480_url
-            path
-            lessons {
-              slug
-              type
-              path
-              title
-              completed
-              duration
-              thumb_url
-              media_url
-            }
-          }
-          ... on Course {
-            title
-            slug
-            type
-            square_cover_480_url
-            path
-            lessons {
-              slug
-              type
-              path
-              title
-              completed
-              duration
-              thumb_url
-              media_url
-            }
-          }
-        }
-        course {
-          title
-          square_cover_480_url
-          slug
-        }
-        tags {
-          name
-          label
-          http_url
-          image_url
-        }
-        instructor {
-          full_name
-          avatar_64_url
-          slug
-          twitter
-        }
-        comments {
-          comment
-          commentable_id
-          commentable_type
-          created_at
-          id
-          is_commentable_owner
-          state
-          user {
-            avatar_url
-            full_name
-            instructor {
-              first_name
-            }
-          }
-        }
-      }
-    }
-  `
-
   token = token || getAccessTokenFromCookie()
   const graphQLClient = getGraphQLClient(token)
 
@@ -110,7 +10,110 @@ export async function loadLesson(slug: string, token?: string) {
     slug: slug,
   }
 
-  const {lesson} = await graphQLClient.request(query, variables)
+  const {lesson} = await graphQLClient.request(
+    loadLessonGraphQLQuery,
+    variables,
+  )
 
   return lesson as LessonResource
 }
+
+const loadLessonGraphQLQuery = /* GraphQL */ `
+  query getLesson($slug: String!) {
+    lesson(slug: $slug) {
+      slug
+      title
+      description
+      duration
+      next_up_url
+      free_forever
+      path
+      transcript
+      transcript_url
+      subtitles_url
+      hls_url
+      dash_url
+      http_url
+      media_url
+      lesson_view_url
+      thumb_url
+      icon_url
+      download_url
+      staff_notes_url
+      repo_url
+      code_url
+      created_at
+      updated_at
+      published_at
+      collection {
+        ... on Playlist {
+          title
+          slug
+          type
+          square_cover_480_url
+          path
+          lessons {
+            slug
+            type
+            path
+            title
+            completed
+            duration
+            thumb_url
+            media_url
+          }
+        }
+        ... on Course {
+          title
+          slug
+          type
+          square_cover_480_url
+          path
+          lessons {
+            slug
+            type
+            path
+            title
+            completed
+            duration
+            thumb_url
+            media_url
+          }
+        }
+      }
+      course {
+        title
+        square_cover_480_url
+        slug
+      }
+      tags {
+        name
+        label
+        http_url
+        image_url
+      }
+      instructor {
+        full_name
+        avatar_64_url
+        slug
+        twitter
+      }
+      comments {
+        comment
+        commentable_id
+        commentable_type
+        created_at
+        id
+        is_commentable_owner
+        state
+        user {
+          avatar_url
+          full_name
+          instructor {
+            first_name
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -2,7 +2,10 @@ import {LessonResource} from 'types'
 import {getGraphQLClient} from '../utils/configured-graphql-client'
 import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
 
-export async function loadLesson(slug: string, token?: string) {
+export async function loadLesson(
+  slug: string,
+  token?: string,
+): Promise<LessonResource> {
   token = token || getAccessTokenFromCookie()
   const graphQLClient = getGraphQLClient(token)
 


### PR DESCRIPTION
This PR puts up the scaffolding for loading Lesson metadata from Sanity alongside egghead-rails (where it is already coming from).

This merges the lesson metadata from both egghead-rails and Sanity, so
if one or the other is either missing or incomplete, the other will make
up for it. This helps as we transition from egghead-rails to Sanity as
the source of truth for lesson metadata.

Individual Commits:

- refactor: extract graphql query to const
- refactor: be explicit about loadLesson return type
- cleanup: remove unused `course` from Lesson query
- refactor: load lesson comments separately
- refactor: move load fn to lesson-comments module
- feat: load some lesson metadata from Sanity

![metadata](https://media0.giphy.com/media/M8HRhvFniWDgacSAww/giphy.gif?cid=d1fd59ab9w4yhc8mbjqmx8uha9x8iol8ymfuomod4w2awird&rid=giphy.gif&ct=g)