### PR TITLE
Fix /courses SSR crash when instructor metadata is null

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -220,6 +220,7 @@ const CollectionPageLayout: React.FunctionComponent<
     slug,
     bio_short,
     twitter,
+    website,
   } = instructor || {}
 
   const image_url = square_cover_480_url || image_thumb_url
@@ -379,7 +380,7 @@ const CollectionPageLayout: React.FunctionComponent<
         type="Person"
         name={name}
         url={`https://egghead.io/q/resources-by-${slug}`}
-        sameAs={[twitter, instructor.website]}
+        sameAs={[twitter, website].filter(Boolean) as string[]}
       />
       <div className="container pb-8 sm:pb-16 dark:text-gray-100">
         {state === 'retired' && (

--- a/src/components/search/instructors/instructor-essential.tsx
+++ b/src/components/search/instructors/instructor-essential.tsx
@@ -73,7 +73,7 @@ const SearchInstructorEssential: FunctionComponent<
         type="Person"
         name={name}
         url={`https://egghead.io/q/resources-by-${slug}`}
-        sameAs={[twitterHandle, instructor.website]}
+        sameAs={[twitterHandle, websiteUrl].filter(Boolean) as string[]}
       />
       <div className="items-center flex flex-col grid-cols-1 space-y-12 lg:grid lg:grid-cols-12 lg:space-y-0 dark:bg-gray-900">
         <div


### PR DESCRIPTION
Fixes the main /courses/[course] 500 signature since the last deploy.

Root cause:
- Sanity course metadata can return `instructor: null` for legacy courses.
- `loadPlaylist` spread-merged that onto the Rails GraphQL playlist, clobbering `playlist.instructor`.
- `CollectionPageLayout` rendered `sameAs={[twitter, instructor.website]}` and crashed when `instructor === null`.

Changes:
- `CollectionPageLayout`: use `website` from safe destructure + filter falsy values.
- `SearchInstructorEssential`: same fix for `sameAs`.
- `loadPlaylist`: return `null` + structured warn log when playlist not found, and merge instructor data without allowing Sanity nulls to override.

Validation:
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test:ci`

Closes: #1564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for missing playlists with warning logging.

* **Improvements**
  * Enhanced handling of instructor website URLs in structured data.
  * Improved instructor information merging from metadata sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->