### PR TITLE
feat: load instructor and tags from Sanity w/ GROQ

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -9,7 +9,19 @@ const lessonQuery = groq`
 *[_type == 'lesson' && slug == $slug][0]{
   title,
   slug,
-  description
+  description,
+  'instructor': collaborators[0]-> {
+    'full_name': person->name,
+    'slug': person->slug.current,
+    'avatar_64_url': person->image.url,
+    'twitter_url': person->twitter
+  },
+  'tags': softwareLibraries[] {
+    'name': library->name,
+    'label': library->slug.current,
+    'http_url': library->url,
+    'image_url': library->image.url
+  }
 }`
 
 /**


### PR DESCRIPTION
@Creeland and I walked through what would be needed to emulate graphql data
for instructor and tags. This data is already available based on our
existing Sanity schema for Lesson.
https://roamresearch.com/#/app/egghead/page/DRrhsDRCU

![groq](https://media4.giphy.com/media/DYGbtrltNhHVX7xZTk/giphy.gif?cid=d1fd59abcxbcvgrhttivj49ozmps16rwxatuvuonsbhsh934&rid=giphy.gif&ct=g)
