### PR TITLE
Add resource widget for more flexible articles

### DIFF
--- a/src/components/mdx/resource-widget.tsx
+++ b/src/components/mdx/resource-widget.tsx
@@ -1,11 +1,13 @@
 import Grid from 'components/grid'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
-import {CardResource} from 'types'
+import analytics from 'utils/analytics'
 
-const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
-  resource,
-}: any) => {
+const ResourceWidget: React.FC<{
+  resource: any
+  cta?: string
+  location?: string
+}> = ({resource, location}: any) => {
   const {podcasts, talks, collections} = resource
   return (
     <>
@@ -22,12 +24,14 @@ const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
                     case 3:
                       return i === 0 ? (
                         <HorizontalResourceCard
+                          location={location}
                           className="col-span-2"
                           key={resource.slug}
                           resource={resource}
                         />
                       ) : (
                         <VerticalResourceCard
+                          location={location}
                           key={resource.slug}
                           resource={resource}
                         />
@@ -35,12 +39,14 @@ const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
                     case 6:
                       return i === 0 || i === 1 ? (
                         <HorizontalResourceCard
+                          location={location}
                           className="col-span-2"
                           key={resource.slug}
                           resource={resource}
                         />
                       ) : (
                         <VerticalResourceCard
+                          location={location}
                           key={resource.slug}
                           resource={resource}
                         />
@@ -48,12 +54,14 @@ const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
                     case 7:
                       return i === 0 ? (
                         <HorizontalResourceCard
+                          location={location}
                           className="col-span-2"
                           key={resource.slug}
                           resource={resource}
                         />
                       ) : (
                         <VerticalResourceCard
+                          location={location}
                           key={resource.slug}
                           resource={resource}
                         />
@@ -61,6 +69,7 @@ const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
                     default:
                       return (
                         <VerticalResourceCard
+                          location={location}
                           key={resource.slug}
                           resource={resource}
                         />
@@ -74,11 +83,21 @@ const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
       {(podcasts || talks) && (
         <Grid className="grid grid-cols-2 gap-2 md:grid-cols-4 xl:gap-5 sm:gap-3">
           {talks.map((talk: any) => {
-            return <VerticalResourceCard key={talk.slug} resource={talk} />
+            return (
+              <VerticalResourceCard
+                key={talk.slug}
+                resource={talk}
+                location={talk.location}
+              />
+            )
           })}
           {podcasts.map((podcast: any) => {
             return (
-              <VerticalResourceCard key={podcast.slug} resource={podcast} />
+              <VerticalResourceCard
+                key={podcast.slug}
+                resource={podcast}
+                location={podcast.location}
+              />
             )
           })}
         </Grid>

--- a/src/components/mdx/resource-widget.tsx
+++ b/src/components/mdx/resource-widget.tsx
@@ -1,0 +1,90 @@
+import Grid from 'components/grid'
+import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
+import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
+import {CardResource} from 'types'
+
+const ResourceWidget: React.FC<{course: any; cta?: string}> = ({
+  resource,
+}: any) => {
+  const {podcasts, talks, collections} = resource
+  return (
+    <>
+      {collections &&
+        collections.map((collection: any) => {
+          return (
+            <div>
+              <h4 className="prose dark:prose-dark sm:prose-lg lg:prose-xl mt-5 max-w-none dark:prose-a:text-blue-300 prose-a:text-blue-500 font-bold">
+                {collection.title}
+              </h4>
+              <Grid>
+                {collection.courses.map((resource: any, i: number) => {
+                  switch (collection.courses.length) {
+                    case 3:
+                      return i === 0 ? (
+                        <HorizontalResourceCard
+                          className="col-span-2"
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      ) : (
+                        <VerticalResourceCard
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      )
+                    case 6:
+                      return i === 0 || i === 1 ? (
+                        <HorizontalResourceCard
+                          className="col-span-2"
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      ) : (
+                        <VerticalResourceCard
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      )
+                    case 7:
+                      return i === 0 ? (
+                        <HorizontalResourceCard
+                          className="col-span-2"
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      ) : (
+                        <VerticalResourceCard
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      )
+                    default:
+                      return (
+                        <VerticalResourceCard
+                          key={resource.slug}
+                          resource={resource}
+                        />
+                      )
+                  }
+                })}
+              </Grid>
+            </div>
+          )
+        })}
+      {(podcasts || talks) && (
+        <Grid className="grid grid-cols-2 gap-2 md:grid-cols-4 xl:gap-5 sm:gap-3">
+          {talks.map((talk: any) => {
+            return <VerticalResourceCard key={talk.slug} resource={talk} />
+          })}
+          {podcasts.map((podcast: any) => {
+            return (
+              <VerticalResourceCard key={podcast.slug} resource={podcast} />
+            )
+          })}
+        </Grid>
+      )}
+    </>
+  )
+}
+
+export default ResourceWidget

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -114,7 +114,11 @@ const Tag = (props: any) => {
                   const resource = find(articleResources, {slug: resourceSlug})
                   return resource ? (
                     <div className="not-prose my-8">
-                      <ResourceWidget resource={resource} {...props} />
+                      <ResourceWidget
+                        resource={resource}
+                        location={resource.location}
+                        {...props}
+                      />
                     </div>
                   ) : null
                 },
@@ -175,6 +179,7 @@ const query = groq`*[_type == "post" && slug.current == $slug][0]{
   coverImage,
   body,
   "articleResources": resources[type == "collection"]{
+    "location": content[0].text,
     title,
     "slug": slug.current,
     "podcasts": resources[type == "podcast"]{

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -96,14 +96,6 @@ const Tag = (props: any) => {
                 />
               </div>
             )}
-            {categories && (
-              <ul>
-                Posted in
-                {categories.map((category: any) => (
-                  <li key={category}>{category}</li>
-                ))}
-              </ul>
-            )}
           </header>
           <main>
             <MDXRemote

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -12,6 +12,7 @@ import {NextSeo} from 'next-seo'
 import {useRouter} from 'next/router'
 import {withProse} from 'utils/remark/with-prose'
 import CourseWidget from 'components/mdx/course-widget'
+import ResourceWidget from 'components/mdx/resource-widget'
 import find from 'lodash/find'
 import {useScrollTracker} from 'react-scroll-tracker'
 import analytics from 'utils/analytics'
@@ -28,6 +29,7 @@ const Tag = (props: any) => {
     seo = {},
     coverImage,
     source,
+    articleResources,
     resources,
   } = props
 
@@ -116,6 +118,14 @@ const Tag = (props: any) => {
                     </div>
                   ) : null
                 },
+                ResourceWidget: ({resource: resourceSlug, ...props}: any) => {
+                  const resource = find(articleResources, {slug: resourceSlug})
+                  return resource ? (
+                    <div className="not-prose my-8">
+                      <ResourceWidget resource={resource} {...props} />
+                    </div>
+                  ) : null
+                },
               }}
             />
           </main>
@@ -172,6 +182,45 @@ const query = groq`*[_type == "post" && slug.current == $slug][0]{
   seo,
   coverImage,
   body,
+  "articleResources": resources[type == "collection"]{
+    title,
+    "slug": slug.current,
+    "podcasts": resources[type == "podcast"]{
+      title,
+      image,
+      path,
+      "description": byline,
+      "slug": slug.current,
+      "name": type,
+  },
+   "collections": resources[type == "collection"]{
+     title,
+     'courses': resources[]->{
+       type,
+       title,
+       image,
+       path,
+       "description": summary,
+       byline,
+       'instructor': collaborators[]->[role == 'instructor'][0]{
+        title,
+        'slug': person->slug.current,
+        'name': person->name,
+        'path': person->website,
+        'twitter': person->twitter,
+        'image': person->image.url
+      },
+     }
+   },
+   "talks": resources[_type == "reference"]->{
+     title,
+     image,
+     "description": byline,
+     byline,
+     path,
+     "name": type,
+   }
+  },
   "resources": resources[]-> {
     title,
     'instructor': collaborators[]->[role == 'instructor'][0]{


### PR DESCRIPTION
This PR is preparatory for [a resource I've put together](https://egghead.notion.site/Land-That-Next-Role-in-Tech-14ff4ce7f25947d6a33de9f5679004e8) for people looking for their next job. 

this creates a more generic `ResourceWidget` that will handle podcasts, talks, and groupings of courses. 

![buffalo](https://media.giphy.com/media/26AHQVhagLrkZKnDi/giphy-downsized.gif)

![desktop view of article](https://user-images.githubusercontent.com/6188161/202723654-82261338-9d52-4b09-bf1b-74a44b575bd5.png)
![mobile view of article](https://user-images.githubusercontent.com/6188161/202723666-bd6c9308-0118-4e82-8bc1-328213d573d6.png)
