### PR TITLE
feat: add icon_url to the GROQ lesson query

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -27,6 +27,7 @@ const lessonQuery = groq`
   'free_forever': isCommunityResource,
   'path': '/lessons/' + slug.current,
   'thumb_url': thumbnailUrl,
+  'icon_url': 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1567198446/og-image-assets/eggo.svg',
   'repo_url': repoUrl,
   'code_url': codeUrl,
   'created_at': eggheadRailsCreatedAt,

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -27,7 +27,7 @@ const lessonQuery = groq`
   'free_forever': isCommunityResource,
   'path': '/lessons/' + slug.current,
   'thumb_url': thumbnailUrl,
-  'icon_url': 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1567198446/og-image-assets/eggo.svg',
+  'icon_url': coalesce(softwareLibraries[0].library->image.url, 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1567198446/og-image-assets/eggo.svg'),
   'repo_url': repoUrl,
   'code_url': codeUrl,
   'created_at': eggheadRailsCreatedAt,
@@ -177,7 +177,6 @@ export async function loadLesson(
 //
 // - dash_url - not used
 // - staff_notes_url - not used
-// - icon_url - this is being used by the lesson page
 
 const loadLessonGraphQLQuery = /* GraphQL */ `
   query getLesson($slug: String!) {


### PR DESCRIPTION
The coalesce function (https://www.sanity.io/docs/groq-functions#80d6f2c07a20) supported by GROQ allows us to try to use the first software library icon, or if that is null, then fallback to the eggo default icon.

![coa](https://media2.giphy.com/media/xUySTQ6Ed5CVlxNgQ0/giphy.gif?cid=d1fd59abrlczjkawytsyn4jwul2y6lglv48w7prngdyl6dmu&rid=giphy.gif&ct=g)
