### PR TITLE
feat: handle coupons that have a minimum

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -110,8 +110,10 @@ export type PricingPlan = {
   interval: string
   interval_count: number
   name: string
-  price: number
   stripe_price_id: string
+  price: number
+  price_discounted?: number
+  price_savings?: number
 }
 
 export type Prices = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod'
+
 export type Resource = {
   title: string
   slug: string
@@ -106,15 +108,17 @@ export type Topic = {
 
 // Commerce Types
 
-export type PricingPlan = {
-  interval: string
-  interval_count: number
-  name: string
-  stripe_price_id: string
-  price: number
-  price_discounted?: number
-  price_savings?: number
-}
+export const pricingPlanSchema = z.object({
+  interval: z.string(),
+  interval_count: z.number(),
+  name: z.string(),
+  stripe_price_id: z.string(),
+  price: z.number(),
+  price_discounted: z.number().optional(),
+  price_savings: z.number().optional(),
+})
+
+export type PricingPlan = z.infer<typeof pricingPlanSchema>
 
 export type Prices = {
   monthlyPrice?: PricingPlan


### PR DESCRIPTION
- Logic was recently added to egghead-rails to allow for a coupon to have a minimum. If a particular plan's price is at or above the minimum, then it qualifies for that coupon discount. If not, then it should ignore that coupon.
- In the case of the Annual-only Fall Sale, we have a minimum set that includes the annual plan and excludes the quarterly and monthly plans.
- The `commerce-machine` in egghead-next assumes that coupons are available across all plans.
- Because of this assumption, we have the annual fall sale coupon code getting included in the Stripe Checkout Session for monthly plans which then fails on the Stripe-side because that is not a valid coupon for that plan.

Note: all of this logic is either for display purposes or communicating to Stripe what coupon to apply. Final say-so about whether a coupon is valid, whether it applies to a particular plan, and how much it affects the price happens server-side/Stripe-side.

More details in Roam: https://roamresearch.com/#/app/egghead/page/alSfRvrtT

![coupon minimum](https://media2.giphy.com/media/ponvUa3urCwJq/giphy.gif?cid=d1fd59abc09f71ot6oguuxe9897lj2xqpi93h4v1w79tzm81&rid=giphy.gif&ct=g)