### PR TITLE
feat: add essential fields to Sanity course schema

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -69,8 +69,8 @@ export default {
     },
     {
       name: 'image',
-      description: 'Links to a full-sized primary image',
-      title: 'Image Url',
+      description: 'Links to a full-sized primary image/illustration',
+      title: 'Image/Illustration Url',
       type: 'url',
     },
     {
@@ -126,9 +126,31 @@ export default {
         list: [
           {title: 'Free', value: 'free'},
           {title: 'Pro', value: 'pro'},
+          {
+            title: 'Community Resource',
+            value: 'community-resource',
+            description: 'Free Forever',
+          },
         ],
         layout: 'radio',
       },
+      initialValue: 'pro',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      title: 'Search Indexing State',
+      description: 'Is this course ready to be indexed for search?',
+      name: 'searchIndexingState',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Hidden', value: 'hidden'},
+          {title: 'Indexed', value: 'indexed'},
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'hidden',
+      validation: (Rule) => Rule.required(),
     },
     {
       title: 'Duration (minutes)',


### PR DESCRIPTION
After @creeland and I walked through the Course page and what the other
course metadata queries are requesting, we updated the Course schema
with some additional essential fields.

- Illustration / Image (same thing)
- We combined the concept of _Community Resource_ into access-level
- Search Indexing State (hidden/indexed)

Beyond that we had already done a comprehensive job with the schema.

There are several fields that the `Resource` supports and which the GROQ query is currently fetching that we decided to disregard for now. Those include:
- essentialQuestions
- pairWithResources
- customOgImage
- features (first)
- prerequisites
- projects

Our rationale is that these can be easily added later on if there is demand for those. We want to err on the side of adding less rather than more to this `Course` schema.

More details behind all of this can be found here: https://roamresearch.com/#/app/egghead/page/rS6yS6uBM

![course](https://media2.giphy.com/media/BqmMllWNawKs0/giphy.gif?cid=d1fd59ab35hoo7oyf6qrhq1gmp8bieih4ngylswtvpidqsl9&rid=giphy.gif&ct=g)
