### PR TITLE
added a link to discord.js on the discord/callback page

### DIFF
--- a/src/pages/discord/callback.tsx
+++ b/src/pages/discord/callback.tsx
@@ -68,7 +68,8 @@ const CallbackPage: FunctionComponent<LoginRequiredParams> = ({
                   Your Discord account{' '}
                   {userData.discordUser &&
                     `(${userData.discordUser.username}#${userData.discordUser.discriminator} - ${userData.discordUser.email})`}{' '}
-                  has been updated.
+                  has been updated. Here is a link to
+                  [discord](https://discord.com/channels/@me)
                 </h1>
                 {userData.discordMember.guildId ===
                   process.env.NEXT_PUBLIC_DISCORD_GUILD_ID && (


### PR DESCRIPTION
I added a link to the discord/callback page for users to click to bring them to discord after verifying their egghead account with discord. I can't access this page locally but a simple link should be fine. Here is the link: [discord](https://discord.com/channels/@me). 

![ALT TEXT](https://media2.giphy.com/media/NVBR6cLvUjV9C/giphy.gif?cid=5a38a5a2ui8om0o1tth2nvtc702s4up4b9rfrqss7r69m4tt&rid=giphy.gif&ct=g)