### PR TITLE
refactor: move illustration logic to course loader

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -80,6 +80,10 @@ export async function loadCourseMetadata(id: number) {
 
   const course = await sanityClient.fetch(courseQuery, params)
 
+  if (course?.illustration?.url) {
+    course['square_cover_480_url'] = course.illustration.url
+  }
+
   return course
 }
 

--- a/src/lib/playlists.ts
+++ b/src/lib/playlists.ts
@@ -290,16 +290,5 @@ export async function loadPlaylist(slug: string, token?: string) {
   const {playlist} = await graphQLClient.request(query, variables)
   const courseMeta = await loadCourseMetadata(playlist.id)
 
-  // This is a temporary hack in order to get an illustration up
-  // for Kent's course: https://egghead.io/courses/up-and-running-with-remix-b82b6bb6
-  // While image uploads are down
-  if (courseMeta?.illustration) {
-    return {
-      ...playlist,
-      ...courseMeta,
-      square_cover_480_url: courseMeta?.illustration.url,
-    }
-  }
-
   return {...playlist, ...courseMeta}
 }


### PR DESCRIPTION
Came up with this solution in a discussion with @Creeland 🙌 

If the Sanity object includes an illustration URL, then we want to use
that as the `square_cover_480_url`. To get that to take precedence over
the one coming from graphql, we need to include it in the GROQ course
metadata. This includes it when present.

![square](https://media2.giphy.com/media/3oEhmNufeTDUzGzftm/giphy.gif?cid=d1fd59abdyp31irhvpxidp74sot2b1txmxihiu91a29xwsc7&rid=giphy.gif&ct=g)
