### PR TITLE
feat: add list of Related Content to course schema

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -172,7 +172,7 @@ export default {
       name: 'related',
       description:
         'Any content that pairs well with this course (for now just Courses and Resources, but could be Articles, Podcasts, etc.).',
-      title: 'Related Content',
+      title: 'Related Resources',
       type: 'array',
       of: [
         {

--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -168,5 +168,18 @@ export default {
       name: 'durationInMinutes',
       type: 'number',
     },
+    {
+      name: 'related',
+      description: 'Stuff that pairs well with this course. Watch next?',
+      title: 'Related Courses',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          title: 'Course/Resource Refs',
+          to: [{type: 'resource'}, {type: 'course'}],
+        },
+      ],
+    },
   ],
 }

--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -170,8 +170,9 @@ export default {
     },
     {
       name: 'related',
-      description: 'Stuff that pairs well with this course. Watch next?',
-      title: 'Related Courses',
+      description:
+        'Any content that pairs well with this course (for now just Courses and Resources, but could be Articles, Podcasts, etc.).',
+      title: 'Related Content',
       type: 'array',
       of: [
         {


### PR DESCRIPTION
This allows us to tag a Course with _Related Content_ which for now is `Course` and `Resource` documents but could eventually include content like Articles, Podcasts, and even individual Lessons.

Roam: https://roamresearch.com/#/app/egghead/page/mruiUHoQP

<img width="893" alt="CleanShot 2022-08-31 at 11 54 20@2x" src="https://user-images.githubusercontent.com/694063/187735678-ba4f7b87-d0f7-4c4f-a866-ab5cd4e389c5.png">


![related](https://media1.giphy.com/media/jDeXrgeN1WysBaOCzU/giphy.gif?cid=d1fd59ab6jlaahximskn0xmy6jw5alf0bdyp54jvc12u7umj&rid=giphy.gif&ct=g)
