### PR TITLE
feat: add Oct 3rd and Nov 7th sold out workshops to history

### DIFF
--- a/src/components/workshop/claude-code/workshop-history.tsx
+++ b/src/components/workshop/claude-code/workshop-history.tsx
@@ -8,6 +8,8 @@ const workshops: WorkshopData[] = [
   {date: 'Aug 08, 2025', attendees: 69},
   {date: 'Aug 15, 2025', attendees: 46},
   {date: 'Sep 12, 2025', attendees: 33},
+  {date: 'Oct 03, 2025', attendees: 45},
+  {date: 'Nov 07, 2025', attendees: 52},
 ]
 
 export default function WorkshopHistory() {


### PR DESCRIPTION
## Summary
- Added Oct 3rd, 2025 workshop (45 attendees) to workshop history
- Added Nov 7th, 2025 workshop (52 attendees) to workshop history
- Total workshops now: 6 sold out sessions with 288 developers trained

![Sold Out](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcDdqOHVvNmY3bGZ4OGx0ODRvZGpxbGxsaHRsbGM0OGQ1bXMyNHZuNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0MYt5jPR6QX5pnqM/giphy.gif)

## Test Plan
- [ ] Verify Oct 3rd and Nov 7th workshops appear in workshop history
- [ ] Check total attendees calculation updates correctly
- [ ] Confirm SOLD OUT badges display for all workshops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new workshop dates: October 3, 2025 (45 attendees) and November 7, 2025 (52 attendees).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->