### PR TITLE
fix: grab duration off resource ref

### DIFF
--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -65,7 +65,7 @@ const lessonQuery = groq`
       'thumb_url': thumbnailUrl,
       resource->_type == 'videoResource' => {
         'media_url': resource->hlsUrl,
-        duration,
+        'duration': resource->duration,
       }
     }
   }

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -64,8 +64,10 @@ const lessonQuery = groq`
       title,
       'thumb_url': thumbnailUrl,
       resource->_type == 'videoResource' => {
-        'media_url': resource->hlsUrl,
-        'duration': resource->duration,
+        ...(resource-> {
+          'media_url': hlsUrl,
+          duration
+        })
       }
     }
   }


### PR DESCRIPTION
The `duration` is an attribute on the `videoResource`, so it needs to be
accessed off that ref. As is, it was trying to access it off the collection
and inevitably just getting `null`.

![reference](https://media0.giphy.com/media/tnYri4n2Frnig/giphy.gif?cid=d1fd59aby5m853xrs9k4mvnvo2v9dmu92cdfbs2htpt19eoc&rid=giphy.gif&ct=g)
