### PR TITLE
feat: groq for a Lesson's collection and siblings

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -21,6 +21,22 @@ const lessonQuery = groq`
     'label': library->slug.current,
     'http_url': library->url,
     'image_url': library->image.url
+  },
+  'collection': *[_type=='course' && references(^._id)][0]{
+    title,
+    'slug': slug.current,
+    'type': 'playlist',
+    'square_cover_480_url': image,
+    'path': '/courses/' + slug.current,
+    'lessons': lessons[]-> {
+      'slug': slug.current,
+      'type': 'lesson',
+      'path': '/lessons/' + slug.current,
+      'title': title,
+      'duration': 0,
+      'thumb_url': null,
+      'media_url': *[_type=='videoResource' && _id == ^.resource->_id][0].hslUrl
+    }
   }
 }`
 


### PR DESCRIPTION
This is the result of some pairing between @Creeland and I.

This adds the collection portion of the graphql Lesson emulation. It
finds the first containing collection (a course) as well as all the
lessons tied to that course (this lesson's siblings).

tl;dr: this is some cool GROQ, but it is also slow GROQ.

To query for this data from the context of a lesson requires some
"sub-queries" (not sure if GROQ calls them that). This appears to be
leading to a big hit in performance. In the Studio Vision tab, running
this query, we are seeing execution time jump to a little above 1000ms.
We are going to need to either adjust this query to get better
performance or break it up into separate queries that each have a better
performance profile.

We are working with a small amount of data in a small graph (in our staging dataset), so I'm hoping we are just missing a better way to do this with GROQ.

Some notes/questions on the performance of this query: https://roamresearch.com/#/app/egghead/page/QQjJQ1QE6

![performance](https://media0.giphy.com/media/Ra4MJBrXnXOwjbKTsP/giphy.gif?cid=d1fd59ab29lvkgq0wywsft1csnnnvbahiwontsijxzcoz6zp&rid=giphy.gif&ct=g)
