### PR TITLE
deleting login tracking events

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -156,9 +156,6 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                               type="submit"
                               disabled={isSubmitting}
                               className="w-full px-5 py-3 mt-2 font-medium text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md hover:bg-blue-700 active:bg-blue-800"
-                              onClick={() => {
-                                analytics.events.activityLogIn('Email LogIn')
-                              }}
                             >
                               {button}
                             </button>
@@ -169,9 +166,6 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
                           <ExternalTrackedLink
                             href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}`}
                             className="flex justify-center px-5 py-3 mt-4 font-medium text-white transition-all duration-300 ease-in-out bg-gray-800 rounded-md hover:bg-gray-700 active:bg-gray-600"
-                            onClick={() => {
-                              analytics.events.activityLogIn('GitHub LogIn')
-                            }}
                           >
                             <div className="flex items-center dark:text-gray-100">
                               <span className="flex items-center justify-center mr-2">


### PR DESCRIPTION
Some users are presenting login problems with email and github, this problem seems to come from the tracking events implemented coming from this [PR](https://github.com/eggheadio/egghead-next/pull/1222)

![image](https://user-images.githubusercontent.com/43156646/195911250-38fe656a-c805-4a36-8541-e211f179aba4.png)

Deleting the events solve the console problems. Not sure what's the root of the problem, but the theory is that since we `noop` the old events, adding the `onClick` event in `ExternalTrackedLink` messed up the redirect using github. 

Hopefully, this PR allows users to login, and we will further investigate how to track the events properly. 

![oops](https://media.giphy.com/media/80TEu4wOBdPLG/giphy.gif)
