### PR TITLE
feat: request full lesson metadata from Sanity with GROQ

### DIFF
--- a/src/lib/lesson-comments.ts
+++ b/src/lib/lesson-comments.ts
@@ -66,7 +66,13 @@ export async function loadLessonComments(
     }
   `
 
-  const {lesson_comments} = await graphQLClient.request(query, variables)
+  try {
+    const {lesson_comments} = await graphQLClient.request(query, variables)
 
-  return lesson_comments
+    return lesson_comments
+  } catch (e) {
+    console.log('Error fetching lesson comments: ', e)
+
+    return []
+  }
 }

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -11,7 +11,7 @@ import groq from 'groq'
 const lessonQuery = groq`
 *[_type == 'lesson' && slug.current == $slug][0]{
   title,
-  slug,
+  'slug': slug.current,
   description,
   resource->_type == 'videoResource' => {
     ...(resource[]-> {

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -11,16 +11,20 @@ const lessonQuery = groq`
   slug,
   description,
   'instructor': collaborators[0]-> {
-    'full_name': person->name,
-    'slug': person->slug.current,
-    'avatar_64_url': person->image.url,
-    'twitter_url': person->twitter
+    ...(person[]-> {
+      'full_name': name,
+      'slug': slug.current,
+      'avatar_64_url': image.url,
+      'twitter_url': twitter
+    }),
   },
   'tags': softwareLibraries[] {
-    'name': library->name,
-    'label': library->slug.current,
-    'http_url': library->url,
-    'image_url': library->image.url
+    ...(library[]-> {
+       name,
+      'label': slug.current,
+      'http_url': url,
+      'image_url': image.url
+    }),
   },
   'collection': *[_type=='course' && references(^._id)][0]{
     title,
@@ -35,7 +39,9 @@ const lessonQuery = groq`
       'title': title,
       'duration': 0,
       'thumb_url': null,
-      'media_url': *[_type=='videoResource' && _id == ^.resource->_id][0].hlsUrl
+      resource->_type == 'videoResource' => {
+        'media_url': resource->hslUrl
+      }
     }
   }
 }`

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -5,6 +5,7 @@ import {loadLessonComments} from './lesson-comments'
 import {sanityClient} from 'utils/sanity-client'
 import groq from 'groq'
 import some from 'lodash/some'
+import isEmpty from 'lodash/isEmpty'
 
 // next_up_url can be derived on the front-end from collection and
 // staff_notes_url seems to be null for all lessons
@@ -152,6 +153,12 @@ export async function loadLesson(
     lessonMetadataFromGraphQL,
     lessonMetadataFromSanity,
   )
+
+  // if we aren't able to find Lesson metadata at either source, throw an
+  // error.
+  if (isEmpty(lessonMetadata.slug)) {
+    throw new Error(`Unable to lookup lesson metadata (slug: ${slug})`)
+  }
 
   return {...lessonMetadata, comments} as LessonResource
 }

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -165,7 +165,7 @@ const mergeLessonMetadata = (
   lessonMetadataFromSanity: LessonResource,
 ): LessonResource => {
   // we can merge most of it together as is, but there are a few nested pieces
-  // that need to be handled either manually.
+  // that need to be handled manually.
   //
   // e.g. if tags haven't been set yet on Sanity, they will appear as an empty
   // array. With a standard spread, they empty tags from Sanity would override

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -17,7 +17,7 @@ const lessonQuery = groq`
     ...(resource[]-> {
       'media_url': hslUrl,
       'transcript': transcriptBody,
-      'transcript_url': transcriptUrl
+      'transcript_url': transcriptUrl,
       duration,
       'subtitles_url': subtitlesUrl,
     })

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -68,9 +68,7 @@ async function loadLessonMetadataFromSanity(slug: string) {
     slug,
   }
 
-  const lesson = await sanityClient.fetch(lessonQuery, params)
-
-  return lesson
+  return await sanityClient.fetch(lessonQuery, params)
 }
 
 export async function loadLesson(

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -40,7 +40,7 @@ const lessonQuery = groq`
     }),
   },
   'tags': softwareLibraries[] {
-    ...(library[]-> {
+    ...(library-> {
        name,
       'label': slug.current,
       'http_url': url,

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -8,7 +8,7 @@ import groq from 'groq'
 // next_up_url can be derived on the front-end from collection and
 // http_url can be built on the frontend from the path
 const lessonQuery = groq`
-*[_type == 'lesson' && slug == $slug][0]{
+*[_type == 'lesson' && slug.current == $slug][0]{
   title,
   slug,
   description,

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -5,11 +5,24 @@ import {loadLessonComments} from './lesson-comments'
 import {sanityClient} from 'utils/sanity-client'
 import groq from 'groq'
 
+// next_up_url can be derived on the front-end from collection and
+// http_url can be built on the frontend from the path
 const lessonQuery = groq`
 *[_type == 'lesson' && slug == $slug][0]{
   title,
   slug,
   description,
+  resource->_type == 'videoResource' => {
+    ...(resource[]-> {
+      'media_url': hslUrl,
+      'transcript': transcriptBody,
+      'transcript_url': transcriptUrl
+      duration,
+      'subtitles_url': subtitlesUrl,
+    })
+  },
+  'free_forever': isCommunityResource,
+  'path': '/lessons/' + slug.current,
   'instructor': collaborators[0]-> {
     ...(person[]-> {
       'full_name': name,
@@ -36,11 +49,11 @@ const lessonQuery = groq`
       'slug': slug.current,
       'type': 'lesson',
       'path': '/lessons/' + slug.current,
-      'title': title,
-      'duration': 0,
+      title,
       'thumb_url': null,
       resource->_type == 'videoResource' => {
-        'media_url': resource->hslUrl
+        'media_url': resource->hslUrl,
+        duration,
       }
     }
   }

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -160,6 +160,12 @@ export async function loadLesson(
   return {...lessonMetadata, comments} as LessonResource
 }
 
+// values in the graphql that are being skipped/ignored by Sanity
+//
+// - dash_url - not used
+// - staff_notes_url - not used
+// - icon_url - this is being used by the lesson page
+
 const loadLessonGraphQLQuery = /* GraphQL */ `
   query getLesson($slug: String!) {
     lesson(slug: $slug) {

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -57,7 +57,7 @@ const lessonQuery = groq`
       'type': 'lesson',
       'path': '/lessons/' + slug.current,
       title,
-      'thumb_url': null,
+      'thumb_url': thumbnailUrl,
       resource->_type == 'videoResource' => {
         'media_url': resource->hslUrl,
         duration,

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -6,7 +6,8 @@ import {sanityClient} from 'utils/sanity-client'
 import groq from 'groq'
 
 // next_up_url can be derived on the front-end from collection and
-// http_url can be built on the frontend from the path
+// staff_notes_url seems to be null for all lessons
+// code_url is only used in a select few Kent C. Dodds lessons
 const lessonQuery = groq`
 *[_type == 'lesson' && slug.current == $slug][0]{
   title,
@@ -23,6 +24,12 @@ const lessonQuery = groq`
   },
   'free_forever': isCommunityResource,
   'path': '/lessons/' + slug.current,
+  'thumb_url': thumbnailUrl,
+  'repo_url': repoUrl,
+  'code_url': codeUrl,
+  'createdAt': eggheadRailsCreatedAt,
+  'updatedAt': eggheadRailsUpdatedAt,
+  'publishedAt': eggheadRailsPublishedAt,
   'instructor': collaborators[0]-> {
     ...(person[]-> {
       'full_name': name,
@@ -74,8 +81,10 @@ async function loadLessonMetadataFromSanity(slug: string) {
 // TODO: Derive the next_up_url from the collection and lesson slug
 const derivedData = (result: any) => {
   const http_url = `${process.env.NEXT_PUBLIC_DEPLOY_URL}${result.path}`
+  const lesson_view_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${result.path}/views`
+  const download_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${result.path}/signed_download`
 
-  return {http_url}
+  return {http_url, lesson_view_url, download_url}
 }
 
 export async function loadLesson(

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -7,7 +7,6 @@ import groq from 'groq'
 import some from 'lodash/some'
 import isEmpty from 'lodash/isEmpty'
 
-// next_up_url can be derived on the front-end from collection and
 // staff_notes_url seems to be null for all lessons
 // code_url is only used in a select few Kent C. Dodds lessons
 const lessonQuery = groq`

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -27,9 +27,9 @@ const lessonQuery = groq`
   'thumb_url': thumbnailUrl,
   'repo_url': repoUrl,
   'code_url': codeUrl,
-  'createdAt': eggheadRailsCreatedAt,
-  'updatedAt': eggheadRailsUpdatedAt,
-  'publishedAt': eggheadRailsPublishedAt,
+  'created_at': eggheadRailsCreatedAt,
+  'updated_at': eggheadRailsUpdatedAt,
+  'published_at': eggheadRailsPublishedAt,
   'instructor': collaborators[0]-> {
     ...(person-> {
       'full_name': name,

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -15,7 +15,7 @@ const lessonQuery = groq`
   'slug': slug.current,
   description,
   resource->_type == 'videoResource' => {
-    ...(resource[]-> {
+    ...(resource-> {
       'media_url': hslUrl,
       'transcript': transcriptBody,
       'transcript_url': transcriptUrl,
@@ -32,7 +32,7 @@ const lessonQuery = groq`
   'updatedAt': eggheadRailsUpdatedAt,
   'publishedAt': eggheadRailsPublishedAt,
   'instructor': collaborators[0]-> {
-    ...(person[]-> {
+    ...(person-> {
       'full_name': name,
       'slug': slug.current,
       'avatar_64_url': image.url,

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -91,7 +91,6 @@ async function loadLessonMetadataFromSanity(slug: string) {
   }
 }
 
-// TODO: Derive the next_up_url from the collection and lesson slug
 const deriveDataFromBaseValues = (result: any) => {
   const http_url = `${process.env.NEXT_PUBLIC_DEPLOY_URL}${result.path}`
   const lesson_view_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${result.path}/views`

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -7,7 +7,6 @@ import groq from 'groq'
 import some from 'lodash/some'
 import isEmpty from 'lodash/isEmpty'
 
-// staff_notes_url seems to be null for all lessons
 // code_url is only used in a select few Kent C. Dodds lessons
 const lessonQuery = groq`
 *[_type == 'lesson' && slug.current == $slug][0]{

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -4,6 +4,7 @@ import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
 import {loadLessonComments} from './lesson-comments'
 import {sanityClient} from 'utils/sanity-client'
 import groq from 'groq'
+import some from 'lodash/some'
 
 // next_up_url can be derived on the front-end from collection and
 // staff_notes_url seems to be null for all lessons
@@ -123,12 +124,78 @@ export async function loadLesson(
    * Merge All Lesson Metadata Together
    * ***********************************/
   // with preference for data coming from Sanity
-  const lessonMetadata = {
-    ...lessonMetadataFromGraphQL,
-    ...lessonMetadataFromSanity,
-  }
+  const lessonMetadata = mergeLessonMetadata(
+    lessonMetadataFromGraphQL,
+    lessonMetadataFromSanity,
+  )
 
   return {...lessonMetadata, comments} as LessonResource
+}
+
+const mergeLessonMetadata = (
+  lessonMetadataFromGraphQL: LessonResource,
+  lessonMetadataFromSanity: LessonResource,
+): LessonResource => {
+  // we can merge most of it together as is, but there are a few nested pieces
+  // that need to be handled either manually.
+  //
+  // e.g. if tags haven't been set yet on Sanity, they will appear as an empty
+  // array. With a standard spread, they empty tags from Sanity would override
+  // an actual list of tags from graphql. We can instead handle this manually
+  // by checking for `_.some()` and falling back to graphql if there aren't
+  // any.
+
+  // Nested fields:
+  // - `tags`
+  // - `instructor`
+  // - `collection`
+  //   - `lessons`
+
+  /*
+   * Extract primary and secondary fields
+   */
+  const {
+    tags: secondaryTags,
+    instructor: secondaryInstructor,
+    collection: secondaryCollection,
+    ...secondaryRest
+  } = lessonMetadataFromGraphQL
+
+  const {
+    tags: primaryTags,
+    instructor: primaryInstructor,
+    collection: primaryCollection,
+    ...primaryRest
+  } = lessonMetadataFromSanity
+
+  /*
+   * Determine which value to take for each complex type (`collection`, `tags`,
+   * and `instructor`).
+   */
+  const collection = collectionIsPresent(primaryCollection)
+    ? primaryCollection
+    : secondaryCollection
+
+  const tags = some(primaryTags) ? primaryTags : secondaryTags
+
+  const instructor = some(primaryInstructor)
+    ? primaryInstructor
+    : secondaryInstructor
+
+  const rest = {...secondaryRest, ...primaryRest}
+
+  return {collection, instructor, tags, ...rest}
+}
+
+const collectionIsPresent = ({
+  lessons,
+  ...collectionMetadata
+}: {
+  lessons: any[]
+}) => {
+  // if there are lessons and some collectionMetadata is present, then the
+  // collection is considered present.
+  return some(lessons) && some(collectionMetadata)
 }
 
 const loadLessonGraphQLQuery = /* GraphQL */ `

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -4,8 +4,8 @@ import getAccessTokenFromCookie from '../utils/get-access-token-from-cookie'
 import {loadLessonComments} from './lesson-comments'
 import {sanityClient} from 'utils/sanity-client'
 import groq from 'groq'
-import some from 'lodash/some'
 import isEmpty from 'lodash/isEmpty'
+import {mergeLessonMetadata} from 'utils/lesson-metadata'
 
 // code_url is only used in a select few Kent C. Dodds lessons
 const lessonQuery = groq`
@@ -158,69 +158,6 @@ export async function loadLesson(
   }
 
   return {...lessonMetadata, comments} as LessonResource
-}
-
-const mergeLessonMetadata = (
-  lessonMetadataFromGraphQL: LessonResource,
-  lessonMetadataFromSanity: LessonResource,
-): LessonResource => {
-  // we can merge most of it together as is, but there are a few nested pieces
-  // that need to be handled manually.
-  //
-  // e.g. if tags haven't been set yet on Sanity, they will appear as an empty
-  // array. With a standard spread, they empty tags from Sanity would override
-  // an actual list of tags from graphql. We can instead handle this manually
-  // by checking for `_.some()` and falling back to graphql if there aren't
-  // any.
-
-  // Nested fields:
-  // - `tags`
-  // - `instructor`
-  // - `collection`
-  //   - `lessons`
-
-  /*
-   * Extract primary and secondary fields
-   */
-  const {
-    tags: secondaryTags,
-    instructor: secondaryInstructor,
-    collection: secondaryCollection,
-    ...secondaryRest
-  } = lessonMetadataFromGraphQL
-
-  const {
-    tags: primaryTags,
-    instructor: primaryInstructor,
-    collection: primaryCollection,
-    ...primaryRest
-  } = lessonMetadataFromSanity
-
-  /*
-   * Determine which value to take for each complex type (`collection`, `tags`,
-   * and `instructor`).
-   */
-  const collection = collectionIsPresent(primaryCollection)
-    ? primaryCollection
-    : secondaryCollection
-
-  const tags = some(primaryTags) ? primaryTags : secondaryTags
-
-  const instructor = some(primaryInstructor)
-    ? primaryInstructor
-    : secondaryInstructor
-
-  const rest = {...secondaryRest, ...primaryRest}
-
-  return {collection, instructor, tags, ...rest}
-}
-
-const collectionIsPresent = (collection: {lessons: any[] | undefined}) => {
-  const {lessons, ...collectionMetadata} = collection || {}
-
-  // if there are lessons and some collectionMetadata is present, then the
-  // collection is considered present.
-  return some(lessons) && some(collectionMetadata)
 }
 
 const loadLessonGraphQLQuery = /* GraphQL */ `

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -71,6 +71,13 @@ async function loadLessonMetadataFromSanity(slug: string) {
   return await sanityClient.fetch(lessonQuery, params)
 }
 
+// TODO: Derive the next_up_url from the collection and lesson slug
+const derivedData = (result: any) => {
+  const http_url = `${process.env.NEXT_PUBLIC_DEPLOY_URL}${result.path}`
+
+  return {http_url}
+}
+
 export async function loadLesson(
   slug: string,
   token?: string,
@@ -87,7 +94,9 @@ export async function loadLesson(
     variables,
   )
 
-  const lessonMetadataFromSanity = await loadLessonMetadataFromSanity(slug)
+  const queryResult = await loadLessonMetadataFromSanity(slug)
+  const derivedDataFromQuery = derivedData(queryResult)
+  const lessonMetadataFromSanity = {...queryResult, ...derivedDataFromQuery}
 
   const lessonMetadata = {...lesson, ...lessonMetadataFromSanity}
 

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -211,12 +211,9 @@ const mergeLessonMetadata = (
   return {collection, instructor, tags, ...rest}
 }
 
-const collectionIsPresent = ({
-  lessons,
-  ...collectionMetadata
-}: {
-  lessons: any[]
-}) => {
+const collectionIsPresent = (collection: {lessons: any[] | undefined}) => {
+  const {lessons, ...collectionMetadata} = collection || {}
+
   // if there are lessons and some collectionMetadata is present, then the
   // collection is considered present.
   return some(lessons) && some(collectionMetadata)

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export type LessonResource = Resource & {
   completed: boolean
   duration: number
   instructor: any
-  collection: Resource
+  collection: Resource & {lessons: any[]}
   staff_notes_url?: string
   download_url?: string
 }

--- a/src/utils/__tests__/lesson-metadata.test.ts
+++ b/src/utils/__tests__/lesson-metadata.test.ts
@@ -1,0 +1,135 @@
+import {LessonResource} from 'types'
+import {mergeLessonMetadata} from '../lesson-metadata'
+
+test('top-level data from Sanity overrides graphql', () => {
+  const graphqlMetadata = {
+    title: 'Ultimate React',
+    duration: 123,
+  } as LessonResource
+  const sanityMetadata = {
+    title: 'Xtreme React',
+    path: '/path/to/lesson',
+  } as LessonResource
+
+  const expectedResult = {
+    title: 'Xtreme React',
+    duration: 123,
+    path: '/path/to/lesson',
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})
+
+test('Sanity tags override graphql tags when present', () => {
+  const graphqlMetadata = {
+    tags: [{name: 'Vue'}],
+  } as LessonResource
+
+  const sanityMetadata = {
+    tags: [{name: 'React'}],
+  } as LessonResource
+
+  const expectedResult = {
+    tags: [{name: 'React'}],
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})
+
+test('graphql tags override Sanity tags if Sanity tags are not present', () => {
+  const graphqlMetadata = {
+    tags: [{name: 'Vue'}],
+  } as LessonResource
+
+  const sanityMetadata = {
+    tags: [] as Array<{}>,
+  } as LessonResource
+
+  const expectedResult = {
+    tags: [{name: 'Vue'}],
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})
+
+test('Sanity instructor takes precedence to graphql instructor', () => {
+  const graphqlMetadata = {
+    instructor: {name: 'Zac Jones'},
+  } as LessonResource
+
+  const sanityMetadata = {
+    instructor: {name: 'Ian Jones'},
+  } as LessonResource
+
+  const expectedResult = {
+    instructor: {name: 'Ian Jones'},
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})
+
+test('graphql instructor is used when Sanity instructor is not present', () => {
+  const graphqlMetadata = {
+    instructor: {name: 'Zac Jones'},
+  } as LessonResource
+
+  const sanityMetadata = {
+    instructor: {},
+  } as LessonResource
+
+  const expectedResult = {
+    instructor: {name: 'Zac Jones'},
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})
+
+test('Sanity collection takes precedence to graphql collection', () => {
+  const graphqlMetadata = {
+    collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
+  } as LessonResource
+
+  // a collection needs to include some course metadata and a non-empty list of
+  // lessons to be considered present.
+  const sanityMetadata = {
+    collection: {title: 'Ultimate React Course', lessons: [1, 2, 3]},
+  } as LessonResource
+
+  const expectedResult = {
+    collection: {title: 'Ultimate React Course', lessons: [1, 2, 3]},
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})
+
+test('graphql collection is used if Sanity collection is not present', () => {
+  const graphqlMetadata = {
+    collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
+  } as LessonResource
+
+  // a collection needs to include some course metadata and a non-empty list of
+  // lessons to be considered present.
+  const sanityMetadata = {
+    collection: {title: 'Ultimate React Course', lessons: [] as Array<{}>},
+  } as LessonResource
+
+  const expectedResult = {
+    collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
+  }
+
+  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+
+  expect(result).toEqual(expectedResult)
+})

--- a/src/utils/lesson-metadata.ts
+++ b/src/utils/lesson-metadata.ts
@@ -1,0 +1,65 @@
+import {LessonResource} from 'types'
+import some from 'lodash/some'
+
+export const mergeLessonMetadata = (
+  lessonMetadataFromGraphQL: LessonResource,
+  lessonMetadataFromSanity: LessonResource,
+): LessonResource => {
+  // we can merge most of it together as is, but there are a few nested pieces
+  // that need to be handled manually.
+  //
+  // e.g. if tags haven't been set yet on Sanity, they will appear as an empty
+  // array. With a standard spread, they empty tags from Sanity would override
+  // an actual list of tags from graphql. We can instead handle this manually
+  // by checking for `_.some()` and falling back to graphql if there aren't
+  // any.
+
+  // Nested fields:
+  // - `tags`
+  // - `instructor`
+  // - `collection`
+  //   - `lessons`
+
+  /*
+   * Extract primary and secondary fields
+   */
+  const {
+    tags: secondaryTags,
+    instructor: secondaryInstructor,
+    collection: secondaryCollection,
+    ...secondaryRest
+  } = lessonMetadataFromGraphQL
+
+  const {
+    tags: primaryTags,
+    instructor: primaryInstructor,
+    collection: primaryCollection,
+    ...primaryRest
+  } = lessonMetadataFromSanity
+
+  /*
+   * Determine which value to take for each complex type (`collection`, `tags`,
+   * and `instructor`).
+   */
+  const collection = collectionIsPresent(primaryCollection)
+    ? primaryCollection
+    : secondaryCollection
+
+  const tags = some(primaryTags) ? primaryTags : secondaryTags
+
+  const instructor = some(primaryInstructor)
+    ? primaryInstructor
+    : secondaryInstructor
+
+  const rest = {...secondaryRest, ...primaryRest}
+
+  return {collection, instructor, tags, ...rest}
+}
+
+const collectionIsPresent = (collection: {lessons: any[] | undefined}) => {
+  const {lessons, ...collectionMetadata} = collection || {}
+
+  // if there are lessons and some collectionMetadata is present, then the
+  // collection is considered present.
+  return some(lessons) && some(collectionMetadata)
+}

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -109,6 +109,44 @@ export default {
       type: 'boolean',
     },
     {
+      name: 'thumbnailUrl',
+      title: 'Thumbnail URL',
+      type: 'url',
+    },
+    {
+      name: 'iconUrl',
+      title: 'Icon URL',
+      type: 'url',
+    },
+    {
+      name: 'repoUrl',
+      title: 'Repo URL',
+      type: 'url',
+    },
+    {
+      name: 'codeUrl',
+      title: 'Code URL',
+      type: 'url',
+    },
+    {
+      name: 'eggheadRailsCreatedAt',
+      title: 'egghead Rails Created At',
+      description: 'Date this lesson resource was created on egghead.io',
+      type: 'datetime',
+    },
+    {
+      name: 'eggheadRailsUpdatedAt',
+      title: 'egghead Rails Updated At',
+      description: 'Date this lesson resource last updated on egghead.io',
+      type: 'datetime',
+    },
+    {
+      name: 'eggheadRailsPublishedAt',
+      title: 'egghead Rails Published At',
+      description: 'Date this lesson resource was published on egghead.io',
+      type: 'datetime',
+    },
+    {
       title: 'The lessons internal ID on egghead-rails',
       name: 'eggheadRailsLessonId',
       type: 'number',

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -104,6 +104,11 @@ export default {
       },
     },
     {
+      name: 'isCommunityResource',
+      title: 'Community Resource?',
+      type: 'boolean',
+    },
+    {
       title: 'The lessons internal ID on egghead-rails',
       name: 'eggheadRailsLessonId',
       type: 'number',

--- a/studio/schemas/documents/videoResource.js
+++ b/studio/schemas/documents/videoResource.js
@@ -37,6 +37,16 @@ export default {
           return true
         }),
     },
+    {
+      name: 'transcriptBody',
+      title: 'Transcript Body',
+      type: 'text',
+    },
+    {
+      name: 'transcriptUrl',
+      title: 'Transcript URL',
+      type: 'url',
+    },
   ],
   preview: {
     select: {

--- a/studio/schemas/documents/videoResource.js
+++ b/studio/schemas/documents/videoResource.js
@@ -47,6 +47,18 @@ export default {
       title: 'Transcript URL',
       type: 'url',
     },
+    {
+      name: 'subtitlesUrl',
+      title: 'Subtitles URL',
+      type: 'url',
+    },
+    {
+      name: 'duration',
+      title: 'Duration',
+      description: 'Duration in seconds',
+      type: 'number',
+      validation: (Rule) => Rule.required(),
+    },
   ],
   preview: {
     select: {


### PR DESCRIPTION
_Collaboration: @Creeland and I worked closely on this PR._

The idea behind this PR is to get us into a place where we have near-parity with our data fetching of Lesson metadata from Sanity.

This involved:
- adding some fields to the Lesson document in the Sanity schema
- adding some video resource specific fields to the VideoResource document in the Sanity Schema
- updating the GROQ Lesson Loading query to fetch all the things that are fetched by GraphQL
- derive some data values that can be computed instead of stored in Sanity
- merge the GraphQL and Sanity query results together, with a preference to Sanity, to account for interim data discrepancies
- handle 404 Not Found scenarios, while also throwing an error if a lesson isn't found from either source

What's next:

- [ ] First, apply the schema changes in production.
- [ ] Second, work with @zacjones93 to import a few lessons one-by-one into Sanity to smoke test this more thoroughly.

![grock](https://media4.giphy.com/media/aLfMb4dDjiifuGrR8j/giphy.gif?cid=d1fd59ab8dxp0ayip6urnvcfpqyp4458704apxzzehpnlof0&rid=giphy.gif&ct=g)