### PR TITLE
fix: ref to videoResource.hlsUrl was typo'd

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -17,7 +17,7 @@ const lessonQuery = groq`
   description,
   resource->_type == 'videoResource' => {
     ...(resource-> {
-      'media_url': hslUrl,
+      'media_url': hlsUrl,
       'transcript': transcriptBody,
       'transcript_url': transcriptUrl,
       duration,
@@ -61,7 +61,7 @@ const lessonQuery = groq`
       title,
       'thumb_url': thumbnailUrl,
       resource->_type == 'videoResource' => {
-        'media_url': resource->hslUrl,
+        'media_url': resource->hlsUrl,
         duration,
       }
     }


### PR DESCRIPTION
I thought we had fixed this at one point, but those changes may have
been clobbered in a bad merge.

https://github.com/eggheadio/egghead-next/blob/42c22c89888d2abce9dea9f455cedf4182bc6dc2/studio/schemas/documents/videoResource.js#L27-L39

![hsl](https://media2.giphy.com/media/3ofT5HjUfjroajYCo8/giphy.gif?cid=d1fd59abw6krwnwo961rkb94pnfkr8ogerpg8tl4xtj7qrq1&rid=giphy.gif&ct=g)