### PR TITLE
feat: add placeholder image host for staging/dev

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,7 @@ const withMDX = require(`@next/mdx`)({
     ],
   },
 })
+const compact = require('lodash/compact')
 
 const withTM = require('next-transpile-modules')(['unist-util-visit'], {
   debug: true,
@@ -31,14 +32,15 @@ checkEnv({
 
 const appUrl = process.env.NEXT_PUBLIC_AUTH_DOMAIN
 
-const IMAGE_HOST_DOMAINS = [
+const IMAGE_HOST_DOMAINS = compact([
   `d2eip9sf3oo6c2.cloudfront.net`,
   `dcv19h61vib2d.cloudfront.net`,
   `image.simplecastcdn.com`,
   `res.cloudinary.com`,
   `app.egghead.io`,
   `gravatar.com`,
-]
+  process.env.NODE_ENV !== 'production' && 'via.placeholder.com',
+])
 
 const nextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
When manually creating entries in Sanity for staging and development
purposes, you sometimes need a quick image URL. Rather than going to
find something weird off the internet, you can instead drop in a
placeholder URL. For example, `https://via.placeholder.com/150.png` will render
as a 150x150 png image.

This uses conditional logic with the node environment to only include
that host domain in non-production environments.

![placeholder](https://media2.giphy.com/media/ODXnSFxLGXlOSNjl9y/giphy.gif?cid=d1fd59abwnvk68v8bhaqqwx0yn70m9l4dia5fdaw851thklh&rid=giphy.gif&ct=g)
