### PR TITLE
cleanup: re-remove comments from graphql

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -156,22 +156,6 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
         slug
         twitter
       }
-      comments {
-        comment
-        commentable_id
-        commentable_type
-        created_at
-        id
-        is_commentable_owner
-        state
-        user {
-          avatar_url
-          full_name
-          instructor {
-            first_name
-          }
-        }
-      }
     }
   }
 `


### PR DESCRIPTION
There must have been a bad merge that re-introduced the comments block
into this graphql query. It was originally removed last week in
https://github.com/eggheadio/egghead-next/pull/1148/files.

Comment loading is now handled elsewhere, so this isn't needed here.

![no comment](https://media1.giphy.com/media/SWFKjmZNMsLP3JoeWm/giphy.gif?cid=d1fd59ab38iy6x4bq0fevxwum8bssmk7hxrahv2os3faninp&rid=giphy.gif&ct=g)
