### PR TITLE
"Completed" label on course page

### DIFF
--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -46,9 +46,9 @@ const Home: React.FC<any> = ({data, jumbotron, location}) => {
             .filter((s: any) => s.slug !== 'jumbotron')
             .map((section: any, i: number) => {
               return section.slug === 'topics' ? (
-                <Topics data={section} />
+                <Topics data={section} key={i} />
               ) : (
-                <section className="pb-16" key={section.id}>
+                <section className="pb-16" key={section.slug}>
                   {!section.image && !section.description ? (
                     // simple section
                     <div className="flex items-center justify-between w-full pb-6">


### PR DESCRIPTION
This adds the "Completed label" on the Course page in case user have already completed it.

![Screen Recording 2022-11-28 at 14 26 15](https://user-images.githubusercontent.com/1519448/204394771-c325faa8-bf7f-485c-8c58-53cfb89d0f5c.gif)

There are few bugs to fix:
1) some users complaint that not all completed courses are marked as "completed", I have created related issue: https://github.com/eggheadio/egghead-next/issues/1240
2) Play button should display "Start watching" or "Continue watching" depends on progress, but it seems it doesn't work ("Start watching" is shown always) - will tackle it in separate PR.

![shia-labeouf-even-stevens (1)](https://user-images.githubusercontent.com/1519448/204395599-3fda9905-fd50-4a13-8703-4e97677b0c11.gif)

P.S. Also fixed "unique key attribute" warning on the Home page, just it was too minor for separate PR. 
