### PR TITLE
fix: update cookie that is incremented for anon viewing

### DIFF
--- a/src/components/EggheadPlayer/use-egghead-player.ts
+++ b/src/components/EggheadPlayer/use-egghead-player.ts
@@ -114,13 +114,12 @@ const onProgress = async (
   }
 }
 
-let emailCaptureCookie: any = {
-  watchCount: 0,
-}
+let emailCaptureCookie: number = 0
 
-const setEmailCaptureCookie = (captureCookie = {}) => {
-  cookies.set('egghead-email', captureCookie)
-  emailCaptureCookie = cookies.get('egghead-email')
+const setEmailCaptureCookie = (captureCookie = 0) => {
+  console.log(captureCookie)
+  cookies.set('egghead-watch-count', captureCookie)
+  emailCaptureCookie = cookies.get('egghead-watch-count')
 }
 
 const getOrCreateLessonView = async (
@@ -191,10 +190,7 @@ const onEnded = async (lesson: {
   slug: any
   tags: any[]
 }) => {
-  setEmailCaptureCookie({
-    ...emailCaptureCookie,
-    watchCount: emailCaptureCookie.watchCount + 1,
-  })
+  setEmailCaptureCookie(emailCaptureCookie + 1)
 
   if (lesson.lesson_view_url) {
     return await onComplete(lesson)


### PR DESCRIPTION
The `Lesson` component is watching `egghead-watch-count` cookie to be incremented to 4 before showing the 'create an account to watch more' lesson banner. 

We are currently incrementing `egghead-email` cookie with a `watchCount` property. This PR updates the logic to increment the `egghead-watch-count` cookie on lesson completion.

Demo of the current behavior: 

https://www.loom.com/share/6418e9acd9784e6caa60d33c38341309

![dancing skeleton](https://media.giphy.com/media/okfvUCpgArv3y/giphy.gif)