### PR TITLE
perf(trpc): collapse header feature-flag fanout + cache Edge Config

### DIFF
--- a/src/components/cta/sale/lifetime-header-banner.tsx
+++ b/src/components/cta/sale/lifetime-header-banner.tsx
@@ -2,16 +2,13 @@ import * as React from 'react'
 import Link from 'next/link'
 import analytics from '@/utils/analytics'
 import {usePathname} from 'next/navigation'
-import {trpc} from '@/app/_trpc/client'
 
-const LifetimeSaleHeaderBanner = () => {
-  const {data: isSaleBannerEnabled} =
-    trpc.featureFlag.isLiveWorkshopSale.useQuery({
-      flag: 'featureFlagLifetimeSale',
-    })
+const LifetimeSaleHeaderBanner: React.FC<{isEnabled?: boolean}> = ({
+  isEnabled,
+}) => {
   const pathname = usePathname()
 
-  return isSaleBannerEnabled ? (
+  return isEnabled ? (
     <Link
       href="/forever"
       onClick={() => {

--- a/src/components/cta/sale/workshop-early-bird-header-banner.tsx
+++ b/src/components/cta/sale/workshop-early-bird-header-banner.tsx
@@ -4,16 +4,13 @@ import * as React from 'react'
 import Link from 'next/link'
 import analytics from '@/utils/analytics'
 import {usePathname} from 'next/navigation'
-import {trpc} from '@/app/_trpc/client'
 
-const WorkshopEarlyBirdHeaderBanner: React.FC = () => {
-  const {data: isEarlyBirdSaleBannerEnabled} =
-    trpc.featureFlag.isEarlyBirdWorkshopSale.useQuery({
-      flag: 'featureFlagCursorWorkshopSale',
-    })
+const WorkshopEarlyBirdHeaderBanner: React.FC<{isEnabled?: boolean}> = ({
+  isEnabled,
+}) => {
   const pathname = usePathname()
 
-  return isEarlyBirdSaleBannerEnabled ? (
+  return isEnabled ? (
     <Link
       href="/workshop/cursor"
       onClick={() => {

--- a/src/components/cta/sale/workshop-header-banner.tsx
+++ b/src/components/cta/sale/workshop-header-banner.tsx
@@ -4,30 +4,23 @@ import * as React from 'react'
 import Link from 'next/link'
 import analytics from '@/utils/analytics'
 import {usePathname} from 'next/navigation'
-import {trpc} from '@/app/_trpc/client'
 import CountdownTimer from './countdown-timer'
 import {isEarlyBirdActive} from '@/utils/workshop'
+import type {LiveWorkshop} from '@/types'
 
 interface WorkshopSaleHeaderBannerProps {
-  flag: string
+  isEnabled?: boolean
+  workshopDateAndTime?: LiveWorkshop
   workshopPath: string
   workshopTitle: string
 }
 
 const WorkshopSaleHeaderBanner: React.FC<WorkshopSaleHeaderBannerProps> = ({
-  flag,
+  isEnabled,
+  workshopDateAndTime,
   workshopPath,
   workshopTitle,
 }) => {
-  const {data: workshopDateAndTime} = trpc.featureFlag.getLiveWorkshop.useQuery(
-    {
-      flag,
-    },
-  )
-  const {data: isSaleBannerEnabled} =
-    trpc.featureFlag.isLiveWorkshopSale.useQuery({
-      flag,
-    })
   const pathname = usePathname()
 
   const isEarlyBird = isEarlyBirdActive(workshopDateAndTime)
@@ -42,7 +35,7 @@ const WorkshopSaleHeaderBanner: React.FC<WorkshopSaleHeaderBannerProps> = ({
         }
       : workshopDateAndTime
 
-  return isSaleBannerEnabled ? (
+  return isEnabled ? (
     <Link
       href={workshopPath}
       onClick={() => {

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,4 +1,6 @@
 import {createClient} from '@vercel/edge-config'
+import {kv} from '@vercel/kv'
+import {logEvent, timeEvent, type LogContext} from '@/utils/structured-log'
 
 interface FeatureFlags {
   allowedRoles?: string[]
@@ -10,23 +12,129 @@ interface FeatureFlags {
 // We use prefixes to avoid mixing up the flags with other Edge Config values
 const prefixKey = (prefix: string, key: string) => `${prefix}_${key}`
 
-export async function getFeatureFlag(prefix: string, key: keyof FeatureFlags) {
-  if (!process.env.FEATURE_FLAGS_EDGE_CONFIG) return false
+const EDGE_CONFIG_ID = process.env.FEATURE_FLAGS_EDGE_CONFIG
+const edgeConfig = EDGE_CONFIG_ID ? createClient(EDGE_CONFIG_ID) : null
+
+const FEATURE_FLAGS_KV_PREFIX = 'feature-flags'
+const FEATURE_FLAGS_KV_TTL_SECONDS = Number(
+  process.env.FEATURE_FLAGS_KV_TTL_SECONDS ?? '60',
+)
+
+type CacheEntry = {value: unknown; expiresAt: number}
+const memoryCache = new Map<string, CacheEntry>()
+const inFlight = new Map<string, Promise<unknown>>()
+
+const memoryGet = <T>(key: string): T | undefined => {
+  const entry = memoryCache.get(key)
+  if (!entry) return undefined
+  if (Date.now() >= entry.expiresAt) {
+    memoryCache.delete(key)
+    return undefined
+  }
+  return entry.value as T
+}
+
+const memorySet = (key: string, value: unknown) => {
+  // Treat non-positive TTL as "no caching" without crashing callers.
+  if (!Number.isFinite(FEATURE_FLAGS_KV_TTL_SECONDS)) return
+  if (FEATURE_FLAGS_KV_TTL_SECONDS <= 0) return
+  memoryCache.set(key, {
+    value,
+    expiresAt: Date.now() + FEATURE_FLAGS_KV_TTL_SECONDS * 1000,
+  })
+}
+
+async function getCachedEdgeConfigValue<T>(
+  prefixedKey: string,
+  fetcher: () => Promise<T>,
+  logContext: LogContext = {},
+): Promise<T> {
+  const mem = memoryGet<T>(prefixedKey)
+  if (mem !== undefined) return mem
+
+  const existing = inFlight.get(prefixedKey)
+  if (existing) return (await existing) as T
+
+  const promise = (async () => {
+    const kvKey = `${FEATURE_FLAGS_KV_PREFIX}:${prefixedKey}`
+
+    // 1) KV (Redis) cache: shared across lambda instances
+    try {
+      const cached = await kv.get<T>(kvKey)
+      if (cached !== null && cached !== undefined) {
+        memorySet(prefixedKey, cached)
+        return cached
+      }
+    } catch {
+      logEvent(
+        'warn',
+        'feature_flags.kv.get_error',
+        {prefixed_key: prefixedKey},
+        logContext,
+      )
+    }
+
+    // 2) Edge Config: source of truth
+    const fetched = await timeEvent(
+      'feature_flags.edge_config.get',
+      {prefixed_key: prefixedKey},
+      fetcher,
+      logContext,
+    )
+
+    memorySet(prefixedKey, fetched)
+    try {
+      if (Number.isFinite(FEATURE_FLAGS_KV_TTL_SECONDS)) {
+        await kv.set(kvKey, fetched, {ex: FEATURE_FLAGS_KV_TTL_SECONDS})
+      }
+    } catch {
+      logEvent(
+        'warn',
+        'feature_flags.kv.set_error',
+        {prefixed_key: prefixedKey},
+        logContext,
+      )
+    }
+
+    return fetched
+  })()
+
+  inFlight.set(prefixedKey, promise as Promise<unknown>)
+  try {
+    return await promise
+  } finally {
+    inFlight.delete(prefixedKey)
+  }
+}
+
+export async function getFeatureFlag(
+  prefix: string,
+  key: keyof FeatureFlags,
+  logContext: LogContext = {},
+) {
   const prefixedKey = prefixKey(prefix, key)
-  const edgeConfig = createClient(process.env.FEATURE_FLAGS_EDGE_CONFIG)
-  const featureFlag = await edgeConfig.get<FeatureFlags>(prefixedKey)
-  return featureFlag
+  if (!edgeConfig) return false
+
+  return getCachedEdgeConfigValue(
+    prefixedKey,
+    () => edgeConfig.get<FeatureFlags>(prefixedKey),
+    logContext,
+  )
 }
 
 export async function getSaleBannerFeatureFlag(
   prefix: string,
   key: keyof FeatureFlags,
+  logContext: LogContext = {},
 ) {
-  if (!process.env.FEATURE_FLAGS_EDGE_CONFIG) return false
   const prefixedKey = prefixKey(prefix, key)
-  const edgeConfig = createClient(process.env.FEATURE_FLAGS_EDGE_CONFIG)
+  if (!edgeConfig) return false
 
-  const featureFlag = await edgeConfig.get<boolean>(prefixedKey)
+  const featureFlag = await getCachedEdgeConfigValue(
+    prefixedKey,
+    () => edgeConfig.get<boolean>(prefixedKey),
+    logContext,
+  )
 
-  return featureFlag
+  return Boolean(featureFlag)
 }

--- a/src/server/routers/feature-flag.ts
+++ b/src/server/routers/feature-flag.ts
@@ -4,6 +4,71 @@ import {getFeatureFlag, getSaleBannerFeatureFlag} from '@/lib/feature-flags'
 import {LiveWorkshopSchema} from '@/types'
 
 export const featureFlagRouter = router({
+  headerBanners: baseProcedure.query(async ({ctx}) => {
+    const requestId =
+      ctx?.req?.headers?.get('x-egghead-request-id') ??
+      ctx?.req?.headers?.get('x-vercel-id') ??
+      undefined
+
+    const logContext = {
+      request_id: requestId,
+      route: 'trpc.featureFlag.headerBanners',
+    }
+
+    const [
+      lifetimeSaleEnabled,
+      cursorWorkshopSaleEnabled,
+      claudeCodeWorkshopSaleEnabled,
+      cursorWorkshopEarlyBirdEnabled,
+      cursorWorkshopRaw,
+      claudeCodeWorkshopRaw,
+    ] = await Promise.all([
+      getSaleBannerFeatureFlag(
+        'featureFlagLifetimeSale',
+        'saleBanner',
+        logContext,
+      ),
+      getSaleBannerFeatureFlag(
+        'featureFlagCursorWorkshopSale',
+        'saleBanner',
+        logContext,
+      ),
+      getSaleBannerFeatureFlag(
+        'featureFlagClaudeCodeWorkshopSale',
+        'saleBanner',
+        logContext,
+      ),
+      getSaleBannerFeatureFlag(
+        'featureFlagCursorWorkshopSale',
+        'earlyBirdBanner',
+        logContext,
+      ),
+      getFeatureFlag('featureFlagCursorWorkshopSale', 'workshop', logContext),
+      getFeatureFlag(
+        'featureFlagClaudeCodeWorkshopSale',
+        'workshop',
+        logContext,
+      ),
+    ])
+
+    const parsedCursorWorkshop = LiveWorkshopSchema.safeParse(cursorWorkshopRaw)
+    const parsedClaudeWorkshop = LiveWorkshopSchema.safeParse(
+      claudeCodeWorkshopRaw,
+    )
+
+    return {
+      lifetimeSaleEnabled: Boolean(lifetimeSaleEnabled),
+      cursorWorkshopSaleEnabled: Boolean(cursorWorkshopSaleEnabled),
+      claudeCodeWorkshopSaleEnabled: Boolean(claudeCodeWorkshopSaleEnabled),
+      cursorWorkshopEarlyBirdEnabled: Boolean(cursorWorkshopEarlyBirdEnabled),
+      cursorWorkshop: parsedCursorWorkshop.success
+        ? parsedCursorWorkshop.data ?? null
+        : null,
+      claudeCodeWorkshop: parsedClaudeWorkshop.success
+        ? parsedClaudeWorkshop.data ?? null
+        : null,
+    }
+  }),
   isLiveWorkshopSale: baseProcedure
     .input(
       z.object({


### PR DESCRIPTION
Fixes the dominant tRPC tax: header feature-flag fanout.

Before:
- Header mounted 4 banner components.
- Those components made 6 separate tRPC calls (Cursor sale x2 + Claude sale x2 + EarlyBird + Lifetime).
- Since deploy, these 3 procedures were ~90% of all tRPC calls.

After:
- Add `featureFlag.headerBanners` tRPC query that returns all banner booleans + workshop metadata in one shot.
- Header uses that single query and passes results into presentational banner components.
- Keep existing per-flag procedures for workshop pages etc.

Bonus:
- Add KV (Redis) + in-memory caching for Edge Config reads.
- Add structured logs when we actually hit Edge Config (`feature_flags.edge_config.get`) and when KV get/set fails.

Validation:
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test:ci`

Closes: #1562


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sale and workshop banners are now dynamically configurable via backend feature flags, enabling real-time visibility and content updates without code changes.

* **Refactor**
  * Improved banner components to accept configuration props instead of fetching their own feature flags, enabling better data management and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->