### PR TITLE
fix: compact undefined values from thumbnailUrls

### DIFF
--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {GetServerSideProps} from 'next'
 import {useRouter} from 'next/router'
-import {filter, get, isEmpty} from 'lodash'
+import {filter, get, isEmpty, compact} from 'lodash'
 import queryString from 'query-string'
 import {useMachine} from '@xstate/react'
 import {Tab, TabList, TabPanel, TabPanels, Tabs} from '@reach/tabs'
@@ -482,7 +482,7 @@ const Lesson: React.FC<LessonProps> = ({
         name={title}
         description={removeMarkdown(description)}
         uploadDate={lesson?.created_at}
-        thumbnailUrls={[lesson?.thumb_url]}
+        thumbnailUrls={compact([lesson?.thumb_url])}
       />
       <div className={cx({'h-screen': isFullscreen})}>
         <div


### PR DESCRIPTION
We are getting alerts from the Google Search Console Team that some of
our Video Object metadata on lesson pages is rendering with invalid
thumbnailUrl. This was only happening for lessons that already didn't
have a thumb_url tied to them. Some shift in the way the lesson metadata
object was being built resulted in `"undefined"` ending up in that array
instead of `""`.

By compacting the array before it is passed as a prop to the next-seo
VideoJsonLd component, we can be sure that we aren't ending up with
invalid values.

More details in Roam: https://roamresearch.com/#/app/egghead/page/lfzRl5FLH

![thumb](https://media1.giphy.com/media/wk19wnRrhGKK4/giphy.gif?cid=d1fd59ab5wqc7ije9mkv62jpuruv6x9fuhats18mh3aebtg5&rid=giphy.gif&ct=g)
