### PR TITLE
updated cards and [slug] to have optional resource fields

### DIFF
--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -43,7 +43,7 @@ const VerticalResourceCard: React.FC<{
       location={location as string}
       target={resource.url ? '_blank' : undefined}
       resource_type={resource.name}
-      instructor={resource.instructor.name}
+      instructor={resource?.instructor?.name}
       tag={resource.tag}
     >
       <Card {...props} resource={resource} className={className}>

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -64,7 +64,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                 {description}
               </ReactMarkdown>
             </div>
-            {jumbotron.resource ? (
+            {jumbotron?.resource ? (
               <div className="max-w-xs w-full">
                 <VerticalResourceCard
                   describe={true}
@@ -73,7 +73,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                   as="h2"
                 />
               </div>
-            ) : jumbotron.image ? (
+            ) : jumbotron?.image ? (
               <Image
                 src={jumbotron.image}
                 width={460}
@@ -127,114 +127,115 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
           </div>
         )}
         <div className="sm:px-5 px-3">
-          {sections.map((section: any) => {
-            return (
-              <section className="pb-16" key={section.id}>
-                {!section.image && !section.description ? (
-                  // simple section
-                  <div className="flex w-full pb-6 items-center justify-between">
-                    <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
-                      {section.title}
-                    </h2>
-                  </div>
-                ) : (
-                  // section with image and description
-                  <div className="flex md:flex-row flex-col md:items-start items-center justify-center w-full mb-5 pb-8 md:space-x-10">
-                    {section.image && (
-                      <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
-                        <Image
-                          aria-hidden
-                          src={section.image}
-                          quality={100}
-                          width={240}
-                          height={240}
-                          alt=""
-                        />
-                      </div>
-                    )}
-                    <div>
-                      <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
+          {!isEmpty(sections) &&
+            sections.map((section: any) => {
+              return (
+                <section className="pb-16" key={section.id}>
+                  {!section.image && !section.description ? (
+                    // simple section
+                    <div className="flex w-full pb-6 items-center justify-between">
+                      <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
                         {section.title}
                       </h2>
-                      {section.description && (
-                        <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700">
-                          {section.description}
-                        </ReactMarkdown>
-                      )}
                     </div>
-                  </div>
-                )}
-                <Grid className="grid grid-cols-2 lg:grid-cols-4 md:grid-cols-3 sm:gap-3 gap-2">
-                  {section.resources.map((resource: any, i: number) => {
-                    switch (section.resources.length) {
-                      case 2:
-                        return (
-                          <HorizontalResourceCard
-                            className="col-span-2"
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
+                  ) : (
+                    // section with image and description
+                    <div className="flex md:flex-row flex-col md:items-start items-center justify-center w-full mb-5 pb-8 md:space-x-10">
+                      {section.image && (
+                        <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
+                          <Image
+                            aria-hidden
+                            src={section.image}
+                            quality={100}
+                            width={240}
+                            height={240}
+                            alt=""
                           />
-                        )
-                      case 3:
-                        return i === 0 ? (
-                          <HorizontalResourceCard
-                            className="col-span-2"
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        ) : (
-                          <VerticalResourceCard
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
-                      case 6:
-                        return i === 0 || i === 1 ? (
-                          <HorizontalResourceCard
-                            className="col-span-2"
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        ) : (
-                          <VerticalResourceCard
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
-                      case 7:
-                        return i === 0 ? (
-                          <HorizontalResourceCard
-                            className="col-span-2"
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        ) : (
-                          <VerticalResourceCard
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
-                      default:
-                        return (
-                          <VerticalResourceCard
-                            key={resource.id}
-                            resource={resource}
-                            location={location}
-                          />
-                        )
-                    }
-                  })}
-                </Grid>
-              </section>
-            )
-          })}
+                        </div>
+                      )}
+                      <div>
+                        <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
+                          {section.title}
+                        </h2>
+                        {section.description && (
+                          <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700">
+                            {section.description}
+                          </ReactMarkdown>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  <Grid className="grid grid-cols-2 lg:grid-cols-4 md:grid-cols-3 sm:gap-3 gap-2">
+                    {section.resources.map((resource: any, i: number) => {
+                      switch (section.resources.length) {
+                        case 2:
+                          return (
+                            <HorizontalResourceCard
+                              className="col-span-2"
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                        case 3:
+                          return i === 0 ? (
+                            <HorizontalResourceCard
+                              className="col-span-2"
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          ) : (
+                            <VerticalResourceCard
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                        case 6:
+                          return i === 0 || i === 1 ? (
+                            <HorizontalResourceCard
+                              className="col-span-2"
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          ) : (
+                            <VerticalResourceCard
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                        case 7:
+                          return i === 0 ? (
+                            <HorizontalResourceCard
+                              className="col-span-2"
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          ) : (
+                            <VerticalResourceCard
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                        default:
+                          return (
+                            <VerticalResourceCard
+                              key={resource.id}
+                              resource={resource}
+                              location={location}
+                            />
+                          )
+                      }
+                    })}
+                  </Grid>
+                </section>
+              )
+            })}
         </div>
       </div>
     </>

--- a/src/hooks/use-load-topic-data.ts
+++ b/src/hooks/use-load-topic-data.ts
@@ -98,6 +98,7 @@ export const topicQuery = groq`*[_type == 'resource' && type == 'landing-page' &
           url,
           image,
           'name': type,
+          'description': summary,
           'instructor': collaborators[]->[role == 'instructor'][0]{
               'name': person->name,
               'image': person->image.url


### PR DESCRIPTION
![](https://media3.giphy.com/media/qOxDo9jqmgv3DMwHaB/200.gif?cid=5a38a5a2wc4ss4p19o3iaa3kf4v8cly94gdm4h4t08ohpsog&rid=200.gif&ct=g)

For the vertical resource card, we made the instructor optional. The issue was with outside links, such as the monorepo.tool, there isn't an instructor and it was erroring out. 

For the jumbotron, we made that optional because when we were building the page, without the jumbotron, the whole page would error and we couldn't see any of our changes that we made. Keeping it option, allows us to not have to create that part of our page first before moving onto other part of the page. 

For the sections, we added `{!isEmpty(sections) &&` for the same reason as above. If we made changes to the page but there weren't any sections, we would just get a full page 500 error and couldn't see our changes. 

We added in the `'description': summary,` for resources that weren't courses so we could add a description on the card. For example, Articles: 
![Screen Shot 2022-10-07 at 2 57 00 PM](https://user-images.githubusercontent.com/26470581/194668397-982f151a-2cc5-41a6-aa07-4ae18f38c358.png)
