### PR TITLE
updated link with correct link

### DIFF
--- a/src/pages/learn/react/beginners/wtf-is-react.mdx
+++ b/src/pages/learn/react/beginners/wtf-is-react.mdx
@@ -100,7 +100,7 @@ Interested in learning React, but don’t know JavaScript? We’ll go over essen
 
 <Callout>
 
-Read our article on the [JavaScript Concepts you Need to Learn before React]()
+Read our article on the [JavaScript Concepts you Need to Learn before React](https://egghead.io/learn/react/beginners/js-before-react)
 
 </Callout>
 


### PR DESCRIPTION
![](https://media3.giphy.com/media/NVBR6cLvUjV9C/giphy.gif?cid=5a38a5a22riob6yuq8e6mwajy654sx2q3fu5xtedb0hd1fm2&rid=giphy.gif&ct=g)

There was a link at the bottom of this article that was supposed to link to JavaScript Concepts you Need to Learn before React but just linked back to the same page that the learner is already on. I updated it with the correct link.

![Screen Shot 2022-08-11 at 2 40 08 PM](https://user-images.githubusercontent.com/26470581/184247147-4d617717-31d5-4fc6-a53e-463382257fb8.png)
 