### PR TITLE
Update banner for sale

### DIFF
--- a/src/components/cta/sale/header-banner.tsx
+++ b/src/components/cta/sale/header-banner.tsx
@@ -25,7 +25,7 @@ const SaleHeaderBanner = () => {
             <span role="img" aria-hidden="true">
               🌟
             </span>{' '}
-            Fall Sale:{' '}
+            End of Year Sale:{' '}
             <span>
               Save <strong>{percentOff}%</strong> on yearly memberships
               {appliedCoupon.coupon_expires_at && ' for limited time'}.{' '}


### PR DESCRIPTION
Went with `End of Year` because we will be on sale for 2 weeks


![Expert led courses for front-end web developers   egghead io](https://user-images.githubusercontent.com/6188161/203568200-997a801f-a895-4c1b-8f4c-a0b3ae778e24.png)

![sale](https://media.giphy.com/media/l3q2t2KAyvxy9xBe0/giphy-downsized.gif)