### PR TITLE
feat: adds first course software library to lesson

### DIFF
--- a/src/pages/api/sanity/lessons/create.ts
+++ b/src/pages/api/sanity/lessons/create.ts
@@ -36,6 +36,7 @@ type SanityLesson = {
   title: string
   description?: string
   repoUrl?: string
+  softwareLibraries: SanitySoftwareLibrary[]
   slug: SanitySlug
   resource: SanityReference
 }
@@ -163,6 +164,8 @@ async function formatSanityMutationForLessons(
       )
       const {description = '', repoUrl = ''} = lesson
 
+      const topicKey = await nanoid()
+
       sanityLessons.push({
         _id: lessonId,
         _type: 'lesson',
@@ -174,6 +177,16 @@ async function formatSanityMutationForLessons(
           _type: 'reference',
           _ref: videoId,
         },
+        softwareLibraries: [
+          {
+            _type: 'versioned-software-library',
+            _key: topicKey,
+            library: {
+              _type: 'reference',
+              _ref: topicIds[0],
+            },
+          },
+        ],
       })
 
       sanityCourse.lessons.push({


### PR DESCRIPTION
Small PR that adds a course's primary softwareLibrary to each lesson. 

> "80% of the time" the tag for the Course is what all the Lessons will end up being tagged with. So this tag is safe to generally apply to each of the lessons. The publisher can change this for individual lessons on an as-needed basis in Sanity
- [Test-Run Roam Notes](https://roamresearch.com/#/app/egghead/page/wanWMtJ5k)

![library](https://media0.giphy.com/media/3o85xpxuULZ1Svqizu/giphy.gif?cid=01d288b0m9ptgrep3ew4hb2c9yvq7zqxlup9s1k0awe6c6sh&rid=giphy.gif&ct=g)