### PR TITLE
feat: add sharedId to course documents in Sanity

### DIFF
--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -56,6 +56,7 @@ type SanityCourse = {
   _type: 'course'
   title: string
   slug: SanitySlug
+  sharedId: string
   collaborators: SanityReferenceArray
   lessons: SanityReferenceArray
   softwareLibraries: SanitySoftwareLibrary[]
@@ -94,6 +95,7 @@ async function formatSanityMutationForLessons(
     _type: 'course',
     title,
     slug: {current: courseSlug},
+    sharedId: nanoid(),
     lessons: [],
     collaborators: [],
     softwareLibraries: [],

--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -1,3 +1,5 @@
+import {nanoid} from 'nanoid'
+
 export default {
   name: 'course',
   type: 'document',
@@ -20,6 +22,13 @@ export default {
         source: 'title',
         maxLength: 96,
       },
+    },
+    {
+      name: 'sharedId',
+      type: 'string',
+      title: 'Shared ID',
+      validation: (Rule) => Rule.required(),
+      initialValue: () => nanoid(),
     },
     {
       name: 'productionProcessState',


### PR DESCRIPTION
These will be used as a universal identifier between egghead-next/Sanity
and egghead-rails.

More details in Roam: https://roamresearch.com/#/app/egghead/page/Xqn387ZgV

![universal](https://media0.giphy.com/media/KBbEFZPNEqqp87NchL/giphy.gif?cid=d1fd59abmuyvy2us2y8ok2otjjppbeedf7207gk0uogvkwfd&rid=giphy.gif&ct=g)
