### PR TITLE
removed the text color of black for jumbotron

### DIFF
--- a/src/components/pages/home/jumbotron.tsx
+++ b/src/components/pages/home/jumbotron.tsx
@@ -52,7 +52,7 @@ const Jumbotron: React.FC<any> = ({data}) => {
                 <PlayIcon className="w-4 text-black" />
               </div>
             </div>
-            <div className="md:pt-10 text-black">
+            <div className="md:pt-10">
               <p className="uppercase font-mono text-xs pb-1 opacity-80">
                 Fresh Course
               </p>


### PR DESCRIPTION
I changed the color of the jumbotron back to white for the release of the Cache Supabase data at the Edge with Cloudflare Workers and KV Storage course. 

Old:
![Screen Shot 2022-08-19 at 8 22 50 AM](https://user-images.githubusercontent.com/26470581/185654389-4793bd7f-7c68-4731-aecd-a3d67fcc247b.png)

New: 
![Screen Shot 2022-08-19 at 8 22 41 AM](https://user-images.githubusercontent.com/26470581/185654439-f0ff5cfb-78c2-41b2-a002-ad12a7a81ef0.png)

![](https://media4.giphy.com/media/cnhiksPIkw5SRDylG0/giphy.gif?cid=5a38a5a2mwlojtkr5c5zvruhpayxjwvr5hls1isfxwtllg7g&rid=giphy.gif&ct=g)

