### PR TITLE
Repo URL and Description metadata fields in /upload form

### DIFF
--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -10,6 +10,8 @@ import client from '@sanity/client'
 
 type LessonData = {
   title: string
+  description?: string
+  repoUrl?: string
   fileMetadata: {
     fileName: string
     signedUrl: string
@@ -55,6 +57,8 @@ type SanitySoftwareLibrary = {
 type SanityCourse = {
   _type: 'course'
   title: string
+  description?: string
+  repoUrl?: string
   slug: SanitySlug
   sharedId: string
   collaborators: SanityReferenceArray
@@ -87,13 +91,21 @@ async function formatSanityMutationForLessons(
   let sanityLessons: SanityLesson[] = []
   let sanityResources: SanityVideoResource[] = []
 
-  const {title, collaboratorId, topicIds} = course
+  const {
+    title,
+    description = '',
+    repoUrl = '',
+    collaboratorId,
+    topicIds,
+  } = course
 
   const courseSlug = slugify(title.toLowerCase(), {remove: /[*+~.()'"!:@]/g})
 
   let sanityCourse: SanityCourse = {
     _type: 'course',
     title,
+    repoUrl,
+    description,
     slug: {current: courseSlug},
     sharedId: nanoid(),
     lessons: [],

--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -44,6 +44,8 @@ type SanityLesson = {
   _type: 'lesson'
   _id: string
   title: string
+  description?: string
+  repoUrl?: string
   slug: SanitySlug
   resource: SanityReference
 }
@@ -57,8 +59,6 @@ type SanitySoftwareLibrary = {
 type SanityCourse = {
   _type: 'course'
   title: string
-  description?: string
-  repoUrl?: string
   slug: SanitySlug
   sharedId: string
   collaborators: SanityReferenceArray
@@ -104,8 +104,6 @@ async function formatSanityMutationForLessons(
   let sanityCourse: SanityCourse = {
     _type: 'course',
     title,
-    repoUrl,
-    description,
     slug: {current: courseSlug},
     sharedId: nanoid(),
     lessons: [],
@@ -159,11 +157,14 @@ async function formatSanityMutationForLessons(
         `${topics[0] || ''} ${lesson.title}`.toLowerCase(),
         {remove: /[*+~.()'"!:@]/g},
       )
+      const {description = '', repoUrl = ''} = lesson
 
       sanityLessons.push({
         _id: lessonId,
         _type: 'lesson',
         title: lesson.title,
+        description,
+        repoUrl,
         slug: {current: lessonSlug},
         resource: {
           _type: 'reference',

--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -91,13 +91,7 @@ async function formatSanityMutationForLessons(
   let sanityLessons: SanityLesson[] = []
   let sanityResources: SanityVideoResource[] = []
 
-  const {
-    title,
-    description = '',
-    repoUrl = '',
-    collaboratorId,
-    topicIds,
-  } = course
+  const {title, collaboratorId, topicIds} = course
 
   const courseSlug = slugify(title.toLowerCase(), {remove: /[*+~.()'"!:@]/g})
 

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -30,8 +30,6 @@ type UploadedFile = {
 
 type LessonMetadata = {
   title: string
-  description?: string
-  repoUrl?: string
   fileMetadata: UploadedFile
 }
 
@@ -98,6 +96,8 @@ const UploadWrapper = ({
   const initialValues: FormProps = {
     course: {
       title: '',
+      description: '',
+      repoUrl: '',
       collaboratorId: undefined,
       topicIds: [],
     },
@@ -175,8 +175,6 @@ const Upload: React.FC<
       if (existingLesson) {
         return {
           title: existingLesson.title,
-          description: existingLesson.description,
-          repoUrl: existingLesson.repoUrl,
           fileMetadata: {
             ...existingLesson.fileMetadata,
             signedUrl: existingLesson.fileMetadata.signedUrl || file.signedUrl,
@@ -185,7 +183,6 @@ const Upload: React.FC<
       } else {
         return {
           title: file.file.name,
-
           fileMetadata: {
             fileName: file.file.name,
             signedUrl: file.signedUrl,
@@ -194,7 +191,7 @@ const Upload: React.FC<
       }
     })
     setFieldValue('lessons', updatedLessons)
-  }, [fileUploadState.files, setFieldValue, values.lessons])
+  }, [fileUploadState.files, setFieldValue])
 
   const noAttachedFiles = fileUploadState.files.length === 0
   // incomplete if video uploads are still being processed
@@ -234,13 +231,28 @@ const Upload: React.FC<
               htmlFor="course-name"
               className="block text-sm font-medium text-gray-700"
             >
-              Course Name
+              Course Name*
             </label>
             <div className="mt-1">
               <Field
                 name="course.title"
                 type="text"
                 required
+                className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Description
+            </label>
+            <div className="mt-1">
+              <Field
+                name="course.description"
+                as="textarea"
                 className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
               />
             </div>
@@ -306,6 +318,21 @@ const Upload: React.FC<
               )}
             </select>
           </div>
+          <div>
+            <label
+              htmlFor="course-name"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Github Link
+            </label>
+            <div className="mt-1">
+              <Field
+                name="course.repoUrl"
+                type="text"
+                className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              />
+            </div>
+          </div>
           <div className="space-y-1">
             <label className="block text-sm font-medium text-gray-700">
               Video Files
@@ -361,27 +388,6 @@ const Upload: React.FC<
                 <Field
                   className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
                   name={`lessons.${i}.title`}
-                />
-                <label
-                  htmlFor={`lessons.${i}.description`}
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Description
-                </label>
-                <Field
-                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                  name={`lessons.${i}.description`}
-                  as="textarea"
-                />
-                <label
-                  htmlFor={`lessons.${i}.repoUrl`}
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Github Repository Link
-                </label>
-                <Field
-                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                  name={`lessons.${i}.repoUrl`}
                 />
                 <p className="mt-2 text-center text-sm text-gray-600">
                   Signed URL: {lesson.fileMetadata.signedUrl || 'processing...'}

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -354,8 +354,29 @@ const Upload: React.FC<
                   </span>
                 </label>
                 <Field
-                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
                   name={`lessons.${i}.title`}
+                />
+                <label
+                  htmlFor={`lessons.${i}.description`}
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Description
+                </label>
+                <Field
+                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  name={`lessons.${i}.description`}
+                  as="textarea"
+                />
+                <label
+                  htmlFor={`lessons.${i}.repoUrl`}
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Github Repository Link
+                </label>
+                <Field
+                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  name={`lessons.${i}.repoUrl`}
                 />
                 <p className="mt-2 text-center text-sm text-gray-600">
                   Signed URL: {lesson.fileMetadata.signedUrl || 'processing...'}

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -175,7 +175,7 @@ const Upload: React.FC<
       if (existingLesson) {
         return {
           title: existingLesson.title,
-          description: existingLesson.title,
+          description: existingLesson.description,
           repoUrl: existingLesson.repoUrl,
           fileMetadata: {
             ...existingLesson.fileMetadata,

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -30,8 +30,8 @@ type UploadedFile = {
 
 type LessonMetadata = {
   title: string
-  description: string
-  repoUrl: string
+  description?: string
+  repoUrl?: string
   fileMetadata: UploadedFile
 }
 
@@ -185,6 +185,7 @@ const Upload: React.FC<
       } else {
         return {
           title: file.file.name,
+
           fileMetadata: {
             fileName: file.file.name,
             signedUrl: file.signedUrl,

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -30,6 +30,8 @@ type UploadedFile = {
 
 type LessonMetadata = {
   title: string
+  description?: string
+  repoUrl?: string
   fileMetadata: UploadedFile
 }
 
@@ -96,8 +98,6 @@ const UploadWrapper = ({
   const initialValues: FormProps = {
     course: {
       title: '',
-      description: '',
-      repoUrl: '',
       collaboratorId: undefined,
       topicIds: [],
     },
@@ -175,6 +175,8 @@ const Upload: React.FC<
       if (existingLesson) {
         return {
           title: existingLesson.title,
+          description: existingLesson.title,
+          repoUrl: existingLesson.repoUrl,
           fileMetadata: {
             ...existingLesson.fileMetadata,
             signedUrl: existingLesson.fileMetadata.signedUrl || file.signedUrl,
@@ -183,6 +185,8 @@ const Upload: React.FC<
       } else {
         return {
           title: file.file.name,
+          description: '',
+          repoUrl: '',
           fileMetadata: {
             fileName: file.file.name,
             signedUrl: file.signedUrl,
@@ -238,21 +242,6 @@ const Upload: React.FC<
                 name="course.title"
                 type="text"
                 required
-                className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
-            </div>
-          </div>
-          <div>
-            <label
-              htmlFor="description"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Description
-            </label>
-            <div className="mt-1">
-              <Field
-                name="course.description"
-                as="textarea"
                 className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
               />
             </div>
@@ -318,21 +307,6 @@ const Upload: React.FC<
               )}
             </select>
           </div>
-          <div>
-            <label
-              htmlFor="course-name"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Github Link
-            </label>
-            <div className="mt-1">
-              <Field
-                name="course.repoUrl"
-                type="text"
-                className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
-            </div>
-          </div>
           <div className="space-y-1">
             <label className="block text-sm font-medium text-gray-700">
               Video Files
@@ -388,6 +362,27 @@ const Upload: React.FC<
                 <Field
                   className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
                   name={`lessons.${i}.title`}
+                />
+                <label
+                  htmlFor={`lessons.${i}.description`}
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Description
+                </label>
+                <Field
+                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  name={`lessons.${i}.description`}
+                  as="textarea"
+                />
+                <label
+                  htmlFor={`lessons.${i}.repoUrl`}
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Repo URL
+                </label>
+                <Field
+                  className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  name={`lessons.${i}.repoUrl`}
                 />
                 <p className="mt-2 text-center text-sm text-gray-600">
                   Signed URL: {lesson.fileMetadata.signedUrl || 'processing...'}

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -30,6 +30,8 @@ type UploadedFile = {
 
 type LessonMetadata = {
   title: string
+  description: string
+  repoUrl: string
   fileMetadata: UploadedFile
 }
 
@@ -173,6 +175,8 @@ const Upload: React.FC<
       if (existingLesson) {
         return {
           title: existingLesson.title,
+          description: existingLesson.description,
+          repoUrl: existingLesson.repoUrl,
           fileMetadata: {
             ...existingLesson.fileMetadata,
             signedUrl: existingLesson.fileMetadata.signedUrl || file.signedUrl,
@@ -189,7 +193,7 @@ const Upload: React.FC<
       }
     })
     setFieldValue('lessons', updatedLessons)
-  }, [fileUploadState.files, setFieldValue])
+  }, [fileUploadState.files, setFieldValue, values.lessons])
 
   const noAttachedFiles = fileUploadState.files.length === 0
   // incomplete if video uploads are still being processed

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,4 +154,6 @@ export type CourseData = {
   title: string
   collaboratorId?: string
   topicIds: string[]
+  description?: string
+  repoUrl?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,4 @@ export type CourseData = {
   title: string
   collaboratorId?: string
   topicIds: string[]
-  description?: string
-  repoUrl?: string
 }

--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -84,13 +84,6 @@ export default {
       type: 'url',
     },
     {
-      name: 'repoUrl',
-      description:
-        'A link to the Github repository where the course project is located',
-      title: 'Repo URL',
-      type: 'url',
-    },
-    {
       name: 'softwareLibraries',
       description: 'Versioned Software Libraries',
       title: 'NPM or other Dependencies',

--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-anonymous-default-export */
 import {nanoid} from 'nanoid'
 
 export default {
@@ -80,6 +81,13 @@ export default {
       name: 'image',
       description: 'Links to a full-sized primary image/illustration',
       title: 'Image/Illustration Url',
+      type: 'url',
+    },
+    {
+      name: 'repoUrl',
+      description:
+        'A link to the Github repository where the course project is located',
+      title: 'Repo URL',
       type: 'url',
     },
     {

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-anonymous-default-export */
 export default {
   name: 'lesson',
   type: 'document',
@@ -53,6 +54,13 @@ export default {
       title: 'Description',
       description:
         'This can be used to provide a short description of the lesson.',
+    },
+    {
+      name: 'repoUrl',
+      type: 'url',
+      title: 'Github Repository Url',
+      description:
+        "A link to the Github repository where the lesson's code is hosted",
     },
     {
       name: 'softwareLibraries',

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -127,11 +127,6 @@ export default {
       type: 'url',
     },
     {
-      name: 'repoUrl',
-      title: 'Repo URL',
-      type: 'url',
-    },
-    {
       name: 'codeUrl',
       title: 'Code URL',
       type: 'url',


### PR DESCRIPTION
During a test run of the course builder, editors noted that they wouldn't be able to add descriptions and repo urls to lessons on creation.

This PR adds these fields to the lessons in the form, saving editors time since they won't have to immediately navigate to the Sanity studio and add this data to each lesson document in the course.

![image](https://user-images.githubusercontent.com/518406/186695547-334d6514-0fe6-421e-9c81-55bbcf2b3aeb.png)


![metaverse](https://media2.giphy.com/media/RvEgWBaBzjlekojOb6/giphy.gif?cid=01d288b0h60y0tr7wgwvsryrqmh7csll4nzo6hx52k8kwswl&rid=giphy.gif&ct=g)
