### PR TITLE
chore(sale): update sales banners and wording

### DIFF
--- a/src/components/cta/sale/header-banner.tsx
+++ b/src/components/cta/sale/header-banner.tsx
@@ -27,12 +27,8 @@ const SaleHeaderBanner = () => {
             </span>{' '}
             Fall Sale:{' '}
             <span>
-              Save <strong>{percentOff}%</strong> on egghead membership
-              {appliedCoupon.coupon_expires_at &&
-                ' for limited time only'}.{' '}
-              <span role="img" aria-hidden="true">
-                💫
-              </span>
+              Save <strong>{percentOff}%</strong> on yearly memberships
+              {appliedCoupon.coupon_expires_at && ' for limited time'}.{' '}
             </span>
           </div>
           <div className="flex items-center flex-shrink-0 px-2 py-px text-white bg-black dark:bg-white dark:bg-opacity-100 bg-opacity-20 dark:text-blue-600">

--- a/src/components/cta/sale/header-banner.tsx
+++ b/src/components/cta/sale/header-banner.tsx
@@ -25,7 +25,7 @@ const SaleHeaderBanner = () => {
             <span role="img" aria-hidden="true">
               🌟
             </span>{' '}
-            Spring Sale:{' '}
+            Fall Sale:{' '}
             <span>
               Save <strong>{percentOff}%</strong> on egghead membership
               {appliedCoupon.coupon_expires_at &&

--- a/src/components/pages/landing/footer/index.tsx
+++ b/src/components/pages/landing/footer/index.tsx
@@ -147,7 +147,7 @@ const PricingCta = () => {
             appliedCoupon?.coupon_expires_at && (
               <div className="w-full max-w-xs mx-auto">
                 <Countdown
-                  label="Fall Sale – Price goes up in:"
+                  label="Save 40% on Yearly Memberships Price goes up in:"
                   date={fromUnixTime(appliedCoupon.coupon_expires_at)}
                 />
               </div>

--- a/src/components/pages/landing/footer/index.tsx
+++ b/src/components/pages/landing/footer/index.tsx
@@ -147,7 +147,7 @@ const PricingCta = () => {
             appliedCoupon?.coupon_expires_at && (
               <div className="w-full max-w-xs mx-auto">
                 <Countdown
-                  label="Spring sale – Price goes up in:"
+                  label="Fall Sale – Price goes up in:"
                   date={fromUnixTime(appliedCoupon.coupon_expires_at)}
                 />
               </div>

--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -236,7 +236,7 @@ const SelectPlanNew: React.FunctionComponent<SelectPlanProps> = ({
         <PlanTitle>{currentPlan?.name}</PlanTitle>
         {!isPPP && appliedCoupon?.coupon_expires_at && !pricesLoading && (
           <Countdown
-            label="Spring sale – Price goes up in:"
+            label="Fall Sale – Price goes up in:"
             date={fromUnixTime(appliedCoupon.coupon_expires_at)}
           />
         )}

--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -236,7 +236,7 @@ const SelectPlanNew: React.FunctionComponent<SelectPlanProps> = ({
         <PlanTitle>{currentPlan?.name}</PlanTitle>
         {!isPPP && appliedCoupon?.coupon_expires_at && !pricesLoading && (
           <Countdown
-            label="Fall Sale – Price goes up in:"
+            label="Save 40% on Yearly Memberships Price goes up in:"
             date={fromUnixTime(appliedCoupon.coupon_expires_at)}
           />
         )}


### PR DESCRIPTION
Updates wording for when sale is active. @garrettdimon is looking including the name of the sale in the `appliedCoupon` that gets sent over so in that case we can update for this to be dynamic so we don't need to put in a PR every time.

- [x] update the sales banner text

![activate sale](https://media.giphy.com/media/YSfWh6GivHaDitEccf/giphy.gif)