### PR TITLE
seo: update canonical url and description for SEO

### DIFF
--- a/src/layouts/fancy-guide.tsx
+++ b/src/layouts/fancy-guide.tsx
@@ -1,6 +1,7 @@
 import React, {FunctionComponent} from 'react'
 import {NextSeo} from 'next-seo'
 import Contributors from '../components/contributors'
+import {useRouter} from 'next/router'
 
 type LayoutProps = {
   meta?: {
@@ -17,14 +18,20 @@ const FancyGuideLayout: FunctionComponent<LayoutProps> = ({
   children,
   meta = {},
 }) => {
+  const router = useRouter()
+  const url = process.env.NEXT_PUBLIC_DEPLOYMENT_URL + router.asPath
+
   const {
     title,
     description,
     titleAppendSiteName = false,
-    url,
+    url: urlFromProps,
     ogImage,
     contributors,
   } = meta
+
+  const canonicalUrl = urlFromProps ? urlFromProps : url
+
   return (
     <>
       <NextSeo
@@ -37,10 +44,10 @@ const FancyGuideLayout: FunctionComponent<LayoutProps> = ({
         openGraph={{
           title,
           description,
-          url,
+          url: canonicalUrl,
           images: ogImage ? [ogImage] : undefined,
         }}
-        canonical={url}
+        canonical={canonicalUrl}
       />
       <div className="container">
         <article className="max-w-screen-md mx-auto mt-5 mb-16">

--- a/src/pages/learn/javascript/the-dom/index.mdx
+++ b/src/pages/learn/javascript/the-dom/index.mdx
@@ -1,5 +1,7 @@
 export const meta = {
   title: `What is the DOM?`,
+  description:
+    'The DOM is an acronym for “Document Object Model which is a tree that shows relationships between elements as parents, children and siblings.',
   contributors: [{name: 'Hiro Nishimura'}, {name: 'Maggie Appleton'}],
 }
 


### PR DESCRIPTION
What is DOM? and what is the dom? are high volume searches (33k/m) which we have very little clicks for. This updates the page with a canonical url and better description which will hopefully increase SEO and click through.


Our page description is lacking for this: 
![image](https://user-images.githubusercontent.com/6188161/197615187-3e1cfb0a-1ff7-4ac5-9e62-7a3cd3c2204e.png)

![image](https://user-images.githubusercontent.com/6188161/197614936-c11f964d-6bef-435d-af0b-6c628f0136cf.png)


![canon](https://media.giphy.com/media/ZXkaSA4kozNfKEi6Ua/giphy.gif)