### PR TITLE
cleanup: remove unused `next_up_url` from query

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -88,7 +88,6 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
       title
       description
       duration
-      next_up_url
       free_forever
       path
       transcript


### PR DESCRIPTION
egghead-next isn't using the `next_up_url`. It has a hook
(`useNextForCollection`) for determining the next lesson without making
an API call.

We can remove a bunch of server code
(https://github.com/eggheadio/egghead-rails/pull/5026) as well by
removing this only place that references `next_up_url`.

![next up](https://media2.giphy.com/media/TKNGghpLhaz9XH1tSj/giphy.gif?cid=d1fd59abgs3k6853gbdm5ez78ssni3kbc86hjk2p3bxgo869&rid=giphy.gif&ct=g)
