### PR TITLE
feat: use getLessonComments graphql field

### DIFF
--- a/src/lib/lesson-comments.ts
+++ b/src/lib/lesson-comments.ts
@@ -46,31 +46,28 @@ export async function loadLessonComments(
   }
 
   const query = /* GraphQL */ `
-    query getLesson($slug: String!) {
-      lesson(slug: $slug) {
-        comments {
-          comment
-          commentable_id
-          commentable_type
-          created_at
-          id
-          is_commentable_owner
-          state
-          user {
-            avatar_url
-            full_name
-            instructor {
-              first_name
-            }
+    query getLessonComments($slug: String!) {
+      lesson_comments(slug: $slug) {
+        title
+        comment
+        commentable_id
+        commentable_type
+        created_at
+        id
+        is_commentable_owner
+        state
+        user {
+          avatar_url
+          full_name
+          instructor {
+            first_name
           }
         }
       }
     }
   `
 
-  const {
-    lesson: {comments},
-  } = await graphQLClient.request(query, variables)
+  const {lesson_comments} = await graphQLClient.request(query, variables)
 
-  return comments
+  return lesson_comments
 }

--- a/src/lib/lesson-comments.ts
+++ b/src/lib/lesson-comments.ts
@@ -48,7 +48,6 @@ export async function loadLessonComments(
   const query = /* GraphQL */ `
     query getLessonComments($slug: String!) {
       lesson_comments(slug: $slug) {
-        title
         comment
         commentable_id
         commentable_type


### PR DESCRIPTION
This updates the fetching of lesson comments to use a field about
comments, rather than indirectly getting them from the lesson field.

Originally suggested here: https://github.com/eggheadio/egghead-next/pull/1148/files#r930385696

Related PR: https://github.com/eggheadio/egghead-rails/pull/5021

![comments](https://media3.giphy.com/media/njxkENt8FXreAt5TIT/giphy.gif?cid=d1fd59abzn52dra899tg3043mh5g9smb2jgh74qqfrsn1b17&rid=giphy.gif&ct=g)