### PR TITLE
feat: handle site-wide coupon with a minimum

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,8 @@ export type PricingPlan = {
   name: string
   price: number
   stripe_price_id: string
+  price_discounted?: string
+  price_savings?: string
 }
 
 export type Prices = {


### PR DESCRIPTION
- Logic was recently added to egghead-rails to allow for a coupon to
  have a minimum. If a particular plan's price is at or above the
  minimum, then it qualifies for that coupon discount. If not, then it
  should ignore that coupon.
- In the case of the Annual-only Fall Sale, we have a minimum set that
  includes the annual plan and excludes the quarterly and monthly plans.
- The `commerce-machine` in egghead-next assumes that coupons are
  available across all plans.
- Because of this assumption, we have the annual fall sale coupon code
  getting included in the Stripe Checkout Session for monthly plans
  which then fails on the Stripe-side because that is not a valid coupon
  for that plan.

Roam: https://roamresearch.com/#/app/egghead/page/alSfRvrtT

![coupons](https://media1.giphy.com/media/3MgKQnmhzW9taEeJSV/giphy.gif?cid=d1fd59abpatr6vu5fbh58rziqyxw544awpinnm32knuvycp8&rid=giphy.gif&ct=g)
