### PR TITLE
feat: prevent infinite loop with deep push

### DIFF
--- a/src/hooks/use-token-signer.tsx
+++ b/src/hooks/use-token-signer.tsx
@@ -94,8 +94,13 @@ function useTokenSigner() {
   const removeQueryFromUrl = React.useCallback(
     (paramName: string) => {
       const {[paramName]: _paramToRemove, ...updatedQuery} = router.query
+      // This used to be a shallow render (`shallow: true`), but we noticed that
+      // even though the URL was getting rewritten, the underlying router state
+      // was not being affect. This meant that `af` and `rc`, though stripped out
+      // of the URL, were continuing to appear in the `router.query` object and
+      // cause an infinite loop with the useEffect.
       router.push({pathname: router.pathname, query: updatedQuery}, undefined, {
-        shallow: true,
+        shallow: false,
       })
     },
     [router],


### PR DESCRIPTION
The shallow routing with `router.push` was leading to an infinite loop
whenever an `af` or `rc` query param was included in the URL. This fixes
it by doing a non-shallow push. The underlying router state (`{ query: {
af: 'some-code' }}`) was bleeding through from render to render. This
led to an infinite loop. Doing a non-shallow push ensures that query
state gets flushed.

**If I get a chance to follow up more on this** -- I kinda suspect there is more going on with this. The `router.query` state should be updated (with the removed `af`/`rc` values) on the subsequent render. It isn't though which makes me suspect that something about our middleware and/or other routing logic is contributing to this weird behavior.

![infinite loop](https://media0.giphy.com/media/3o7WTQqsDe6gyLv0hG/giphy.gif?cid=d1fd59ab9afpzktwso2ujipt2jx5fbqjxshmkn39jn9crhu8&rid=giphy.gif&ct=g)
