### PR TITLE
feat: add explicitly public Last Updated attr

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -30,8 +30,8 @@ const lessonQuery = groq`
   'repo_url': repoUrl,
   'code_url': codeUrl,
   'created_at': eggheadRailsCreatedAt,
-  'updated_at': eggheadRailsUpdatedAt,
-  'published_at': eggheadRailsPublishedAt,
+  'updated_at': displayedUpdatedAt,
+  'published_at': publishedAt,
   'instructor': collaborators[0]-> {
     ...(person-> {
       'full_name': name,

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -129,21 +129,21 @@ export default {
       type: 'url',
     },
     {
+      name: 'displayedUpdatedAt',
+      description: 'The last time this lesson was meaningfully updated',
+      title: 'Displayed Updated At',
+      type: 'date',
+    },
+    {
+      name: 'publishedAt',
+      description: 'The date this lesson was published',
+      title: 'Published At',
+      type: 'date',
+    },
+    {
       name: 'eggheadRailsCreatedAt',
       title: 'egghead Rails Created At',
       description: 'Date this lesson resource was created on egghead.io',
-      type: 'datetime',
-    },
-    {
-      name: 'eggheadRailsUpdatedAt',
-      title: 'egghead Rails Updated At',
-      description: 'Date this lesson resource last updated on egghead.io',
-      type: 'datetime',
-    },
-    {
-      name: 'eggheadRailsPublishedAt',
-      title: 'egghead Rails Published At',
-      description: 'Date this lesson resource was published on egghead.io',
       type: 'datetime',
     },
     {


### PR DESCRIPTION
With Sanity, we already have an underlying `_updatedAt` attribute on all
records. That is an internal value that is updated anytime we touch the
record. It's great for internal auditing, but not a value that we want
to display publicly to communicate meaningful updates to the lesson.

Instead, we had originally added an `eggheadRailsUpdatedAt` field as a
destination for syncing the `updated_at` field from egghead-rails. This
naming is off though. What we want this field to represent is a point in
time when the lesson was meaningfully updated which we can display to
the learner. Thus, `displayedUpdatedAt`.

When we import lessons from egghead-rails, we can initially seed that
attribute with whatever is in the egghead-rails `updated_at`. However,
from there, it is a field that can be manually updated by editors as
they see fit.

This commit also renames the `publishedAt` field along similar lines.

The `eggheadRailsCreatedAt` is left as named because that accurately
represents what value that field will contain. It will be synced from
egghead-rails and let you know when the lesson was actually created
instead of when the Sanity record was (much more recently) created.

![CleanShot 2022-08-14 at 13 28 51@2x](https://user-images.githubusercontent.com/694063/184550285-52e1091b-f2fb-40e8-a39c-513a60016c0b.png)

![display](https://media4.giphy.com/media/3ornjR6lXGBkS2H5Ti/giphy.gif?cid=d1fd59abibel1anaa1rh6uovkhzjgsqxgb5fkn303d2tzpgk&rid=giphy.gif&ct=g)
