### PR TITLE
fix: only remove nil values from metadata objects

### DIFF
--- a/src/utils/__tests__/compacted-merge.test.ts
+++ b/src/utils/__tests__/compacted-merge.test.ts
@@ -4,17 +4,21 @@ test('it can merge two objects together', () => {
   const secondaryObject = {
     title: 'Ignored Title',
     lesson_view_url: '/some/url',
+    thumb_url: '',
   }
 
   const primaryObject = {
     title: 'Actual Title',
     duration: 123,
+    count: 0,
   }
 
   const expectedResult = {
     title: 'Actual Title',
     lesson_view_url: '/some/url',
     duration: 123,
+    thumb_url: '',
+    count: 0,
   }
 
   const result = compactedMerge(secondaryObject, primaryObject)

--- a/src/utils/compacted-merge.ts
+++ b/src/utils/compacted-merge.ts
@@ -1,4 +1,5 @@
-import pickBy from 'lodash/pickBy'
+import omitBy from 'lodash/omitBy'
+import isNil from 'lodash/isNil'
 
 // A typical ES6 destructuring merge ({ ...obj1, ...obj2 }) will allow values
 // of `null` and `undefined` to override actual values. This compactedMerge
@@ -9,7 +10,11 @@ import pickBy from 'lodash/pickBy'
 // `lesson_view_url: '/some/url'` that it doesn't get overridden by the second
 // object having `lesson_view_url: undefined`.
 const compactedMerge = (obj1: any, obj2: any): any => {
-  return {...pickBy(obj1), ...pickBy(obj2)}
+  return {...removeNilValues(obj1), ...removeNilValues(obj2)}
+}
+
+const removeNilValues = (obj: any): any => {
+  return omitBy(obj, isNil)
 }
 
 export default compactedMerge


### PR DESCRIPTION
There was an error with the `thumbnailUrl` values being invalid for some
lessons. It was provisionally fixed in
https://github.com/eggheadio/egghead-next/pull/1171. However, it seemed
to me that it was only a partial fix. It didn't explain why we were
suddenly seeing this failure.

I now understand what originally surfaced the error and this PR fixes
it.

We introduced lodash's `_.pickBy(obj)` as a way of stripping out the
`null` and `undefined` key-value pairs in the metadata. However,
`pickBy` removes all things that aren't truthy. That includes `0` values
and `""` (empty string) values.

Before this change, we had a number of lessons return an empty string
for the `thumb_url` since nothing was set. But once it was being
stripped out, accessing the value from the object was suddenly resulting
in `undefined` instead of `""`.

This commit switches back to the `omitBy(obj, isNil)` to ensure that
exactly `null` and `undefined` are removed, and nothing else.

![empty](https://media4.giphy.com/media/26hkhPJ5hmdD87HYA/giphy.gif?cid=d1fd59ab6mqwyyiwaiydofqwr8ho26xszgalm1y0ys3p9x4y&rid=giphy.gif&ct=g)
