### PR TITLE
feat: require productionProcessState for course

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -25,6 +25,7 @@ export default {
       name: 'productionProcessState',
       title: 'Production Process State',
       type: 'productionProcessState',
+      validation: (Rule) => Rule.required(),
     },
     {
       name: 'description',


### PR DESCRIPTION
Since we removed the validation the productionProcessState schema
object, we should add it to the course's use of that object.

Complements the work done here: https://github.com/eggheadio/egghead-next/pull/1158

![fur sure](https://media3.giphy.com/media/DmRu4qCv39160/giphy.gif?cid=d1fd59ab6v00yjjwrcmcv8x32vczluufq3alg59v23qs5kyo&rid=giphy.gif&ct=g)