### PR TITLE
added styling to the discord callback page

### DIFF
--- a/src/pages/discord/callback.tsx
+++ b/src/pages/discord/callback.tsx
@@ -49,28 +49,39 @@ const CallbackPage: FunctionComponent<LoginRequiredParams> = ({
 
   return (
     <LoginRequired loginRequired={loginRequired}>
-      <div>
+      <div className=" max-w-screen-lg mx-auto mt-6">
+        <h1 className=" text-2xl block w-2/3 mx-auto">Discord Info</h1>
         {syncingAccount ? (
           <>
-            <h1>
+            <p className="text-center text-xl pt-16">
               <span role="img" aria-label="recycle">
                 ♻️
               </span>{' '}
               Currently syncing your egghead account to the egghead Discord
-              server. Please wait!
-            </h1>
+              server.
+            </p>
+            <p className="text-center text-xl">Please wait!</p>
           </>
         ) : (
           <>
             {userData && (
               <div className="flex flex-col space-y-3">
-                <h1>
-                  Your Discord account{' '}
-                  {userData.discordUser &&
-                    `(${userData.discordUser.username}#${userData.discordUser.discriminator} - ${userData.discordUser.email})`}{' '}
-                  has been updated. Here is a link to
-                  [discord](https://discord.com/channels/@me)
-                </h1>
+                <p className="text-center pt-16">
+                  Your Discord account (
+                  <span className="font-bold">
+                    {userData.discordUser &&
+                      `(${userData.discordUser.username}#${userData.discordUser.discriminator} - ${userData.discordUser.email})`}{' '}
+                  </span>
+                  ) has been updated. Here is a link to{' '}
+                  <a
+                    className="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://discord.com/channels/@me"
+                  >
+                    discord.
+                  </a>
+                </p>
                 {userData.discordMember.guildId ===
                   process.env.NEXT_PUBLIC_DISCORD_GUILD_ID && (
                   <div>We added you to the egghead Discord!</div>
@@ -87,13 +98,13 @@ const CallbackPage: FunctionComponent<LoginRequiredParams> = ({
             )}
           </>
         )}
-        <div className="pt-16">
-          <h2 className="text-2xl font-bold">FAQ</h2>
+        <div className="pt-16 w-2/3 mx-auto">
+          <h2 className="text-2xl font-semibold">FAQ</h2>
           <div>
-            <h3 className="text-lg font-bold">
+            <h3 className="text-lg font-bold mt-4">
               The egghead Discord doesn't show up in my server list?
             </h3>
-            <p>
+            <p className="mt-4">
               The authorization flow uses the Discord account currently logged
               in to the browser. Sometimes this is different than the account
               logged into the Discord app.


### PR DESCRIPTION
The discord callback page was seriously lacking in styling. Zac and I ran through and did a first pass on basic styles and page structure.
 
Here is the old page: 
![Screen Shot 2022-10-12 at 9 22 31 AM](https://user-images.githubusercontent.com/26470581/195397010-65e4f29e-596e-410c-af65-1b0381a184a4.png)

Here is the new page: 
![Screen Shot 2022-10-12 at 9 22 23 AM](https://user-images.githubusercontent.com/26470581/195397043-a54fee54-a8c6-474b-97e1-4a200c5e3787.png)

![GIF](https://media1.giphy.com/media/ghAbYUswkmXHq/giphy.gif?cid=5a38a5a2u0grua84nn7xzaygnx4n7vplp3s5gyfj1xep4q77&rid=giphy.gif&ct=g)