### PR TITLE
fix: change hsl_url to hls_url

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -35,7 +35,7 @@ const lessonQuery = groq`
       'title': title,
       'duration': 0,
       'thumb_url': null,
-      'media_url': *[_type=='videoResource' && _id == ^.resource->_id][0].hslUrl
+      'media_url': *[_type=='videoResource' && _id == ^.resource->_id][0].hlsUrl
     }
   }
 }`

--- a/studio/schemas/documents/videoResource.js
+++ b/studio/schemas/documents/videoResource.js
@@ -17,21 +17,21 @@ export default {
       type: 'url',
       validation: (Rule) =>
         Rule.custom((originalVideoUrl, context) => {
-          if (isEmpty(originalVideoUrl) && isEmpty(context.document.hslUrl)) {
-            return 'Either "Original Video URL" or "HSL URL" must be set.'
+          if (isEmpty(originalVideoUrl) && isEmpty(context.document.hlsUrl)) {
+            return 'Either "Original Video URL" or "HLS URL" must be set.'
           }
 
           return true
         }),
     },
     {
-      name: 'hslUrl',
-      title: 'HSL URL',
+      name: 'hlsUrl',
+      title: 'HLS URL',
       type: 'url',
       validation: (Rule) =>
-        Rule.custom((hslUrl, context) => {
-          if (isEmpty(hslUrl) && isEmpty(context.document.originalVideoUrl)) {
-            return 'Either "HSL URL" or "Original Video URL" must be set.'
+        Rule.custom((hlsUrl, context) => {
+          if (isEmpty(hlsUrl) && isEmpty(context.document.originalVideoUrl)) {
+            return 'Either "HLS URL" or "Original Video URL" must be set.'
           }
 
           return true


### PR DESCRIPTION
HTTP Live Stream (HLS) is the appropriate acronym for this type of media
file. The HSL was a typo that got propogated a few places.

Since the VideoResource document isn't being actively used in production
yet, we should be able to update the naming without an explicit data
migration.

![live stream](https://media0.giphy.com/media/3o7WIKBSdsc0vsWScM/giphy.gif?cid=d1fd59ab57308gcv69l3gj3dcjbbcy5ue5wxxi39figina06&rid=giphy.gif&ct=g)
