### PR TITLE
Up Next overlay refactoring

### DIFF
--- a/src/components/pages/lessons/overlay/email-capture-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/email-capture-cta-overlay.tsx
@@ -2,6 +2,7 @@ import React, {FunctionComponent} from 'react'
 import LoginForm from 'pages/login'
 import {track} from 'utils/analytics'
 import {LessonResource} from 'types'
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
 type CreateAccountCTAProps = {
   lesson: LessonResource
@@ -15,46 +16,49 @@ const EmailCaptureCtaOverlay: FunctionComponent<CreateAccountCTAProps> = ({
   const {collection} = lesson
 
   return (
-    <section className="flex flex-col items-center justify-center p-4">
-      <LoginForm
-        image={<></>}
-        className="w-full mx-auto flex flex-col items-center justify-center text-white"
-        label="Email address"
-        formClassName="max-w-xs md:max-w-sm mx-auto w-full"
-        button="Finish Watching this Course"
-        track={() => {
-          const {slug} = lesson
-          track('submitted email', {
-            lesson: slug,
-            technology,
-            location: 'lesson overlay',
-          })
-        }}
-      >
-        <div className="text-center">
-          {collection ? (
-            <h1 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
-              Ready to finish{' '}
-              <strong className="font-bold">{collection.title}</strong>?
-            </h1>
-          ) : (
-            <h1 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
-              Unlock this free lesson!
-            </h1>
-          )}
+    <OverlayWrapper>
+      <section className="flex flex-col items-center justify-center p-4">
+        <LoginForm
+          image={<></>}
+          className="w-full mx-auto flex flex-col items-center justify-center text-white"
+          label="Email address"
+          formClassName="max-w-xs md:max-w-sm mx-auto w-full"
+          button="Finish Watching this Course"
+          track={() => {
+            const {slug} = lesson
+            track('submitted email', {
+              lesson: slug,
+              technology,
+              location: 'lesson overlay',
+            })
+          }}
+        >
+          <div className="text-center">
+            {collection ? (
+              <h1 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
+                Ready to finish{' '}
+                <strong className="font-bold">{collection.title}</strong>?
+              </h1>
+            ) : (
+              <h1 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
+                Unlock this free lesson!
+              </h1>
+            )}
 
-          <h2 className="pt-4 text-lg leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
-            This lesson (and hundreds more!) by awesome instructors like <br />
-            {lesson.instructor.full_name} are{' '}
-            <strong className="font-bold">free to watch</strong> with your
-            egghead account.
-          </h2>
-          <p className="font-normal text-blue-300 text-base sm:text-md lg:text-base xl:text-md mt-4">
-            Enter your email to unlock this free lesson.
-          </p>
-        </div>
-      </LoginForm>
-    </section>
+            <h2 className="pt-4 text-lg leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
+              This lesson (and hundreds more!) by awesome instructors like{' '}
+              <br />
+              {lesson.instructor.full_name} are{' '}
+              <strong className="font-bold">free to watch</strong> with your
+              egghead account.
+            </h2>
+            <p className="font-normal text-blue-300 text-base sm:text-md lg:text-base xl:text-md mt-4">
+              Enter your email to unlock this free lesson.
+            </p>
+          </div>
+        </LoginForm>
+      </section>
+    </OverlayWrapper>
   )
 }
 

--- a/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/go-pro-cta-overlay.tsx
@@ -21,6 +21,7 @@ import Spinner from 'components/spinner'
 import ConfirmMembership from './confirm-membership'
 import {useRouter} from 'next/router'
 import noop from 'utils/noop'
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
 type JoinCTAProps = {
   lesson: LessonResource
@@ -294,17 +295,19 @@ const OverlayParent: FunctionComponent<JoinCTAProps> = ({
 
   const {session_id} = query
 
-  if (session_id) {
-    return (
-      <ConfirmMembership
-        lesson={lesson}
-        sessionId={session_id as string}
-        viewLesson={viewLesson}
-      />
-    )
-  } else {
-    return <GoProCtaOverlay lesson={lesson} />
-  }
+  return (
+    <OverlayWrapper>
+      {session_id ? (
+        <ConfirmMembership
+          lesson={lesson}
+          sessionId={session_id as string}
+          viewLesson={viewLesson}
+        />
+      ) : (
+        <GoProCtaOverlay lesson={lesson} />
+      )}
+    </OverlayWrapper>
+  )
 }
 
 export default OverlayParent

--- a/src/components/pages/lessons/overlay/rate-course-overlay/index.tsx
+++ b/src/components/pages/lessons/overlay/rate-course-overlay/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {Field, Form, Formik} from 'formik'
 import {useTrackComponent} from 'hooks/use-track-component'
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
 const rangeArr = [1, 2, 3, 4, 5, 6, 7]
 
@@ -25,36 +26,38 @@ const RateCourseOverlay: React.FunctionComponent<{
   useTrackComponent('show rate course', {course: slug})
 
   return (
-    <div className="flex flex-col items-center justify-center p-4">
-      <div className="flex flex-col items-center">
-        <img
-          src={square_cover_480_url}
-          alt={`illustration of ${title} course`}
-          className="w-16 md:w-24"
-        />
-        <h3 className="text-md md:text-lg lg:text-xl font-semibold mt-4 text-center white">
-          {title}
-        </h3>
+    <OverlayWrapper>
+      <div className="flex flex-col items-center justify-center p-4">
+        <div className="flex flex-col items-center">
+          <img
+            src={square_cover_480_url}
+            alt={`illustration of ${title} course`}
+            className="w-16 md:w-24"
+          />
+          <h3 className="text-md md:text-lg lg:text-xl font-semibold mt-4 text-center white">
+            {title}
+          </h3>
+        </div>
+        {!rating && (
+          <NumericRating
+            course={course}
+            onRated={(rating: any) => {
+              setRating(rating)
+            }}
+          />
+        )}
+        {rating && !complete && (
+          <TextComment
+            rating={rating}
+            onAnswer={(comment: any) => {
+              onRated({rating, comment})
+              setComplete(true)
+            }}
+          />
+        )}
+        {complete && <div>Thank you!</div>}
       </div>
-      {!rating && (
-        <NumericRating
-          course={course}
-          onRated={(rating: any) => {
-            setRating(rating)
-          }}
-        />
-      )}
-      {rating && !complete && (
-        <TextComment
-          rating={rating}
-          onAnswer={(comment: any) => {
-            onRated({rating, comment})
-            setComplete(true)
-          }}
-        />
-      )}
-      {complete && <div>Thank you!</div>}
-    </div>
+    </OverlayWrapper>
   )
 }
 

--- a/src/components/pages/lessons/overlay/recommend-next-step-overlay/index.tsx
+++ b/src/components/pages/lessons/overlay/recommend-next-step-overlay/index.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {track} from 'utils/analytics'
 import Share from 'components/share'
 import {useTrackComponent} from 'hooks/use-track-component'
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
 const RecommendNextStepOverlay: React.FunctionComponent<{
   lesson: any
@@ -16,55 +17,57 @@ const RecommendNextStepOverlay: React.FunctionComponent<{
   })
 
   return (
-    <div className="flex flex-col items-center justify-center p-4">
-      {courseImage && (
-        <div className="w-16 h-16 md:w-24 md:h-24 lg:w-32 lg:h-32 relative">
-          <Image
-            src={courseImage}
-            alt={`illustration of ${lesson?.collection.title} course`}
-            layout="fill"
-          />
+    <OverlayWrapper>
+      <div className="flex flex-col items-center justify-center p-4">
+        {courseImage && (
+          <div className="w-16 h-16 md:w-24 md:h-24 lg:w-32 lg:h-32 relative">
+            <Image
+              src={courseImage}
+              alt={`illustration of ${lesson?.collection.title} course`}
+              layout="fill"
+            />
+          </div>
+        )}
+        <h2 className="text-md md:text-lg lg:text-md  mt-4 text-center">
+          Congrats, you finished!
+        </h2>
+        <h3 className="text-md md:text-xl lg:text-2xl  mt-2 text-center">
+          {' '}
+          <span className="font-semibold">
+            {lesson?.collection ? lesson?.collection?.title : lesson.title}
+          </span>
+        </h3>
+        <Share
+          resource={lesson?.collection || lesson}
+          instructor={lesson?.instructor}
+          className="text-black flex items-center mt-6"
+        >
+          <div className="max-w-md mt-2 text-center">
+            If this {lesson?.collection ? 'course' : 'video'} was useful for
+            you, please share it with your colleagues. It will really help{' '}
+            {lesson.instructor.full_name.split(' ')[0]} get the word out.
+          </div>
+        </Share>
+        <div className="mt-8 text-xs md:mt-10 lg:mt-6 xl:mt-16 text-center">
+          Ready for something new?{' '}
+          <Link href="/">
+            <a
+              onClick={() => {
+                track('clicked ready for new', {
+                  ...(lesson?.collection && {
+                    collection: lesson?.collection.slug,
+                  }),
+                  video: lesson.slug,
+                })
+              }}
+              className="font-semibold"
+            >
+              Click here to start your next project.
+            </a>
+          </Link>
         </div>
-      )}
-      <h2 className="text-md md:text-lg lg:text-md  mt-4 text-center">
-        Congrats, you finished!
-      </h2>
-      <h3 className="text-md md:text-xl lg:text-2xl  mt-2 text-center">
-        {' '}
-        <span className="font-semibold">
-          {lesson?.collection ? lesson?.collection?.title : lesson.title}
-        </span>
-      </h3>
-      <Share
-        resource={lesson?.collection || lesson}
-        instructor={lesson?.instructor}
-        className="text-black flex items-center mt-6"
-      >
-        <div className="max-w-md mt-2 text-center">
-          If this {lesson?.collection ? 'course' : 'video'} was useful for you,
-          please share it with your colleagues. It will really help{' '}
-          {lesson.instructor.full_name.split(' ')[0]} get the word out.
-        </div>
-      </Share>
-      <div className="mt-8 text-xs md:mt-10 lg:mt-6 xl:mt-16 text-center">
-        Ready for something new?{' '}
-        <Link href="/">
-          <a
-            onClick={() => {
-              track('clicked ready for new', {
-                ...(lesson?.collection && {
-                  collection: lesson?.collection.slug,
-                }),
-                video: lesson.slug,
-              })
-            }}
-            className="font-semibold"
-          >
-            Click here to start your next project.
-          </a>
-        </Link>
       </div>
-    </div>
+    </OverlayWrapper>
   )
 }
 

--- a/src/components/pages/lessons/overlay/watch-full-course-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/watch-full-course-cta-overlay.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {track} from 'utils/analytics'
 import noop from 'utils/noop'
 import {useTrackComponent} from 'hooks/use-track-component'
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
 const WatchFullCourseCtaOverlay: React.FunctionComponent<{
   lesson: any
@@ -14,48 +15,50 @@ const WatchFullCourseCtaOverlay: React.FunctionComponent<{
   useTrackComponent('show course pitch', {course: lesson?.collection?.slug})
 
   return (
-    <div className="flex flex-col items-center justify-center p-4">
-      {courseImage && (
-        <div className="w-16 h-16 md:w-32 md:h-32 lg:w-40 lg:h-40 xl:w-48 xl:h-48 relative flex-shrink-0">
-          <Image
-            src={courseImage}
-            alt={`illustration of ${lesson.collection.title} course`}
-            layout="fill"
-          />
-        </div>
-      )}
-      <div className="mt-4 md:mt-4">This Lesson is Part of a Course</div>
-      <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
-        {lesson.collection.title}
-      </h3>
-      <div className="flex mt-6 md:mt-8">
-        <button
-          className="border border-blue-600 rounded px-3 py-2 flex items-center hover:bg-gray-900 transition-colors duration-200 ease-in-out"
-          onClick={() => {
-            track('clicked rewatch video', {
-              lesson: lesson.slug,
-              location: 'lesson overlay',
-            })
-            onClickRewatch()
-          }}
-        >
-          <IconRefresh className="w-6 mr-2" /> Watch again
-        </button>
-        <Link href={lesson?.collection?.path || '#'}>
-          <a
+    <OverlayWrapper>
+      <div className="flex flex-col items-center justify-center p-4">
+        {courseImage && (
+          <div className="w-16 h-16 md:w-32 md:h-32 lg:w-40 lg:h-40 xl:w-48 xl:h-48 relative flex-shrink-0">
+            <Image
+              src={courseImage}
+              alt={`illustration of ${lesson.collection.title} course`}
+              layout="fill"
+            />
+          </div>
+        )}
+        <div className="mt-4 md:mt-4">This Lesson is Part of a Course</div>
+        <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
+          {lesson.collection.title}
+        </h3>
+        <div className="flex mt-6 md:mt-8">
+          <button
+            className="border border-blue-600 rounded px-3 py-2 flex items-center hover:bg-gray-900 transition-colors duration-200 ease-in-out"
             onClick={() => {
-              track('clicked view course', {
+              track('clicked rewatch video', {
                 lesson: lesson.slug,
                 location: 'lesson overlay',
               })
+              onClickRewatch()
             }}
-            className="bg-blue-600 rounded px-3 py-2 flex items-center ml-4 hover:bg-blue-500 transition-colors duration-200 ease-in-out"
           >
-            <IconPlay className="w-6 mr-2" /> Explore the Whole Course
-          </a>
-        </Link>
+            <IconRefresh className="w-6 mr-2" /> Watch again
+          </button>
+          <Link href={lesson?.collection?.path || '#'}>
+            <a
+              onClick={() => {
+                track('clicked view course', {
+                  lesson: lesson.slug,
+                  location: 'lesson overlay',
+                })
+              }}
+              className="bg-blue-600 rounded px-3 py-2 flex items-center ml-4 hover:bg-blue-500 transition-colors duration-200 ease-in-out"
+            >
+              <IconPlay className="w-6 mr-2" /> Explore the Whole Course
+            </a>
+          </Link>
+        </div>
       </div>
-    </div>
+    </OverlayWrapper>
   )
 }
 

--- a/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
@@ -5,6 +5,7 @@ import {track} from 'utils/analytics'
 import noop from 'utils/noop'
 import {useTrackComponent} from 'hooks/use-track-component'
 import {useRouter} from 'next/router'
+import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
 
 const WatchNextLessonCtaOverlay: React.FunctionComponent<{
   lesson: any
@@ -12,6 +13,7 @@ const WatchNextLessonCtaOverlay: React.FunctionComponent<{
   ctaContent?: any
   onClickRewatch?: () => void
 }> = ({lesson, nextLesson, onClickRewatch = noop, ctaContent}) => {
+  const [collapsed, setCollapsed] = React.useState<boolean>(false)
   const courseImage = lesson?.collection?.square_cover_480_url
 
   useTrackComponent('show next up', {
@@ -21,84 +23,105 @@ const WatchNextLessonCtaOverlay: React.FunctionComponent<{
 
   const router = useRouter()
 
-  return (
-    <div className="flex flex-col items-center justify-center p-4">
-      {courseImage && (
-        <div className="w-16 h-16 md:w-32 md:h-32 lg:w-40 lg:h-40 xl:w-48 xl:h-48 relative flex-shrink-0">
-          <Image
-            src={courseImage}
-            alt={`illustration of ${lesson.collection.title} course`}
-            layout="fill"
-          />
-        </div>
-      )}
-      <div className="mt-4 md:mt-4">Up Next</div>
-      <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
-        {nextLesson.title}
-      </h3>
-      <div className="flex mt-6 md:mt-8">
+  return collapsed ? (
+    <div className="absolute top-6 right-6">
+      <div>
         <button
-          className="border border-blue-600 rounded px-3 py-2 flex items-center hover:bg-gray-900 transition-colors duration-200 ease-in-out"
-          onClick={() => {
-            track('clicked rewatch video', {
-              lesson: lesson.slug,
-              location: 'lesson overlay',
-            })
-            onClickRewatch()
-          }}
+          className="bg-red-500 text-white p-2"
+          onClick={() => setCollapsed(false)}
         >
-          <IconRefresh className="w-6 mr-2" /> Watch again
-        </button>
-        <button
-          onClick={() => {
-            router.push(nextLesson.path || '#')
-            track('clicked play next', {
-              lesson: lesson.slug,
-              location: 'lesson overlay',
-            })
-          }}
-          className="bg-blue-600 rounded px-3 py-2 flex items-center ml-4 hover:bg-blue-500 transition-colors duration-200 ease-in-out"
-        >
-          <IconPlay className="w-6 mr-2" /> Play next
+          Expand
         </button>
       </div>
-      {ctaContent && (
-        <div className="flex flex-col mt-6 md:mt-8 space-y-3">
-          <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
-            {ctaContent.headline}
-          </h3>
-          {ctaContent.linksTo.map((content: any) => {
-            return (
-              <Link
-                href={content.slug ? `/${content.type}s/${content.slug}` : '#'}
-              >
-                <a
-                  onClick={() => {
-                    track('clicked cta content', {
-                      from: lesson.slug,
-                      [content.type]: content.slug,
-                      location: 'lesson overlay',
-                    })
-                  }}
-                  className="px-3 py-2 flex items-center ml-4 transition-colors duration-200 ease-in-out space-x-2 hover:underline"
-                >
-                  <div className="w-12 h-12 relative flex-shrink-0 ">
-                    <Image
-                      src={content.imageUrl}
-                      alt={`illustration of ${content.title} course`}
-                      width="64"
-                      height="64"
-                      layout="fill"
-                    />
-                  </div>
-                  <div className="font-bold relative">{content.title}</div>
-                </a>
-              </Link>
-            )
-          })}
-        </div>
-      )}
     </div>
+  ) : (
+    <OverlayWrapper>
+      <div className="flex flex-col items-center justify-center p-4 relative">
+        <button
+          className="absolute bg-red-500 text-white p-2 top-6 right-6"
+          onClick={() => setCollapsed(true)}
+        >
+          Collapse
+        </button>
+        {courseImage && (
+          <div className="w-16 h-16 md:w-32 md:h-32 lg:w-40 lg:h-40 xl:w-48 xl:h-48 relative flex-shrink-0">
+            <Image
+              src={courseImage}
+              alt={`illustration of ${lesson.collection.title} course`}
+              layout="fill"
+            />
+          </div>
+        )}
+        <div className="mt-4 md:mt-4">Up Next</div>
+        <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
+          {nextLesson.title}
+        </h3>
+        <div className="flex mt-6 md:mt-8">
+          <button
+            className="border border-blue-600 rounded px-3 py-2 flex items-center hover:bg-gray-900 transition-colors duration-200 ease-in-out"
+            onClick={() => {
+              track('clicked rewatch video', {
+                lesson: lesson.slug,
+                location: 'lesson overlay',
+              })
+              onClickRewatch()
+            }}
+          >
+            <IconRefresh className="w-6 mr-2" /> Watch again
+          </button>
+          <button
+            onClick={() => {
+              router.push(nextLesson.path || '#')
+              track('clicked play next', {
+                lesson: lesson.slug,
+                location: 'lesson overlay',
+              })
+            }}
+            className="bg-blue-600 rounded px-3 py-2 flex items-center ml-4 hover:bg-blue-500 transition-colors duration-200 ease-in-out"
+          >
+            <IconPlay className="w-6 mr-2" /> Play next
+          </button>
+        </div>
+        {ctaContent && (
+          <div className="flex flex-col mt-6 md:mt-8 space-y-3">
+            <h3 className="text-md md:text-lg font-semibold mt-4 text-center">
+              {ctaContent.headline}
+            </h3>
+            {ctaContent.linksTo.map((content: any) => {
+              return (
+                <Link
+                  href={
+                    content.slug ? `/${content.type}s/${content.slug}` : '#'
+                  }
+                >
+                  <a
+                    onClick={() => {
+                      track('clicked cta content', {
+                        from: lesson.slug,
+                        [content.type]: content.slug,
+                        location: 'lesson overlay',
+                      })
+                    }}
+                    className="px-3 py-2 flex items-center ml-4 transition-colors duration-200 ease-in-out space-x-2 hover:underline"
+                  >
+                    <div className="w-12 h-12 relative flex-shrink-0 ">
+                      <Image
+                        src={content.imageUrl}
+                        alt={`illustration of ${content.title} course`}
+                        width="64"
+                        height="64"
+                        layout="fill"
+                      />
+                    </div>
+                    <div className="font-bold relative">{content.title}</div>
+                  </a>
+                </Link>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </OverlayWrapper>
   )
 }
 

--- a/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
@@ -24,24 +24,24 @@ const WatchNextLessonCtaOverlay: React.FunctionComponent<{
   const router = useRouter()
 
   return collapsed ? (
-    <div className="absolute top-6 right-6">
+    <div className="absolute top-3 right-3">
       <div>
         <button
-          className="bg-red-500 text-white p-2"
+          className="rounded bg-black/50 text-white p-2"
           onClick={() => setCollapsed(false)}
         >
-          Expand
+          Next Lesson
         </button>
       </div>
     </div>
   ) : (
-    <OverlayWrapper>
+    <OverlayWrapper className="absolute top-0 z-10">
       <div className="flex flex-col items-center justify-center p-4">
         <button
-          className="absolute bg-red-500 text-white p-2 top-6 right-6"
+          className="rounded bg-black/50 absolute text-white p-2 top-3 right-3"
           onClick={() => setCollapsed(true)}
         >
-          Collapse
+          Back to the video
         </button>
         {courseImage && (
           <div className="w-16 h-16 md:w-32 md:h-32 lg:w-40 lg:h-40 xl:w-48 xl:h-48 relative flex-shrink-0">

--- a/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/watch-next-lesson-cta-overlay.tsx
@@ -36,7 +36,7 @@ const WatchNextLessonCtaOverlay: React.FunctionComponent<{
     </div>
   ) : (
     <OverlayWrapper>
-      <div className="flex flex-col items-center justify-center p-4 relative">
+      <div className="flex flex-col items-center justify-center p-4">
         <button
           className="absolute bg-red-500 text-white p-2 top-6 right-6"
           onClick={() => setCollapsed(true)}

--- a/src/components/pages/lessons/overlay/wrapper.tsx
+++ b/src/components/pages/lessons/overlay/wrapper.tsx
@@ -1,10 +1,10 @@
-import React, {FunctionComponent} from 'react'
+import * as React from 'react'
 
-const OverlayWrapper: FunctionComponent<{
+const OverlayWrapper: React.FC<{
   children: React.ReactNode
 }> = ({children}) => {
   return (
-    <div className="sm:py-16 py-8 flex items-center justify-center h-full bg-black text-white bg-opacity-90 w-full">
+    <div className="sm:py-16 py-8 flex items-center justify-center h-full bg-black text-white bg-opacity-80 w-full absolute top-0 z-10">
       {children}
     </div>
   )

--- a/src/components/pages/lessons/overlay/wrapper.tsx
+++ b/src/components/pages/lessons/overlay/wrapper.tsx
@@ -1,10 +1,17 @@
 import * as React from 'react'
+import cx from 'classnames'
 
 const OverlayWrapper: React.FC<{
   children: React.ReactNode
-}> = ({children}) => {
+  className?: string
+}> = ({children, className}) => {
   return (
-    <div className="sm:py-16 py-8 flex items-center justify-center h-full bg-black text-white bg-opacity-80 w-full absolute top-0 z-10">
+    <div
+      className={cx(
+        'sm:py-16 py-8 flex items-center justify-center h-full bg-black text-white bg-opacity-80 w-full',
+        className,
+      )}
+    >
       {children}
     </div>
   )

--- a/src/components/pages/lessons/overlays.tsx
+++ b/src/components/pages/lessons/overlays.tsx
@@ -6,8 +6,6 @@ import {track} from 'utils/analytics'
 import specialLessons from './special-lessons'
 import {CIOSubscriber} from 'hooks/use-cio'
 
-import OverlayWrapper from 'components/pages/lessons/overlay/wrapper'
-
 import RateCourseOverlay from 'components/pages/lessons/overlay/rate-course-overlay'
 import RecommendNextStepOverlay from 'components/pages/lessons/overlay/recommend-next-step-overlay'
 import GoProCtaOverlay from 'components/pages/lessons/overlay/go-pro-cta-overlay'
@@ -129,13 +127,7 @@ const Overlays: React.FC<OverlaysProps> = ({
     overlayToRender = <RecommendNextStepOverlay lesson={lesson} />
   }
 
-  return (
-    <>
-      {overlayToRender ? (
-        <OverlayWrapper>{overlayToRender}</OverlayWrapper>
-      ) : null}
-    </>
-  )
+  return <>{overlayToRender ? overlayToRender : null}</>
 }
 
 export default Overlays

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -219,6 +219,7 @@ const Lesson: React.FC<LessonProps> = ({
         'viewing',
         'completed',
         'addingNote',
+        'showingNext',
       ].includes(currentLessonState),
     )
   }, [currentLessonState])
@@ -549,11 +550,11 @@ const Lesson: React.FC<LessonProps> = ({
                 )}
               </Player>
             </div>
-            <div
+            {/* <div
               className={cx('aspect-w-16 aspect-h-9', {
                 hidden: mounted,
               })}
-            />
+            /> */}
             <Overlays
               lessonSend={send}
               lessonState={lessonState}


### PR DESCRIPTION
It's possible now to collapse/expand the Next Up lesson overlay:
https://share.getcloudapp.com/rRuQLJpE

related PR on packages/player: https://github.com/skillrecordings/products/pull/443

![expand sign language GIF by Sign with Robert](https://user-images.githubusercontent.com/1519448/188791996-b7021695-c224-482c-8302-17871502779c.gif)
