### PR TITLE
fix flash of "Complete" on Page Load

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -121,14 +121,11 @@ export const PeopleCompleted: React.FunctionComponent<{count: number}> = ({
   </div>
 )
 
-const useIsCourseCompleted = (viewerId: number, slug: string) => {
+const useCompletedCourses = (viewerId: number) => {
   return useQuery(['completeCourses'], async () => {
     if (viewerId) {
       const {completeCourses} = await loadUserCompletedCourses()
-      const isCompleted = completeCourses.some(
-        (course: any) => course?.collection?.slug === slug,
-      )
-      return isCompleted
+      return completeCourses
     }
   })
 }
@@ -143,7 +140,12 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
   const [clickable, setIsClickable] = React.useState(true)
   const {viewer} = useViewer()
   const viewerId = viewer?.id
-  const {data: isCourseCompleted} = useIsCourseCompleted(viewerId, course.slug)
+  const {data: completedCourses} = useCompletedCourses(viewerId)
+  const isCourseCompleted =
+    !isEmpty(completedCourses) &&
+    completedCourses.some(
+      (courseItem: any) => courseItem?.collection?.slug === course.slug,
+    )
   const defaultPairWithResources: any[] = take(
     [
       {


### PR DESCRIPTION
related Linear issue: https://linear.app/skillrecordings/issue/EGG-41/flash-of-complete-on-page-load

Should be fixed now.

![giphy](https://user-images.githubusercontent.com/1519448/207419979-2cd8cb55-0ab0-43f5-83a2-34fd709d9ccf.gif)
