### PR TITLE
refactor: move and test derive data function

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -5,8 +5,10 @@ import {loadLessonComments} from './lesson-comments'
 import {sanityClient} from 'utils/sanity-client'
 import groq from 'groq'
 import isEmpty from 'lodash/isEmpty'
-import {mergeLessonMetadata} from 'utils/lesson-metadata'
-import invariant from 'tiny-invariant'
+import {
+  mergeLessonMetadata,
+  deriveDataFromBaseValues,
+} from 'utils/lesson-metadata'
 import compactedMerge from 'utils/compacted-merge'
 
 // code_url is only used in a select few Kent C. Dodds lessons
@@ -88,24 +90,6 @@ async function loadLessonMetadataFromSanity(slug: string) {
     // Likely a 404 Not Found error
     console.log('Error fetching from Sanity: ', e)
 
-    return {}
-  }
-}
-
-// TODO: Move this into `src/utils/lesson-metadata.ts` and add tests.
-const deriveDataFromBaseValues = ({path}: {path: string}) => {
-  if (!isEmpty(path)) {
-    invariant(
-      path.startsWith('/'),
-      'Path value must begin with a forward slash (`/`).',
-    )
-
-    const http_url = `${process.env.NEXT_PUBLIC_DEPLOY_URL}${path}`
-    const lesson_view_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${path}/views`
-    const download_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${path}/signed_download`
-
-    return {http_url, lesson_view_url, download_url}
-  } else {
     return {}
   }
 }

--- a/src/utils/__tests__/lesson-metadata.test.ts
+++ b/src/utils/__tests__/lesson-metadata.test.ts
@@ -1,135 +1,137 @@
 import {LessonResource} from 'types'
 import {mergeLessonMetadata} from '../lesson-metadata'
 
