### PR TITLE
fix: update Claude Code image URL to resolve 404 error

### DIFF
--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -12,7 +12,7 @@ import {InstantSearchSSRProvider} from 'react-instantsearch'
 const topics = [
   {
     image:
-      'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1754499088/claude-code.png',
+      'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1758918145/claude_hfq89e.png',
     path: '/q/claude-code',
     title: 'Claude Code',
   },


### PR DESCRIPTION

![https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzdnZjl1cDUxNmswZGZueWxnbWdiZG5yZ2Jlbnc0YzB4ejNiYXR4MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UzAqj1KIbS4qA/giphy.gif](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzdnZjl1cDUxNmswZGZueWxnbWdiZG5yZ2Jlbnc0YzB4ejNiYXR4MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UzAqj1KIbS4qA/giphy.gif)
The previous Cloudinary URL for claude-code.png was returning a 404 error, causing a broken image on the homepage. Updated to use a working Claude image URL that returns 200 OK.

- Changed from v1754499088/claude-code.png (404)
- To v1758918145/claude_hfq89e.png (200 OK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Claude Code topic image displayed on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->