### PR TITLE
feat: Update size of jumbotron content

### DIFF
--- a/src/components/pages/home/jumbotron.tsx
+++ b/src/components/pages/home/jumbotron.tsx
@@ -9,10 +9,31 @@ const Jumbotron: React.FC<any> = ({data}) => {
     <ResourceLink location="jumbotron" path={resource.path} className="group">
       <header className="md:aspect-w-16 md:aspect-h-6 relative h-full rounded-b-lg text-white ">
         <div className="flex items-center justify-center relative z-10 md:pb-16 pb-32 md:px-0 px-5 md:pt-0 pt-10">
-          <div className="w-full max-w-screen-md flex md:flex-row flex-col items-center justify-center md:text-left text-center ">
+          <div className="w-full lg:max-w-screen-lg md:max-w-screen-sm flex md:flex-row flex-col items-center justify-center md:text-left text-center lg:pt-0 md:pt-10">
             <div
               aria-hidden
-              className="flex-shrink-0 relative flex items-center justify-center lg:max-w-none md:max-w-[220px] max-w-[180px] p-5"
+              className="hidden flex-shrink-0 relative lg:flex items-center justify-center p-5"
+            >
+              <Image
+                src={resource.image}
+                alt={resource.title}
+                width={360}
+                height={360}
+                quality={100}
+                loading="eager"
+                priority
+                className="group-hover:scale-95 group-hover:opacity-90 transition-all ease-in-out duration-300"
+              />
+              <div
+                aria-hidden
+                className="absolute flex items-center justify-center group-hover:opacity-100 opacity-0 group-hover:scale-100 scale-0 transition-all ease-in-out duration-300 w-10 h-10 rounded-full bg-white bg-opacity-80 shadow-smooth"
+              >
+                <PlayIcon className="w-4 text-black" />
+              </div>
+            </div>
+            <div
+              aria-hidden
+              className="lg:hidden flex flex-shrink-0 relative items-center justify-center p-5"
             >
               <Image
                 src={resource.image}
@@ -31,7 +52,7 @@ const Jumbotron: React.FC<any> = ({data}) => {
                 <PlayIcon className="w-4 text-black" />
               </div>
             </div>
-            <div className="md:pl-10 text-black">
+            <div className="md:pt-10 text-black">
               <p className="uppercase font-mono text-xs pb-1 opacity-80">
                 Fresh Course
               </p>


### PR DESCRIPTION
Updated the background of the featured course jumbotron in Sanity.

I also made the content of the jumbotron take up more space for all viewport sizes

![giant](https://media2.giphy.com/media/a61ByHFHefKni65HyK/giphy.gif?cid=01d288b0x6t18bn1gypoazoa3oc1htvjpfu7iszansa5o9r6&rid=giphy.gif&ct=g)

# New
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/518406/184963181-9de3a4bd-4dc3-4a02-a2e3-19bba4a7861d.png">
<img width="503" alt="image" src="https://user-images.githubusercontent.com/518406/184963270-16a594b8-8c93-4983-a413-3025fdf10ab0.png">

# Old
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/518406/184963314-b5fd62e6-a992-4c37-8a25-ccf93a2c60f5.png">
<img width="502" alt="image" src="https://user-images.githubusercontent.com/518406/184963340-f25b5389-275a-4069-8ec2-bed54ba6b144.png">
