### PR TITLE
Add custom landing page for Filip Hric

### DIFF
--- a/src/components/search/instructors/filip-hric/index.tsx
+++ b/src/components/search/instructors/filip-hric/index.tsx
@@ -51,12 +51,12 @@ export default function SearchFilipHric({
           <div className="my-4">
             <div className="flex flex-wrap sm:flex-nowrap gap-3 justify-center sm:h-[424px]">
               <VerticalResourceCard
-                className="col-span-1 flex flex-col h-full justify-center text-center w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
+                className="col-span-1 flex flex-col h-full justify-center text-center sm:w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
                 resource={primaryCourse}
                 as="h3"
               />
               <VerticalResourceCard
-                className="col-span-1 flex flex-col justify-center text-center w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
+                className="col-span-1 flex flex-col justify-center text-center sm:w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
                 resource={secondCourse}
                 as="h3"
               />

--- a/src/components/search/instructors/filip-hric/index.tsx
+++ b/src/components/search/instructors/filip-hric/index.tsx
@@ -168,7 +168,8 @@ const NewExternalTrackedLink: React.FunctionComponent<any> = ({
       event.stopPropagation()
 
       analytics.events
-        .activityExternalLinkClick(
+        .activityCtaClick(
+          'workshop',
           instructor,
           currentLocation,
           topic,

--- a/src/components/search/instructors/filip-hric/index.tsx
+++ b/src/components/search/instructors/filip-hric/index.tsx
@@ -1,0 +1,223 @@
+import React, {FunctionComponent} from 'react'
+import SearchInstructorEssential from '../instructor-essential'
+import Image from 'next/image'
+import {get} from 'lodash'
+import Link from 'next/link'
+import groq from 'groq'
+import {isFunction} from 'formik'
+import analytics from 'utils/analytics'
+
+import {Card} from 'components/card'
+
+import {track} from 'utils/analytics'
+import {HorizontalResourceCard} from 'components/card/horizontal-resource-card'
+import {VerticalResourceCard} from 'components/card/verticle-resource-card'
+
+export default function SearchFilipHric({
+  instructor,
+}: {
+  instructor: any
+  props: any
+}) {
+  const {
+    courses,
+    resources: {socials, workshopCta},
+    articles,
+  } = instructor
+  const [primaryCourse, secondCourse] = courses.resources
+
+  console.log({socials})
+  return (
+    <div className="">
+      <SearchInstructorEssential
+        instructor={instructor}
+        socials={socials}
+        CTAComponent={
+          <CypressCourseCTA
+            currentLocation="instructor landing page"
+            instructor="Filip Hric"
+            topic="cypress"
+            redirectTo="https://filiphric.com/cypress-core-workshop-november-2022"
+            image={workshopCta.image}
+            url={workshopCta.url}
+          />
+        }
+      />
+      <div className="flex flex-wrap justify-center xl:flex-nowrap gap-4">
+        <section className="text-center xl:text-left">
+          <h2 className="my-4 lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+            Courses
+          </h2>
+          <div className="my-4">
+            <div className="flex flex-wrap sm:flex-nowrap gap-3 justify-center sm:h-[424px]">
+              <VerticalResourceCard
+                className="col-span-1 flex flex-col h-full justify-center text-center w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
+                resource={primaryCourse}
+                as="h3"
+              />
+              <VerticalResourceCard
+                className="col-span-1 flex flex-col justify-center text-center w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
+                resource={secondCourse}
+                as="h3"
+              />
+            </div>
+          </div>
+        </section>
+        <section className="text-center xl:text-left">
+          <h2 className="my-4 lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+            Articles
+          </h2>
+          <div className="grid lg:grid-cols-2 grid-cols-1 gap-3 justify-center max-w-xl mx-auto">
+            <HorizontalResourceCard
+              className="col-span-2"
+              resource={articles.resources[0]}
+            />
+            <HorizontalResourceCard
+              className="col-span-2"
+              resource={articles.resources[1]}
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export const filipHricQuery = groq`*[_type == 'resource' && slug.current == "filip-hric-landing-page"][0]{
+	resources[slug.current == 'instructor-landing-page-projects'][0]{
+    'socials': resources[slug.current == 'socials'][0] {
+      'discord': resources[slug.current == 'discord'][0]{
+        title,
+        'url': urls[0].url
+      },
+      'youtube': resources[slug.current == 'youtube'][0]{
+        title,
+        'url': urls[0].url
+      },
+      'github': resources[slug.current == 'github'][0]{
+        title,
+        'url': urls[0].url
+      },
+      'linkedin': resources[slug.current == 'linkedin'][0]{
+        title,
+        'url': urls[0].url
+      },
+    },
+    'workshopCta': resources[slug.current == 'workshop-cta'][0] {
+      'url': urls[0].url,
+      image
+    }
+  },
+	'courses': resources[slug.current == 'instructor-landing-page-featured-courses'][0]{
+    resources[]->{
+      title,
+      'description': summary,
+    	path,
+      byline,
+    	image,
+      'background': images[label == 'feature-card-background'][0].url,
+      'instructor': collaborators[]->[role == 'instructor'][0]{
+      	'name': person->.name
+    	},
+    }
+  },
+  'articles': resources[slug.current == 'instructor-landing-page-featured-articles'][0]{
+    resources[] {
+      title,
+      summary,
+      image,
+      byline,
+      path,
+      collaborators[0]-> {
+        'name': person->name,
+        'image': person->image.url
+      }
+    }
+  }
+}`
+
+const isModifiedEvent = (event: any) =>
+  !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
+
+const NewExternalTrackedLink: React.FunctionComponent<any> = ({
+  currentLocation,
+  instructor,
+  topic,
+  redirectTo,
+  label,
+  children,
+  onClick = () => {},
+  ...props
+}) => {
+  const handleClick = (event: any) => {
+    const {href} = props
+
+    if (isFunction(props.onClick)) props.onClick(event)
+
+    function updateLocation() {
+      window.location.href = href || '#'
+    }
+
+    if (
+      !event.defaultPrevented && // onClick prevented default
+      event.button === 0 && // ignore right clicks
+      !props.target && // let browser handle "target=_blank" etc.
+      !isModifiedEvent(event) // ignore clicks with modifier keys
+    ) {
+      event.preventDefault()
+      event.stopPropagation()
+
+      analytics.events
+        .activityExternalLinkClick(
+          instructor,
+          currentLocation,
+          topic,
+          redirectTo,
+        )
+        .then(() => {
+          if (isFunction(onClick)) {
+            onClick()
+          }
+          updateLocation()
+        })
+      return false
+    }
+  }
+
+  let {eventName, ...rest} = props
+
+  return (
+    <a {...rest} aria-label={label || ''} onClick={handleClick}>
+      {children}
+    </a>
+  )
+}
+
+const CypressCourseCTA: React.FC<{
+  instructor: string
+  currentLocation: string
+  topic: string
+  redirectTo: string
+  image: string
+  url: string
+}> = ({instructor, currentLocation, topic, redirectTo, image, url}) => {
+  return (
+    <NewExternalTrackedLink
+      eventName="clicked epic react banner"
+      params={{currentLocation, instructor, topic, redirectTo}}
+      className="block md:col-span-4 lg:w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
+      href={url}
+      target="_blank"
+      rel="noopener"
+    >
+      <Image
+        priority
+        quality={100}
+        width={417}
+        height={463}
+        alt="Get Really Good at Cypress on with Filip Hric"
+        src={image}
+      />
+    </NewExternalTrackedLink>
+  )
+}

--- a/src/components/search/instructors/index.tsx
+++ b/src/components/search/instructors/index.tsx
@@ -19,6 +19,7 @@ import SearchMatiasHernandez from './matias-hernandez'
 import SearchLazarNikolov from './lazar-nikolov'
 import SearchChrisAchard from './chris-achard'
 import SearchKadiKraman from './kadi-kraman'
+import SearchFilipHric from './filip-hric'
 
 const InstructorsIndex: any = {
   'dan-abramov': SearchDanAbramov,
@@ -42,6 +43,7 @@ const InstructorsIndex: any = {
   'lazar-nikolov': SearchLazarNikolov,
   'chris-achard': SearchChrisAchard,
   'kadi-kraman': SearchKadiKraman,
+  'filip-hric': SearchFilipHric,
 }
 
 export default InstructorsIndex

--- a/src/components/search/instructors/instructor-essential.tsx
+++ b/src/components/search/instructors/instructor-essential.tsx
@@ -3,10 +3,12 @@ import Markdown from 'react-markdown'
 import Image from 'next/image'
 import {NextSeo} from 'next-seo'
 import DefaultCTA from '../curated/default-cta'
+import analytics from 'utils/analytics'
 
 type InstructorProps = {
   className?: string
   instructor: any
+  socials?: any
   CTAComponent?: React.ReactElement | React.FC
 }
 
@@ -15,6 +17,7 @@ const SearchInstructorEssential: FunctionComponent<InstructorProps> = ({
   className,
   CTAComponent,
   instructor,
+  socials,
 }) => {
   const {
     avatar_url: imageUrl,
@@ -26,6 +29,8 @@ const SearchInstructorEssential: FunctionComponent<InstructorProps> = ({
     company,
     bio,
   } = instructor
+
+  console.log({socials, slug})
 
   const location = `${name} landing`
   return (
@@ -75,6 +80,16 @@ const SearchInstructorEssential: FunctionComponent<InstructorProps> = ({
                     <a
                       href={`http://twitter.com/${twitterHandle}`}
                       className="text-gray-400 hover:text-gray-500"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        analytics.events.activityExternalLinkClick(
+                          slug,
+                          'Instructor Profile',
+                          'social',
+                          `http://twitter.com/${twitterHandle}`,
+                        )
+                      }}
                     >
                       <span className="sr-only">Twitter</span>
                       <svg
@@ -88,12 +103,134 @@ const SearchInstructorEssential: FunctionComponent<InstructorProps> = ({
                     </a>
                   </li>
                 )}
-
+                {socials?.github && (
+                  <li>
+                    <a
+                      href={socials?.github.url}
+                      className="text-gray-400 hover:text-gray-500  m-0"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        analytics.events.activityExternalLinkClick(
+                          slug,
+                          'Instructor Profile',
+                          'social',
+                          socials.github.url,
+                        )
+                      }}
+                    >
+                      <span className="sr-only">GitHub</span>
+                      <svg
+                        className="w-5 h-5"
+                        fill="currentColor"
+                        viewBox="0 0 25 25"
+                        aria-hidden="true"
+                      >
+                        <title>GitHub</title>
+                        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                      </svg>
+                    </a>
+                  </li>
+                )}
+                {socials?.linkedin && (
+                  <li>
+                    <a
+                      href={socials?.linkedin.url}
+                      className="text-gray-400 hover:text-gray-500  m-0"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        analytics.events.activityExternalLinkClick(
+                          slug,
+                          'Instructor Profile',
+                          'social',
+                          socials.linkedin.url,
+                        )
+                      }}
+                    >
+                      <span className="sr-only">LinkedIn</span>
+                      <svg
+                        className="w-7 h-5"
+                        fill="currentColor"
+                        viewBox="0 0 25 25"
+                        aria-hidden="true"
+                      >
+                        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                      </svg>
+                    </a>
+                  </li>
+                )}
+                {socials?.discord && (
+                  <li>
+                    <a
+                      href={socials?.discord.url}
+                      className="text-gray-400 hover:text-gray-500  m-0"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        analytics.events.activityExternalLinkClick(
+                          slug,
+                          'Instructor Profile',
+                          'social',
+                          socials?.discord.url,
+                        )
+                      }}
+                    >
+                      <span className="sr-only">Discord</span>
+                      <svg
+                        className="w-7 h-5"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        aria-hidden="true"
+                      >
+                        <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+                      </svg>
+                    </a>
+                  </li>
+                )}
+                {socials?.youtube && (
+                  <li>
+                    <a
+                      href={socials?.youtube.url}
+                      className="text-gray-400 hover:text-gray-500  m-0"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        analytics.events.activityExternalLinkClick(
+                          slug,
+                          'Instructor Profile',
+                          'social',
+                          socials?.youtube.url,
+                        )
+                      }}
+                    >
+                      <span className="sr-only">YouTube</span>
+                      <svg
+                        className="w-7 h-5"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        aria-hidden="true"
+                      >
+                        <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+                      </svg>
+                    </a>
+                  </li>
+                )}
                 {websiteUrl && (
                   <li>
                     <a
                       href={websiteUrl}
                       className="text-gray-400 hover:text-gray-500"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        analytics.events.activityExternalLinkClick(
+                          slug,
+                          'Instructor Profile',
+                          'social',
+                          websiteUrl,
+                        )
+                      }}
                     >
                       <span className="sr-only">Website</span>
                       <svg

--- a/src/components/search/instructors/stephanie-eckles/index.tsx
+++ b/src/components/search/instructors/stephanie-eckles/index.tsx
@@ -157,7 +157,7 @@ const CssFormStyling: React.FC<{location: string; resource: any}> = ({
     >
       <div className="md:min-h-[477px] md:-mt-5 flex items-center justify-center bg-white dark:bg-gray-900 text-white overflow-hidden rounded-b-lg md:rounded-t-none rounded-t-lg shadow-sm">
         {/* <div className="absolute top-0 left-0 bg-gradient-to-r from-yellow-500 to-sky-500 w-full h-2 z-20" /> */}
-        <div className="relative z-10 px-5 sm:py-16 py-10 sm:text-left text-center">
+        <div className="relative z-10 px-5 sm:py-16 py-10 sm:text-left text-center h-full">
           <div className="space-y-5 mx-auto flex items-center justify-center max-w-screen-xl">
             <div className="flex flex-col items-center justify-center sm:space-x-5 sm:space-y-0 space-y-5">
               <div className="flex-shrink-0">
@@ -182,12 +182,12 @@ const CssFormStyling: React.FC<{location: string; resource: any}> = ({
                 </Link>
               </div>
               <div className="flex flex-col sm:items-start items-center">
-                <p className="text-xs text-gray-900 dark:text-white  uppercase font-semibold mb-2">
+                <p className="text-xs text-white  uppercase font-semibold mb-2">
                   {byline}
                 </p>
                 <Link href={path}>
                   <a
-                    className="text-xl font-extrabold leading-tighter text-gray-900 dark:text-white hover:text-blue-300"
+                    className="text-xl font-extrabold leading-tighter text-white hover:text-blue-300"
                     onClick={() =>
                       track('clicked jumbotron resource', {
                         resource: path,
@@ -198,15 +198,13 @@ const CssFormStyling: React.FC<{location: string; resource: any}> = ({
                     <h2>{title}</h2>
                   </a>
                 </Link>
-                <p className="mt-4 text-gray-900 dark:text-white">
-                  {description}
-                </p>
+                <p className="mt-4text-white">{description}</p>
               </div>
             </div>
           </div>
         </div>
         <img
-          className="absolute top-0 left-0 z-0 w-full"
+          className="absolute top-0 left-0 z-0 h-full w-full"
           src={background}
           alt=""
         />

--- a/src/lib/instructors.ts
+++ b/src/lib/instructors.ts
@@ -17,6 +17,7 @@ import {ChrisBiscardiQuery} from 'components/search/instructors/chris-biscardi'
 import {LazarNikolovQuery} from 'components/search/instructors/lazar-nikolov'
 import {ChrisAchardQuery} from 'components/search/instructors/chris-achard'
 import {KadiKramanQuery} from 'components/search/instructors/kadi-kraman'
+import {filipHricQuery} from 'components/search/instructors/filip-hric'
 
 import config from './config'
 
@@ -56,6 +57,7 @@ export async function loadInstructor(slug: string) {
 
   if (canLoadSanityInstructor(slug)) {
     sanityInstructor = await loadSanityInstructor(slug)
+    console.log({sanityInstructor, slug})
   }
 
   return {...instructor, ...sanityInstructor}
@@ -78,6 +80,7 @@ const sanityInstructorHash = {
   'lazar-nikolov': LazarNikolovQuery,
   'chris-achard': ChrisAchardQuery,
   'kadi-kraman': KadiKramanQuery,
+  'filip-hric': filipHricQuery,
 }
 
 type SelectedInstructor = keyof typeof sanityInstructorHash
@@ -95,6 +98,6 @@ export const loadSanityInstructor = async (selectedInstructor: string) => {
 
   const query = sanityInstructorHash[selectedInstructor]
   if (!query) return
-
+  console.log(await sanityClient.fetch(query))
   return await sanityClient.fetch(query)
 }


### PR DESCRIPTION
this adds a custom landing page for Filip highlighting his egghead courses and articles. This also extends the `InstructorEssential` component to take more social media and display links for those. Filip has several links he would like shared.

Filip also runs a cypress workshop that I link to as the top CTA.


![Learn web development from Filip Hric on egghead  egghead io](https://user-images.githubusercontent.com/6188161/195183878-a3eca04f-6a9d-465e-8b81-81a701656e5e.png)
![Learn web development from Filip Hric on egghead  egghead io](https://user-images.githubusercontent.com/6188161/195183890-d10eb040-cc08-4d11-ace3-96d76debc11c.png)

![custom landing page](https://media.giphy.com/media/lp0nBuaRjcj13j3nMH/giphy.gif)