-test('top-level data from Sanity overrides graphql', () => {
-  const graphqlMetadata = {
-    title: 'Ultimate React',
-    duration: 123,
-  } as LessonResource
-  const sanityMetadata = {
-    title: 'Xtreme React',
-    path: '/path/to/lesson',
-  } as LessonResource
+describe('mergeLessonMetadata()', () => {
+  test('top-level data from Sanity overrides graphql', () => {
+    const graphqlMetadata = {
+      title: 'Ultimate React',
+      duration: 123,
+    } as LessonResource
+    const sanityMetadata = {
+      title: 'Xtreme React',
+      path: '/path/to/lesson',
+    } as LessonResource
 
-  const expectedResult = {
-    title: 'Xtreme React',
-    duration: 123,
-    path: '/path/to/lesson',
-  }
+    const expectedResult = {
+      title: 'Xtreme React',
+      duration: 123,
+      path: '/path/to/lesson',
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
-})
+    expect(result).toEqual(expectedResult)
+  })
 
-test('Sanity tags override graphql tags when present', () => {
-  const graphqlMetadata = {
-    tags: [{name: 'Vue'}],
-  } as LessonResource
+  test('Sanity tags override graphql tags when present', () => {
+    const graphqlMetadata = {
+      tags: [{name: 'Vue'}],
+    } as LessonResource
 
-  const sanityMetadata = {
-    tags: [{name: 'React'}],
-  } as LessonResource
+    const sanityMetadata = {
+      tags: [{name: 'React'}],
+    } as LessonResource
 
-  const expectedResult = {
-    tags: [{name: 'React'}],
-  }
+    const expectedResult = {
+      tags: [{name: 'React'}],
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
-})
+    expect(result).toEqual(expectedResult)
+  })
 
-test('graphql tags override Sanity tags if Sanity tags are not present', () => {
-  const graphqlMetadata = {
-    tags: [{name: 'Vue'}],
-  } as LessonResource
+  test('graphql tags override Sanity tags if Sanity tags are not present', () => {
+    const graphqlMetadata = {
+      tags: [{name: 'Vue'}],
+    } as LessonResource
 
-  const sanityMetadata = {
-    tags: [] as Array<{}>,
-  } as LessonResource
+    const sanityMetadata = {
+      tags: [] as Array<{}>,
+    } as LessonResource
 
-  const expectedResult = {
-    tags: [{name: 'Vue'}],
-  }
+    const expectedResult = {
+      tags: [{name: 'Vue'}],
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
-})
+    expect(result).toEqual(expectedResult)
+  })
 
-test('Sanity instructor takes precedence to graphql instructor', () => {
-  const graphqlMetadata = {
-    instructor: {name: 'Zac Jones'},
-  } as LessonResource
+  test('Sanity instructor takes precedence to graphql instructor', () => {
+    const graphqlMetadata = {
+      instructor: {name: 'Zac Jones'},
+    } as LessonResource
 
-  const sanityMetadata = {
-    instructor: {name: 'Ian Jones'},
-  } as LessonResource
+    const sanityMetadata = {
+      instructor: {name: 'Ian Jones'},
+    } as LessonResource
 
-  const expectedResult = {
-    instructor: {name: 'Ian Jones'},
-  }
+    const expectedResult = {
+      instructor: {name: 'Ian Jones'},
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
-})
+    expect(result).toEqual(expectedResult)
+  })
 
-test('graphql instructor is used when Sanity instructor is not present', () => {
-  const graphqlMetadata = {
-    instructor: {name: 'Zac Jones'},
-  } as LessonResource
+  test('graphql instructor is used when Sanity instructor is not present', () => {
+    const graphqlMetadata = {
+      instructor: {name: 'Zac Jones'},
+    } as LessonResource
 
-  const sanityMetadata = {
-    instructor: {},
-  } as LessonResource
+    const sanityMetadata = {
+      instructor: {},
+    } as LessonResource
 
-  const expectedResult = {
-    instructor: {name: 'Zac Jones'},
-  }
+    const expectedResult = {
+      instructor: {name: 'Zac Jones'},
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
-})
+    expect(result).toEqual(expectedResult)
+  })
 
-test('Sanity collection takes precedence to graphql collection', () => {
-  const graphqlMetadata = {
-    collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
-  } as LessonResource
+  test('Sanity collection takes precedence to graphql collection', () => {
+    const graphqlMetadata = {
+      collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
+    } as LessonResource
 
-  // a collection needs to include some course metadata and a non-empty list of
-  // lessons to be considered present.
-  const sanityMetadata = {
-    collection: {title: 'Ultimate React Course', lessons: [1, 2, 3]},
-  } as LessonResource
+    // a collection needs to include some course metadata and a non-empty list of
+    // lessons to be considered present.
+    const sanityMetadata = {
+      collection: {title: 'Ultimate React Course', lessons: [1, 2, 3]},
+    } as LessonResource
 
-  const expectedResult = {
-    collection: {title: 'Ultimate React Course', lessons: [1, 2, 3]},
-  }
+    const expectedResult = {
+      collection: {title: 'Ultimate React Course', lessons: [1, 2, 3]},
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
-})
+    expect(result).toEqual(expectedResult)
+  })
 
-test('graphql collection is used if Sanity collection is not present', () => {
-  const graphqlMetadata = {
-    collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
-  } as LessonResource
+  test('graphql collection is used if Sanity collection is not present', () => {
+    const graphqlMetadata = {
+      collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
+    } as LessonResource
 
-  // a collection needs to include some course metadata and a non-empty list of
-  // lessons to be considered present.
-  const sanityMetadata = {
-    collection: {title: 'Ultimate React Course', lessons: [] as Array<{}>},
-  } as LessonResource
+    // a collection needs to include some course metadata and a non-empty list of
+    // lessons to be considered present.
+    const sanityMetadata = {
+      collection: {title: 'Ultimate React Course', lessons: [] as Array<{}>},
+    } as LessonResource
 
-  const expectedResult = {
-    collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
-  }
+    const expectedResult = {
+      collection: {title: 'Xtreme React Course', lessons: [4, 5, 6]},
+    }
 
-  const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
+    const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
-  expect(result).toEqual(expectedResult)
+    expect(result).toEqual(expectedResult)
+  })
 })

--- a/src/utils/__tests__/lesson-metadata.test.ts
+++ b/src/utils/__tests__/lesson-metadata.test.ts
@@ -160,8 +160,6 @@ describe('deriveDataFromBaseValues()', () => {
   test('it throws an error when there is no leading slash', () => {
     expect(() => {
       deriveDataFromBaseValues({path: 'lessons/some-slug'})
-    }).toThrow(
-      'Invariant failed: Path value must begin with a forward slash (`/`).',
-    )
+    }).toThrow(/Invariant failed/)
   })
 })

--- a/src/utils/__tests__/lesson-metadata.test.ts
+++ b/src/utils/__tests__/lesson-metadata.test.ts
@@ -1,5 +1,5 @@
 import {LessonResource} from 'types'
-import {mergeLessonMetadata} from '../lesson-metadata'
+import {mergeLessonMetadata, deriveDataFromBaseValues} from '../lesson-metadata'
 
 describe('mergeLessonMetadata()', () => {
   test('top-level data from Sanity overrides graphql', () => {
@@ -133,5 +133,35 @@ describe('mergeLessonMetadata()', () => {
     const result = mergeLessonMetadata(graphqlMetadata, sanityMetadata)
 
     expect(result).toEqual(expectedResult)
+  })
+})
+
+describe('deriveDataFromBaseValues()', () => {
+  test('it returns an empty object if path is blank', () => {
+    expect(deriveDataFromBaseValues({path: undefined})).toEqual({})
+  })
+
+  test('it returns URLs when path is set', () => {
+    const expectedResult = {
+      http_url: expect.stringContaining('/lessons/some-slug'),
+      lesson_view_url: expect.stringContaining(
+        '/api/v1/lessons/some-slug/views',
+      ),
+      download_url: expect.stringContaining(
+        '/api/v1/lessons/some-slug/signed_download',
+      ),
+    }
+
+    const result = deriveDataFromBaseValues({path: '/lessons/some-slug'})
+
+    expect(result).toMatchObject(expectedResult)
+  })
+
+  test('it throws an error when there is no leading slash', () => {
+    expect(() => {
+      deriveDataFromBaseValues({path: 'lessons/some-slug'})
+    }).toThrow(
+      'Invariant failed: Path value must begin with a forward slash (`/`).',
+    )
   })
 })

--- a/src/utils/lesson-metadata.ts
+++ b/src/utils/lesson-metadata.ts
@@ -1,6 +1,8 @@
 import {LessonResource} from 'types'
 import some from 'lodash/some'
+import isEmpty from 'lodash/isEmpty'
 import compactedMerge from 'utils/compacted-merge'
+import invariant from 'tiny-invariant'
 
 export const mergeLessonMetadata = (
   lessonMetadataFromGraphQL: LessonResource,
@@ -63,4 +65,21 @@ const collectionIsPresent = (collection: {lessons: any[] | undefined}) => {
   // if there are lessons and some collectionMetadata is present, then the
   // collection is considered present.
   return some(lessons) && some(collectionMetadata)
+}
+
+export const deriveDataFromBaseValues = ({path}: {path?: string}) => {
+  if (!isEmpty(path)) {
+    invariant(
+      path.startsWith('/'),
+      'Path value must begin with a forward slash (`/`).',
+    )
+
+    const http_url = `${process.env.NEXT_PUBLIC_DEPLOY_URL}${path}`
+    const lesson_view_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${path}/views`
+    const download_url = `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1${path}/signed_download`
+
+    return {http_url, lesson_view_url, download_url}
+  } else {
+    return {}
+  }
 }

--- a/src/utils/lesson-metadata.ts
+++ b/src/utils/lesson-metadata.ts
@@ -70,7 +70,7 @@ const collectionIsPresent = (collection: {lessons: any[] | undefined}) => {
 export const deriveDataFromBaseValues = ({path}: {path?: string}) => {
   if (!isEmpty(path)) {
     invariant(
-      path.startsWith('/'),
+      path?.startsWith('/'),
       'Path value must begin with a forward slash (`/`).',
     )
 


### PR DESCRIPTION
The `deriveDataFromBaseValues` function already caused one production error. This PR moves the function to a more apt module, improves the types a little, and adds test coverage.

- tests: wrap mergeLessonMetadata in describe block
- refactor: move and test the deriveData function
- types: handle potentially undefined path value

![derive](https://media2.giphy.com/media/pmG1YiQTVAIofdJYJw/giphy.gif?cid=d1fd59ab7qgss437ls46logxcgw62zdtxp397r25yb8rhwsj&rid=giphy.gif&ct=g)