### PR TITLE
chore: add Nov 21, 2025 sold out workshop

### DIFF
--- a/src/components/workshop/claude-code/workshop-history.tsx
+++ b/src/components/workshop/claude-code/workshop-history.tsx
@@ -10,6 +10,7 @@ const workshops: WorkshopData[] = [
   {date: 'Sep 12, 2025', attendees: 33},
   {date: 'Oct 03, 2025', attendees: 45},
   {date: 'Nov 07, 2025', attendees: 52},
+  {date: 'Nov 21, 2025', attendees: 45},
 ]
 
 export default function WorkshopHistory() {


### PR DESCRIPTION
## Summary
- Add 7th workshop entry (Nov 21, 2025) to the workshop history display
- 45 attendees for this workshop
- Updates total to 7 workshops and 333 developers trained

## Test plan
- [ ] Verify workshop history page displays 7 entries
- [ ] Verify totals update correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workshop records with a new session scheduled for November 21, 2025, with 45 attendees.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->