### PR TITLE
build: add build script for dev w/o sitemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev-build": "yarn test:ci && next build",
     "prebuild": "yarn make-tags-sitemap",
-    "build": "yarn test:ci && next build",
+    "build": "yarn dev-build",
     "postbuild": "NODE_ENV=production next-sitemap",
     "build:style": "tailwind build src/styles/index.css -o src/styles/output.css",
     "start": "next start",


### PR DESCRIPTION
Whenever I run the `yarn build` command locally, I takes longer then it
needs to because it is generating a bunch of sitemap files and then
afterward I have to manually cleanup those sitemap files. This commit
adds a `dev-build` script that does just the testing and `next build`
without all the sitemap noise.

Meanwhile, this leaves the `build` script alone to continue doing what is expected in CI / Vercel.

![noise](https://media4.giphy.com/media/QFuBzoQdijNFztFEp6/giphy.gif?cid=d1fd59abhron3beyka7f0i1dxxqx1eov3ceas2cfaidd87it&rid=giphy.gif&ct=g)
