### PR TITLE
Switch mixpanel tracking logic to use interval instead of amount

### DIFF
--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -11,20 +11,19 @@ function stripeToMixpanelDataConverter(stripeDate: number) {
   return date.toISOString()
 }
 
+type PlanInterval = 'month' | 'year' | 'quarter'
+
 function checkForUpgrade(
-  previousPlanInterval: string,
-  newPlanInterval: string,
+  previousPlanInterval: PlanInterval,
+  newPlanInterval: PlanInterval,
 ) {
-  if (previousPlanInterval === 'month') return true
-  if (previousPlanInterval === 'year') return false
-  if (previousPlanInterval === 'quarter') {
-    if (newPlanInterval === 'year') {
-      return true
-    } else {
-      return false
-    }
+  const previousPlanIntervalUpgrades = {
+    month: true,
+    year: false,
+    quarter: newPlanInterval === 'year',
   }
-  return false
+
+  return previousPlanIntervalUpgrades[previousPlanInterval] ?? false
 }
 
 async function getCIO(email: string) {


### PR DESCRIPTION
@nicollguarnizo and I were digging around in our analytics and ended up going through the subscription purchase to upgrade flow.

We noticed that the object that stripe sends back doesn't include any amounts and has those set to null or they don't exist. 

For example, the `previous_attributes.plan.amount` doesn't exist.
```json
"previous_attributes": {
    ...
    "plan": {
      "id": "price_1IJSQ12nImeJXwdJ9WyUxdBZ",
      "created": 1613000905,
      "interval": "month",
      ...
    }
  }
```
As well as the current plans `items.data[0].plan?.amount` is set to `null`.
```json
    "items": {
      "object": "list",
      "data": [
        {
          "id": "si_MLzwOpt9msxUAA",
          "object": "subscription_item",
          "billing_thresholds": null,
          "created": 1662056237,
          "metadata": {
          },
          "plan": {
            "id": "price_1IJSO22nImeJXwdJHKrb5j2I",
            "object": "plan",
            "active": true,
            "aggregate_usage": null,
            "amount": null,     <-----
            ...
          },
      }],
      ...
    },
```
This forces the webhook to send `Subscription Downgrade` events because `0 < 0` is returning false.

This PR switches the logic to check the interval that is set. The options we have are `month`, `quarter`, and `year`. If `month` is the previous attribute we know we have an upgrade. If `year` is the previous attribute we know we have a downgrade. If `quarter` is the previous attribute we check current attribute for `month` or `year` and downgrade/upgrade accordingly.

The logic is not pretty.



![it works](https://media.giphy.com/media/l3UcA1HpL5kLuiWOc/giphy.gif)