### PR TITLE
fix: link directly to `resources-by-:slug` path

### DIFF
--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -194,6 +194,8 @@ const Lesson: React.FC<LessonProps> = ({
     comments,
   } = lesson
 
+  const instructorPagePath = `/q/resources-by-${get(instructor, 'slug', '#')}`
+
   const nextLesson = useNextForCollection(collection, lesson.slug)
   const enhancedTranscript = useEnhancedTranscript(transcript_url)
   const transcriptAvailable = transcript || enhancedTranscript
@@ -588,9 +590,7 @@ const Lesson: React.FC<LessonProps> = ({
                 <div className="flex items-center justify-between w-full space-x-5 md:w-auto">
                   {instructor && (
                     <div className="flex items-center flex-shrink-0">
-                      <Link
-                        href={`/instructors/${get(instructor, 'slug', '#')}`}
-                      >
+                      <Link href={instructorPagePath}>
                         <a
                           onClick={() => {
                             track(`clicked view instructor`, {
@@ -616,13 +616,7 @@ const Lesson: React.FC<LessonProps> = ({
                       <div className="flex flex-col">
                         <span className="text-xs">Instructor</span>
                         {get(instructor, 'full_name') && (
-                          <Link
-                            href={`/instructors/${get(
-                              instructor,
-                              'slug',
-                              '#',
-                            )}`}
-                          >
+                          <Link href={instructorPagePath}>
                             <a
                               onClick={() => {
                                 track(`clicked view instructor`, {


### PR DESCRIPTION
We've been linking to the legacy path `/instructors/:slug` which should
be redirected by Next.js config. This, however, stopped working
recently. While I have not root-caused why the path redirect from a
`<Link>` isn't working, I have directly fixed the issue as reported by
updating the instructor path to the current one.

Issue: https://github.com/eggheadio/egghead-next/issues/1175

![link](https://media0.giphy.com/media/fe3NDdz8tl6Vwm4xbr/giphy.gif?cid=d1fd59ab1gzaq4yyhz77jtxwpafc94802nlf5obfwz6co5mu&rid=giphy.gif&ct=g)
