### PR TITLE
feat: free is free, remove community resource option

### DIFF
--- a/studio/schemas/documents/course.js
+++ b/studio/schemas/documents/course.js
@@ -136,11 +136,6 @@ export default {
         list: [
           {title: 'Free', value: 'free'},
           {title: 'Pro', value: 'pro'},
-          {
-            title: 'Community Resource',
-            value: 'community-resource',
-            description: 'Free Forever',
-          },
         ],
         layout: 'radio',
       },

--- a/studio/schemas/documents/lesson.js
+++ b/studio/schemas/documents/lesson.js
@@ -112,11 +112,6 @@ export default {
       },
     },
     {
-      name: 'isCommunityResource',
-      title: 'Community Resource?',
-      type: 'boolean',
-    },
-    {
       name: 'thumbnailUrl',
       title: 'Thumbnail URL',
       type: 'url',


### PR DESCRIPTION
- The only distinction to make is whether a Course / Lesson is `free` to access or requires `pro` membership.
- There is no distinction we want to make between a temporarily free resource and a 'Community Resource'.

Roam: https://roamresearch.com/#/app/egghead/page/vdcdtaEDj

![free is free](https://media0.giphy.com/media/5wWf7GMbT1ZUGTDdTqM/giphy.gif?cid=d1fd59ab1yn8b6q4zs26xs1jt3v4dhav4ppcows5zu1rx75x&rid=giphy.gif&ct=g)
