### PR TITLE
add learner stats to profile page

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@tailwindcss/line-clamp": "^0.3.0",
     "@tailwindcss/typography": "^0.5.0",
     "@tanem/react-nprogress": "^3.0.77",
+    "@tanstack/react-query": "^4.3.4",
+    "@tanstack/react-query-devtools": "^4.3.5",
     "@testing-library/react-hooks": "^8.0.0",
     "@tippyjs/react": "^4.2.5",
     "@videojs/http-streaming": "^2.9.3",

--- a/src/components/users/request-email-change-form.tsx
+++ b/src/components/users/request-email-change-form.tsx
@@ -27,114 +27,115 @@ async function requestEmailChange(newEmail: string) {
   return data
 }
 
-const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProps> = ({
-  originalEmail,
-}) => {
-  const [state, send] = useMachine(requestEmailChangeMachine, {
-    services: {
-      requestChange: (_, event: DoneEventObject) => {
-        return requestEmailChange(event.data.newEmail)
+const RequestEmailChangeForm: React.FunctionComponent<RequestEmailChangeFormProps> =
+  ({originalEmail}) => {
+    const [state, send] = useMachine(requestEmailChangeMachine, {
+      services: {
+        requestChange: (_, event: DoneEventObject) => {
+          return requestEmailChange(event.data.newEmail)
+        },
       },
-    },
-  })
+    })
 
-  return (
-    <Formik
-      initialValues={{email: originalEmail}}
-      validationSchema={emailChangeSchema}
-      onSubmit={async (values) => {
-        send({type: 'SUBMIT', data: {newEmail: values.email}})
-      }}
-    >
-      {(props) => {
-        const {
-          values,
-          isSubmitting,
-          handleChange,
-          handleBlur,
-          handleSubmit,
-          setFieldValue,
-        } = props
-        return (
-          <form onSubmit={handleSubmit}>
-            <div className="flex flex-col space-y-2">
-              <h2 className="text-xl pb-1 border-b border-gray-200 dark:border-gray-800">
-                Email
-              </h2>
-              <p>Your email address:</p>
-              <div className="text-sm text-gray-600 dark:text-gray-200">
-                {state.matches('edit') && (
-                  <p>
-                    To ensure that you have access to this email address, we
-                    will send an email to that account with a confirmation link.
-                  </p>
-                )}
-                {state.matches('success') && !state.context.error && (
-                  <p>
-                    Your email change request has been received. A confirmation
-                    email has been sent to {state.context.newEmail}.
-                  </p>
-                )}
-                {state.matches('success') && !!state.context.error && (
-                  <p>
-                    We weren't able to automatically update your email. Please
-                    contact{' '}
-                    <a
-                      className="font-bold hover:text-blue-600 transition-colors ease-in-out duration-150"
-                      href="mailto:support@egghead.io"
-                    >
-                      support@egghead.io
-                    </a>{' '}
-                    to get further help with this request.
-                  </p>
-                )}
-              </div>
-              <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-                <input
-                  id="email"
-                  type="email"
-                  value={state.matches('edit') ? values.email : originalEmail}
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  placeholder="you@company.com"
-                  required
-                  disabled={isSubmitting || !state.matches('edit')}
-                  className="bg-gray-50 dark:bg-gray-800 focus:outline-none focus:shadow-outline border border-gray-100 dark:border-gray-700 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
-                />
-                {state.matches('edit') || state.matches('loading') ? (
-                  <div className="flex space-x-2">
+    return (
+      <Formik
+        initialValues={{email: originalEmail}}
+        validationSchema={emailChangeSchema}
+        onSubmit={async (values) => {
+          send({type: 'SUBMIT', data: {newEmail: values.email}})
+        }}
+      >
+        {(props) => {
+          const {
+            values,
+            isSubmitting,
+            handleChange,
+            handleBlur,
+            handleSubmit,
+            setFieldValue,
+          } = props
+          return (
+            <form className="grow" onSubmit={handleSubmit}>
+              <div className="flex flex-col space-y-2">
+                <h2 className="text-xl pb-1 border-b border-gray-200 dark:border-gray-800">
+                  Email
+                </h2>
+                <p>Your email address:</p>
+                <div className="text-sm text-gray-600 dark:text-gray-200">
+                  {state.matches('edit') && (
+                    <p>
+                      To ensure that you have access to this email address, we
+                      will send an email to that account with a confirmation
+                      link.
+                    </p>
+                  )}
+                  {state.matches('success') && !state.context.error && (
+                    <p>
+                      Your email change request has been received. A
+                      confirmation email has been sent to{' '}
+                      {state.context.newEmail}.
+                    </p>
+                  )}
+                  {state.matches('success') && !!state.context.error && (
+                    <p>
+                      We weren't able to automatically update your email. Please
+                      contact{' '}
+                      <a
+                        className="font-bold hover:text-blue-600 transition-colors ease-in-out duration-150"
+                        href="mailto:support@egghead.io"
+                      >
+                        support@egghead.io
+                      </a>{' '}
+                      to get further help with this request.
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+                  <input
+                    id="email"
+                    type="email"
+                    value={state.matches('edit') ? values.email : originalEmail}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="you@company.com"
+                    required
+                    disabled={isSubmitting || !state.matches('edit')}
+                    className="bg-gray-50 dark:bg-gray-800 focus:outline-none focus:shadow-outline border border-gray-100 dark:border-gray-700 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
+                  />
+                  {state.matches('edit') || state.matches('loading') ? (
+                    <div className="flex space-x-2">
+                      <button
+                        type="submit"
+                        className="text-white bg-green-600 border-0 py-2 px-8 focus:outline-none hover:bg-green-700 rounded"
+                        disabled={isSubmitting}
+                      >
+                        Submit
+                      </button>
+                      <button
+                        onClick={() => {
+                          setFieldValue('email', originalEmail)
+                          send({type: 'CANCEL'})
+                        }}
+                        className="text-black bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-gray-300 rounded"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
                     <button
-                      type="submit"
-                      className="text-white bg-green-600 border-0 py-2 px-8 focus:outline-none hover:bg-green-700 rounded"
-                      disabled={isSubmitting}
+                      onClick={() => send({type: 'EDIT'})}
+                      className="text-white bg-orange-600 border-0 py-2 px-8 focus:outline-none hover:bg-orange-700 rounded-md"
                     >
-                      Submit
+                      Edit
                     </button>
-                    <button
-                      onClick={() => {
-                        setFieldValue('email', originalEmail)
-                        send({type: 'CANCEL'})
-                      }}
-                      className="text-black bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-gray-300 rounded"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => send({type: 'EDIT'})}
-                    className="text-white bg-orange-600 border-0 py-2 px-8 focus:outline-none hover:bg-orange-700 rounded-md"
-                  >
-                    Edit
-                  </button>
-                )}
+                  )}
+                </div>
               </div>
-            </div>
-          </form>
-        )
-      }}
-    </Formik>
-  )
-}
+            </form>
+          )
+        }}
+      </Formik>
+    )
+  }
 
 export default RequestEmailChangeForm

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -155,18 +155,13 @@ export async function loadUserCompletedCourses(token?: string): Promise<any> {
   token = token || getAccessTokenFromCookie()
   const graphQLClient = getGraphQLClient(token)
 
-  try {
-    const {user_progress} = await graphQLClient.request(query)
+  const {user_progress} = await graphQLClient.request(query)
 
-    let completeCourses = user_progress.filter((p: any) => p.is_complete)
+  let completeCourses = user_progress.filter((p: any) => p.is_complete)
 
-    if (user_progress) {
-      return {
-        completeCourses,
-      }
+  if (user_progress) {
+    return {
+      completeCourses,
     }
-  } catch (e) {
-    console.log(e)
-    return e
   }
 }

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -133,3 +133,35 @@ export async function loadUserProgress(
     }
   }
 }
+
+export async function loadUserCompletedCourses(token?: string): Promise<any> {
+  const query = gql`
+    query completedCourses {
+      user_progress {
+        completed_at
+        lesson_count
+        is_complete
+        collection {
+          ... on Playlist {
+            slug
+            title
+            image: image_thumb_url
+            path
+          }
+        }
+      }
+    }
+  `
+  token = token || getAccessTokenFromCookie()
+  const graphQLClient = getGraphQLClient(token)
+
+  const {user_progress} = await graphQLClient.request(query)
+
+  let completeCourses = user_progress.filter((p: any) => p.is_complete)
+
+  if (user_progress) {
+    return {
+      completeCourses,
+    }
+  }
+}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -34,6 +34,9 @@ export async function loadUserProgress(
   const query = gql`
     query AllProgress($user_id: Int!, $page: Int!, $per_page: Int!) {
       user(id: $user_id) {
+        courses_completed
+        lessons_completed
+        minutes_watched
         email
         all_progress(page: $page, per_page: $per_page) {
           count
@@ -120,6 +123,13 @@ export async function loadUserProgress(
   const {user} = await graphQLClient.request(query, variables)
 
   if (user) {
-    return user.all_progress
+    return {
+      completionStats: {
+        minutesWatched: user.minutes_watched,
+        completedCourseCount: user.courses_completed,
+        completedLessonCount: user.lessons_completed,
+      },
+      progress: user.all_progress,
+    }
   }
 }

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -155,13 +155,18 @@ export async function loadUserCompletedCourses(token?: string): Promise<any> {
   token = token || getAccessTokenFromCookie()
   const graphQLClient = getGraphQLClient(token)
 
-  const {user_progress} = await graphQLClient.request(query)
+  try {
+    const {user_progress} = await graphQLClient.request(query)
 
-  let completeCourses = user_progress.filter((p: any) => p.is_complete)
+    let completeCourses = user_progress.filter((p: any) => p.is_complete)
 
-  if (user_progress) {
-    return {
-      completeCourses,
+    if (user_progress) {
+      return {
+        completeCourses,
+      }
     }
+  } catch (e) {
+    console.log(e)
+    return e
   }
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,6 +18,8 @@ import RouteLoadingIndicator from 'components/route-loading-indicator'
 import {useRouter} from 'next/router'
 import {ThemeProvider} from 'next-themes'
 import {Toaster} from 'react-hot-toast'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 
 declare global {
   interface Window {
@@ -28,6 +30,8 @@ declare global {
     gtag: any
   }
 }
+
+const queryClient = new QueryClient()
 
 export function reportWebVitals(metric: NextWebVitalsMetric) {
   console.debug(`web vitals`, metric)
@@ -104,9 +108,12 @@ const App: React.FC<AppProps> = ({Component, pageProps}) => {
         <ViewerProvider>
           <LogRocketProvider>
             <CioProvider>
-              <MDXProvider components={mdxComponents}>
-                {getLayout(Component, pageProps)}
-              </MDXProvider>
+              <QueryClientProvider client={queryClient}>
+                <MDXProvider components={mdxComponents}>
+                  {getLayout(Component, pageProps)}
+                </MDXProvider>
+                <ReactQueryDevtools />
+              </QueryClientProvider>
             </CioProvider>
           </LogRocketProvider>
         </ViewerProvider>

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -7,6 +7,7 @@ import {get, isEmpty, find, first} from 'lodash'
 import SubscriptionDetails from 'components/users/subscription-details'
 import {loadUserProgress} from 'lib/users'
 import InProgressResource from 'components/pages/users/dashboard/activity/in-progress-resource'
+import {convertMintoHours} from 'utils/time-utils'
 
 const GithubConnectButton: React.FunctionComponent<{
   authToken: string
@@ -45,6 +46,7 @@ const User: React.FunctionComponent<
   const [account, setAccount] = React.useState<ViewerAccount>()
   const {viewer, authToken} = useViewer()
   const [progress, setProgress] = React.useState<any>([])
+  const [completions, setCompletions] = React.useState<any>({})
   const {email: currentEmail, accounts, providers} = viewer || {}
   const {slug} = getAccountWithSubscription(accounts)
   const isConnectedToGithub = providers?.includes('github')
@@ -53,8 +55,12 @@ const User: React.FunctionComponent<
   React.useEffect(() => {
     const loadProgressForUser = async (viewerId: number) => {
       if (viewerId) {
-        const {data} = await loadUserProgress(viewerId)
+        const {
+          progress: {data},
+          completionStats,
+        } = await loadUserProgress(viewerId)
         setProgress(data)
+        setCompletions(completionStats)
       }
     }
 
@@ -78,7 +84,17 @@ const User: React.FunctionComponent<
         <div className="flex flex-col max-w-screen-md mx-auto space-y-10 sm:space-y-16">
           {/* Account details */}
           <div className="sm:px-6 lg:px-0 lg:col-span-9">
-            <RequestEmailChangeForm originalEmail={currentEmail} />
+            <div className="flex gap-4 justify-between">
+              <RequestEmailChangeForm originalEmail={currentEmail} />
+              <div className="flex flex-col space-y-2">
+                <h2 className="pb-1 text-xl border-b border-gray-200 dark:border-gray-800">
+                  Learner Stats
+                </h2>
+                <p>{convertMintoHours(completions.minutesWatched)} watched</p>
+                <p>{completions.completedCourseCount} courses completed</p>
+                <p>{completions.completedLessonCount} lessons completed</p>
+              </div>
+            </div>
           </div>
           {/* Connect to GitHub */}
           {isConnectedToGithub ? (

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -84,9 +84,9 @@ const User: React.FunctionComponent<
         <div className="flex flex-col max-w-screen-md mx-auto space-y-10 sm:space-y-16">
           {/* Account details */}
           <div className="sm:px-6 lg:px-0 lg:col-span-9">
-            <div className="flex gap-4 justify-between">
+            <div className="flex gap-4 sm:justify-between flex-wrap">
               <RequestEmailChangeForm originalEmail={currentEmail} />
-              <div className="flex flex-col space-y-2">
+              <div className="flex flex-col space-y-2 sm:grow-0 grow">
                 <h2 className="pb-1 text-xl border-b border-gray-200 dark:border-gray-800">
                   Learner Stats
                 </h2>

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -12,6 +12,7 @@ import {CardResource} from 'types'
 import {VerticalResourceCard} from 'components/card/verticle-resource-card'
 import {BadgeCheckIcon} from '@heroicons/react/solid'
 import {useQuery} from '@tanstack/react-query'
+import {format} from 'date-fns'
 
 const GithubConnectButton: React.FunctionComponent<{
   authToken: string
@@ -159,19 +160,31 @@ const User: React.FunctionComponent<
                 <h2 className="pb-1 text-xl border-b border-gray-200 dark:border-gray-800">
                   Completed Courses
                 </h2>
-                <div className="flex flex-wrap gap-4 justify-evenly">
+                <div className="flex flex-wrap gap-4 justify-evenly mt-4">
                   {completeCourseData.map(
-                    ({collection}: {collection: CardResource}) => {
+                    ({
+                      collection,
+                      completed_at,
+                    }: {
+                      collection: CardResource
+                      completed_at: string
+                    }) => {
                       return (
-                        <div className="relative mt-4">
-                          <span className="absolute z-10 left-40">
-                            {<BadgeCheckIcon color="green" width="1.5em" />}
-                          </span>
+                        <div className="flex flex-col justify-between">
                           <VerticalResourceCard
                             resource={collection}
                             location="user profile"
-                            className="text-center w-44 flex flex-col items-center justify-center"
+                            className="text-center w-44 flex flex-col items-center justify-center self-center"
                           />
+                          <span className="z-10 flex flex-row">
+                            <span>
+                              <BadgeCheckIcon color="green" width="1.5em" />
+                            </span>
+                            <span className="ml-1 h-fit my-auto text-xs text-gray-600 italic font-bold">
+                              Completed on{' '}
+                              {format(new Date(completed_at), 'yyyy/MM/dd')}
+                            </span>
+                          </span>
                         </div>
                       )
                     },

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -6,8 +6,8 @@ function pad(s: string | any[]) {
 }
 
 export function convertMintoHours(minutes: number) {
-  const mins = ~~(minutes / 60)
-  return `${pad(mins.toString())}h`
+  const hours = ~~(minutes / 60)
+  return `${pad(hours.toString())}h`
 }
 
 export function convertTimeToMins(seconds: number) {

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -5,6 +5,11 @@ function pad(s: string | any[]) {
   return s.length > 10 ? s : s.length == 0 ? '00' : s
 }
 
+export function convertMintoHours(minutes: number) {
+  const mins = ~~(minutes / 60)
+  return `${pad(mins.toString())}h`
+}
+
 export function convertTimeToMins(seconds: number) {
   const mins = ~~(seconds / 60)
   return `${pad(mins.toString())}m`


### PR DESCRIPTION
After looking at our graphql endpoint for the user, I updated the user profile page with the stats that are currently being exposed.

Those stats are the aggregated amount of `minutesWatched`, `courses_completed`, and `lessons_completed`.

Underneath the github section is a 'completed courses' section that lists all courses with the date of completion on them.

This is loosely based off the mock up that Maggie made when she worked on some UX Research for profile pages.

## Updated profile
![Build the portfolio you need to be a badass web developer   egghe](https://user-images.githubusercontent.com/6188161/189984725-26c36a02-ae16-4eab-8dd3-320a39a6e341.png)
![Build the portfolio you need to be a badass web developer   egghe](https://user-images.githubusercontent.com/6188161/189984740-a0717f72-df51-4238-b606-696d252b30ca.png)


## Mock up
![maggies mock up](https://user-images.githubusercontent.com/6188161/189223102-2d71752e-6331-41e7-8035-ce6a1aded5bf.png)

![data](https://media.giphy.com/media/UEGwYCVTBFa9tJEf66/giphy.gif)
 