### PR TITLE
feat: combine community resource into access state

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -222,6 +222,10 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
     tags: railsTags = [],
   } = course
 
+  const communityResource = ['free', 'community-resource'].includes(
+    access_state,
+  )
+
   const sanityTagsPresent = () => {
     return sanityTags.length > 0
   }
@@ -436,7 +440,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
               {access_state && (
                 <div
                   className={`${
-                    access_state === 'free' ? 'bg-orange-500' : 'bg-blue-500'
+                    communityResource ? 'bg-orange-500' : 'bg-blue-500'
                   } text-white w-12 items-center text-center py-1 rounded-full uppercase font-bold my-2 text-xs mx-auto md:m-0 md:mb-2`}
                 >
                   {access_state}
@@ -647,7 +651,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
               <div className="block pt-5 md:hidden">
                 <CourseProjectCard courseProject={courseProject} />
 
-                {get(course, 'access_state') === 'free' && (
+                {communityResource && (
                   <div className="p-4 my-8 border border-gray-100 rounded-md bg-gray-50 dark:border-gray-800 dark:bg-gray-800">
                     <CommunityResource type="course" />
                   </div>
@@ -767,7 +771,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
 
               <CourseProjectCard courseProject={courseProject} />
 
-              {get(course, 'access_state') === 'free' && (
+              {communityResource && (
                 <div className="p-4 my-8 border border-gray-100 rounded-md bg-gray-50 dark:border-gray-800 dark:bg-gray-800">
                   <CommunityResource type="course" />
                 </div>

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -107,14 +107,14 @@ export default {
         list: [
           {title: 'Free', value: 'free'},
           {title: 'Pro', value: 'pro'},
+          {
+            title: 'Community Resource',
+            value: 'community-resource',
+            description: 'Free Forever',
+          },
         ],
         layout: 'radio',
       },
-    },
-    {
-      name: 'isCommunityResource',
-      title: 'Community Resource?',
-      type: 'boolean',
     },
     {
       name: 'thumbnailUrl',


### PR DESCRIPTION
- feat: Community Resource is an Access Level option

This way we can mark a Lesson (as well as a Course) as either `Pro`,
`Free`, or `Community Resource` ("Free Forever"). Essentially use an
enum rather than several booleans.

- feat: check free & community resource access state

Forward-compatible way of checking if the course is a free Community
Resource and if so, that we should display Community Resource messaging
on the page.

Forward-compatible because the Sanity Studio options for access-level on
a course is Pro / Free / Community Resource. If it is one of the
latter two, then we want to display it as a Community Resource.
Eventually, we can update the display logic to differentiate between
(temporarily) Free content and Community Resource (free-forever)
content.

![community](https://media2.giphy.com/media/YcMs3OGd89Pxu/giphy.gif?cid=d1fd59abwpb6nql5455k24dyt5wsv8lqryeahmymuyzz5x5u&rid=giphy.gif&ct=g)
