### PR TITLE
fix: eliminate /api/cio-subscriber 500s (57% of all frontend errors)

### DIFF
--- a/src/pages/api/cio-subscriber.ts
+++ b/src/pages/api/cio-subscriber.ts
@@ -5,26 +5,28 @@ import getTracer from '@/utils/honeycomb-tracer'
 import {setupHttpTracing} from '@/utils/tracing-js/dist/src/index'
 import {CIO_IDENTIFIER_KEY} from '@/config'
 import {ENCODED_CUSTOMER_IO_TRACKING_API_CREDENTIALS} from '@/lib/customer-io'
-import {inngest} from '@/inngest/inngest.server'
-import {SEND_SLACK_MESSAGE_EVENT} from '@/inngest/events/send-slack-message'
 import {reportCioApiError} from '@/utils/cio/report-cio-api-error'
 
 const serverCookie = require('cookie')
 const axios = require('axios')
-const {first} = require('lodash')
 
 const tracer = getTracer('subscriber-api')
 
 const CIO_BASE_URL = `https://beta-api.customer.io/v1/api/`
 
+const RAILS_TIMEOUT_MS = 5000
+const CIO_TIMEOUT_MS = 3000
+
 const cioAxios = axios.create({
   baseURL: CIO_BASE_URL,
+  timeout: CIO_TIMEOUT_MS,
 })
 
 const EGGHEAD_AUTH_DOMAIN = process.env.NEXT_PUBLIC_AUTH_DOMAIN
 
 const eggAxios = axios.create({
   baseURL: EGGHEAD_AUTH_DOMAIN,
+  timeout: RAILS_TIMEOUT_MS,
 })
 
 async function fetchEggheadUser(token: any) {
@@ -44,100 +46,188 @@ async function fetchEggheadUser(token: any) {
 
 const cioSubscriber = async (req: NextApiRequest, res: NextApiResponse) => {
   setupHttpTracing({name: cioSubscriber.name, tracer, req, res})
+  const startTime = Date.now()
 
-  if (req.method === 'GET') {
-    try {
-      const {cioId, eggheadToken} = getTokenFromCookieHeaders(
-        req.headers.cookie as string,
+  if (req.method !== 'GET') {
+    console.error('non-get request made')
+    res.status(404).end()
+    return
+  }
+
+  // No cookies = no user to identify. Return 200 immediately.
+  // This eliminates all bot/crawler 500s (57% of frontend errors).
+  if (!req.headers.cookie) {
+    console.debug(
+      JSON.stringify({
+        event: 'cio_subscriber_skip',
+        reason: 'no_cookies',
+        duration_ms: Date.now() - startTime,
+      }),
+    )
+    res.status(200).end()
+    return
+  }
+
+  try {
+    const {cioId, eggheadToken} = getTokenFromCookieHeaders(
+      req.headers.cookie || '',
+    )
+
+    // No CIO id and no auth token = anonymous user with random cookies
+    if (!cioId && !eggheadToken) {
+      console.debug(
+        JSON.stringify({
+          event: 'cio_subscriber_skip',
+          reason: 'no_identifiers',
+          duration_ms: Date.now() - startTime,
+        }),
       )
+      res.status(200).end()
+      return
+    }
 
-      if (!process.env.CUSTOMER_IO_APPLICATION_API_KEY)
-        throw new Error('No CIO Secret Key Found')
+    if (!process.env.CUSTOMER_IO_APPLICATION_API_KEY) {
+      throw new Error('No CIO Secret Key Found')
+    }
 
-      let subscriber
+    let subscriber
 
-      if (!cioId) {
-        const eggheadUser = await fetchEggheadUser(eggheadToken)
+    if (!cioId) {
+      const eggheadUser = await fetchEggheadUser(eggheadToken)
 
-        if (!eggheadUser || eggheadUser.opted_out || !eggheadUser.contact_id) {
-        } else {
-          const headers = {
-            'content-type': 'application/json',
-            Authorization: `Basic ${ENCODED_CUSTOMER_IO_TRACKING_API_CREDENTIALS}`,
-          }
-
-          try {
-            await axios.put(
-              `https://track.customer.io/api/v1/customers/${eggheadUser.contact_id}`,
-              {
-                email: eggheadUser.email,
-                pro: eggheadUser.is_pro,
-                created_at: eggheadUser.created_at,
-              },
-              {headers},
-            )
-          } catch (syncError: any) {
-            console.error('CIO tracking sync failed:', syncError?.message)
-          }
-
-          subscriber = await cioAxios
-            .get(`/customers/${eggheadUser.contact_id}/attributes`, {
-              headers: {
-                Authorization: `Bearer ${process.env.CUSTOMER_IO_APPLICATION_API_KEY}`,
-              },
-            })
-            .then(({data}: {data: any}) => data.customer)
-            .catch((error: any) => {
-              console.error('CIO attributes fetch failed:', error?.message)
-              return undefined
-            })
-        }
+      if (!eggheadUser || eggheadUser.opted_out || !eggheadUser.contact_id) {
+        // User found but not identifiable in CIO
       } else {
+        const headers = {
+          'content-type': 'application/json',
+          Authorization: `Basic ${ENCODED_CUSTOMER_IO_TRACKING_API_CREDENTIALS}`,
+        }
+
+        try {
+          await axios.put(
+            `https://track.customer.io/api/v1/customers/${eggheadUser.contact_id}`,
+            {
+              email: eggheadUser.email,
+              pro: eggheadUser.is_pro,
+              created_at: eggheadUser.created_at,
+            },
+            {headers, timeout: CIO_TIMEOUT_MS},
+          )
+        } catch (syncError: any) {
+          console.error(
+            JSON.stringify({
+              event: 'cio_subscriber_error',
+              error_type: 'cio_sync',
+              error_message: syncError?.message,
+              error_status: syncError?.response?.status,
+              contact_id: eggheadUser.contact_id,
+              duration_ms: Date.now() - startTime,
+            }),
+          )
+        }
+
         subscriber = await cioAxios
-          .get(`/customers/${cioId}/attributes`, {
+          .get(`/customers/${eggheadUser.contact_id}/attributes`, {
             headers: {
               Authorization: `Bearer ${process.env.CUSTOMER_IO_APPLICATION_API_KEY}`,
             },
           })
-          .then(({data}: {data: any}) => {
-            return data.customer
-          })
+          .then(({data}: {data: any}) => data.customer)
           .catch((error: any) => {
-            console.error('CIO attributes fetch failed:', error?.message)
+            console.error(
+              JSON.stringify({
+                event: 'cio_subscriber_error',
+                error_type: 'cio_attributes',
+                error_message: error?.message,
+                error_status: error?.response?.status,
+                contact_id: eggheadUser.contact_id,
+                duration_ms: Date.now() - startTime,
+              }),
+            )
             return undefined
           })
       }
-
-      if (subscriber) {
-        const cioCookie = serverCookie.serialize(
-          CIO_IDENTIFIER_KEY,
-          subscriber.id,
-          {
-            secure: process.env.NODE_ENV === 'production',
-            path: '/',
-            maxAge: 31556952,
+    } else {
+      subscriber = await cioAxios
+        .get(`/customers/${cioId}/attributes`, {
+          headers: {
+            Authorization: `Bearer ${process.env.CUSTOMER_IO_APPLICATION_API_KEY}`,
           },
-        )
+        })
+        .then(({data}: {data: any}) => {
+          return data.customer
+        })
+        .catch((error: any) => {
+          console.error(
+            JSON.stringify({
+              event: 'cio_subscriber_error',
+              error_type: 'cio_attributes',
+              error_message: error?.message,
+              error_status: error?.response?.status,
+              cio_id: cioId,
+              duration_ms: Date.now() - startTime,
+            }),
+          )
+          return undefined
+        })
+    }
 
-        res.setHeader('Set-Cookie', cioCookie)
-        // res.setHeader('Cache-Control', 'max-age=1, stale-while-revalidate')
-        res.status(200).json(subscriber)
-      } else {
-        console.debug('no subscriber was loaded')
-        res.status(200).end()
-      }
-    } catch (error: any) {
-      if (process.env.NODE_ENV === 'development') return
-      console.error(error)
+    if (subscriber) {
+      const cioCookie = serverCookie.serialize(
+        CIO_IDENTIFIER_KEY,
+        subscriber.id,
+        {
+          secure: process.env.NODE_ENV === 'production',
+          path: '/',
+          maxAge: 31556952,
+        },
+      )
+
+      res.setHeader('Set-Cookie', cioCookie)
+      res.setHeader('Cache-Control', 'private, max-age=60')
+      console.debug(
+        JSON.stringify({
+          event: 'cio_subscriber_success',
+          has_subscriber: true,
+          cio_id: subscriber.id,
+          duration_ms: Date.now() - startTime,
+        }),
+      )
+      res.status(200).json(subscriber)
+    } else {
+      console.debug(
+        JSON.stringify({
+          event: 'cio_subscriber_success',
+          has_subscriber: false,
+          duration_ms: Date.now() - startTime,
+        }),
+      )
+      res.status(200).end()
+    }
+  } catch (error: any) {
+    if (process.env.NODE_ENV === 'development') return
+
+    console.error(
+      JSON.stringify({
+        event: 'cio_subscriber_error',
+        error_type: error?.code === 'ECONNABORTED' ? 'timeout' : 'unhandled',
+        error_message: error?.message,
+        error_status: error?.response?.status,
+        has_cookies: !!req.headers.cookie,
+        duration_ms: Date.now() - startTime,
+      }),
+    )
+
+    try {
       if (error.response?.status !== 404) {
         await reportCioApiError(error)
       }
-
-      res.status(200).end()
+    } catch {
+      // Never let error reporting crash the handler
     }
-  } else {
-    console.error('non-get request made')
-    res.status(404).end()
+
+    // Always return 200 — this endpoint is non-critical
+    res.status(200).end()
   }
 }
 

--- a/src/utils/cio/report-cio-api-error.ts
+++ b/src/utils/cio/report-cio-api-error.ts
@@ -1,29 +1,26 @@
-import {SEND_SLACK_MESSAGE_EVENT} from '@/inngest/events/send-slack-message'
-import {inngest} from '@/inngest/inngest.server'
-
+/**
+ * Reports CIO API errors with structured logging.
+ * Defensive: never throws, even for non-axios errors.
+ */
 export async function reportCioApiError(error: any) {
-  console.error('CIO API error:', error)
+  try {
+    const isAxiosError = !!error?.response
+    const cioId = isAxiosError
+      ? error.response?.config?.url?.split('/')?.pop()
+      : undefined
 
-  const cioId = error.response.config.url.split('/').pop()
-  // await inngest.send({
-  //   name: SEND_SLACK_MESSAGE_EVENT,
-  //   data: {
-  //     messageType: 'error',
-  //     message: `CustomerIO responded with a ${error.response.status} / ${error.response.statusText} on ${error.response.request.path}`,
-  //     attachments: [
-  //       {
-  //         color: '#d42115',
-  //         blocks: [
-  //           {
-  //             type: 'section',
-  //             text: {
-  //               type: 'mrkdwn',
-  //               text: `${process.env.CUSTOMER_IO_WORKSPACE_URL}/${cioId}`,
-  //             },
-  //           },
-  //         ],
-  //       },
-  //     ],
-  //   },
-  // })
+    console.error(
+      JSON.stringify({
+        event: 'cio_api_error',
+        error_message: error?.message || 'unknown',
+        error_status: error?.response?.status,
+        error_path: error?.response?.config?.url,
+        cio_id: cioId,
+        is_axios_error: isAxiosError,
+      }),
+    )
+  } catch {
+    // Never let the error reporter itself throw
+    console.error('reportCioApiError failed:', error?.message)
+  }
 }


### PR DESCRIPTION
## Summary

- **1,332 500 errors in 6 hours** from `/api/cio-subscriber` — **57% of all frontend errors**
- Root cause: cookieless bot/crawler requests trigger `cookie.parse(undefined)` which throws, then `reportCioApiError` crashes on `error.response.config.url` (non-axios error), TypeError escapes the catch block, `withPagesApiLogging` returns 500
- All 500s were **4-21ms instant crashes** — no external API call was ever made

## Changes

### `/api/cio-subscriber.ts`
- **Early return 200** when no cookies present (kills all bot/crawler 500s)
- **Early return 200** when no cioId AND no eggheadToken (anonymous users with random cookies)
- **Axios timeouts**: 5s for Rails, 3s for CIO APIs (was: no timeout → Vercel function timeout → 500)
- **Structured JSON logging** with high-cardinality fields for Axiom: `event`, `error_type`, `error_message`, `error_status`, `duration_ms`
- **Cache-Control: private, max-age=60** for subscriber responses
- **Try/catch around `reportCioApiError`** in the outer catch block so it can never crash the handler
- Removed unused imports (inngest, lodash)

### `report-cio-api-error.ts`
- **Null-safe**: checks `error.response` before accessing `.config.url`
- **Never throws**: outer try/catch ensures the error reporter itself can't crash
- **Structured JSON logging** for CIO API errors

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| `/api/cio-subscriber` 500s | ~1,332/6h (57% of all errors) | ~0 |
| Total frontend 500s | ~2,312/6h | ~980/6h (58% reduction) |
| Bot request processing | Full handler execution → crash | Instant 200 (no CPU wasted) |
| Axiom debugging | `console.error(error)` blob | Structured JSON, filterable by `error_type` |

## Axiom Query Patterns (post-deploy)

```apl
["vercel"] | where message contains "cio_subscriber_skip"
| summarize count() by reason
-- Shows: no_cookies vs no_identifiers breakdown

["vercel"] | where message contains "cio_subscriber_error"
| summarize count() by error_type
-- Shows: cio_sync vs cio_attributes vs timeout vs unhandled

["vercel"] | where message contains "cio_subscriber_success"
| summarize avg(todouble(duration_ms)), count()
-- Shows: average latency for successful requests
```

## Test plan

- [ ] Preview deploy builds successfully
- [ ] Smoke test: hit `/api/cio-subscriber` with no cookies → 200 empty response
- [ ] Smoke test: hit `/api/cio-subscriber` with valid auth cookie → 200 with subscriber data
- [ ] Verify structured logs appear in Vercel function logs
- [ ] Monitor Axiom for 500 rate reduction post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request handling with strict validation and early error responses.
  * Enhanced error handling with structured logging and retry mechanisms.

* **Refactor**
  * Reorganized error reporting for better monitoring and debugging.
  * Implemented timeout controls to optimize request performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->