### PR TITLE
perf: stop calling Sanity for non-overrides (allowlist + Upstash)

### DIFF
--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,9 +1,16 @@
 import {withAppApiLogging} from '@/lib/logging'
+import {refreshAllowlistIfStale} from '@/lib/sanity-allowlist'
 
 async function _GET() {
   await fetch(`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/api/inngest`, {
     method: 'PUT',
   })
+
+  // Keep allowlists warm so we can skip Sanity for ~95%+ of legacy content.
+  // Staleness-gated to avoid hammering Sanity (cron runs every minute).
+  await refreshAllowlistIfStale('lesson', {route: '/api/cron'})
+  await refreshAllowlistIfStale('course', {route: '/api/cron'})
+
   return new Response(null, {
     status: 200,
   })

--- a/src/lib/sanity-allowlist.ts
+++ b/src/lib/sanity-allowlist.ts
@@ -1,0 +1,330 @@
+import {sanityClient} from '@/utils/sanity-client'
+import groq from 'groq'
+import {getRedis} from '@/lib/upstash-redis'
+import {logEvent, type LogContext} from '@/utils/structured-log'
+
+type AllowlistKind = 'lesson' | 'course'
+
+const LESSON_SET_KEY = 'sanity:allowlist:lesson:slugs'
+const LESSON_META_KEY = 'sanity:allowlist:lesson:meta'
+
+// Course metadata can match by slug OR by Rails numeric IDs.
+// loadCourseMetadata() matches: railsCourseId == $courseId || externalId == $courseId || slug.current == $slug
+const COURSE_SET_KEY = 'sanity:allowlist:course:keys'
+const COURSE_META_KEY = 'sanity:allowlist:course:meta'
+
+const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 6 // 6h
+const META_MEMORY_TTL_MS = 60 * 1000 // 1m per lambda instance
+
+type AllowlistMeta = {
+  version: 1
+  kind: AllowlistKind
+  refreshed_at: string
+  count: number
+}
+
+type AllowlistStatus = {
+  ready: boolean
+  allowed: boolean
+  reason: 'allowlist_hit' | 'allowlist_miss' | 'allowlist_not_ready'
+}
+
+type RefreshResult = {
+  ok: boolean
+  kind: AllowlistKind
+  refreshed: boolean
+  count?: number
+  duration_ms?: number
+  error_message?: string
+}
+
+function metaKeyFor(kind: AllowlistKind) {
+  return kind === 'lesson' ? LESSON_META_KEY : COURSE_META_KEY
+}
+
+function setKeyFor(kind: AllowlistKind) {
+  return kind === 'lesson' ? LESSON_SET_KEY : COURSE_SET_KEY
+}
+
+function tmpKeyFor(kind: AllowlistKind, nonce: string) {
+  return `${setKeyFor(kind)}:tmp:${nonce}`
+}
+
+function isMetaFresh(meta: AllowlistMeta, maxAgeSeconds: number): boolean {
+  const ms = Date.parse(meta.refreshed_at)
+  if (!Number.isFinite(ms)) return false
+  return Date.now() - ms <= maxAgeSeconds * 1000
+}
+
+const metaMemoryCache = new Map<
+  AllowlistKind,
+  {value: AllowlistMeta | null; expiresAt: number}
+>()
+
+async function getMeta(kind: AllowlistKind): Promise<AllowlistMeta | null> {
+  const cached = metaMemoryCache.get(kind)
+  if (cached && Date.now() < cached.expiresAt) return cached.value
+
+  const redis = getRedis()
+  if (!redis) {
+    metaMemoryCache.set(kind, {
+      value: null,
+      expiresAt: Date.now() + META_MEMORY_TTL_MS,
+    })
+    return null
+  }
+
+  try {
+    const meta = await redis.get<AllowlistMeta>(metaKeyFor(kind))
+    const value = meta ?? null
+    metaMemoryCache.set(kind, {
+      value,
+      expiresAt: Date.now() + META_MEMORY_TTL_MS,
+    })
+    return value
+  } catch {
+    metaMemoryCache.set(kind, {
+      value: null,
+      expiresAt: Date.now() + META_MEMORY_TTL_MS,
+    })
+    return null
+  }
+}
+
+const lessonAllowlistQuery = groq`
+*[_type == "lesson" && defined(slug.current)]{
+  "slug": slug.current
+}
+`
+
+const courseAllowlistQuery = groq`
+*[_type in ["course","resource"] && (defined(slug.current) || defined(railsCourseId) || defined(externalId))]{
+  "slug": slug.current,
+  "railsCourseId": railsCourseId,
+  "externalId": externalId
+}
+`
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (size <= 0) return [items]
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size)
+    out.push(items.slice(i, i + size))
+  return out
+}
+
+async function refreshAllowlist(
+  kind: AllowlistKind,
+  logContext: LogContext,
+): Promise<RefreshResult> {
+  const redis = getRedis()
+  if (!redis) {
+    return {ok: false, kind, refreshed: false, error_message: 'redis_missing'}
+  }
+
+  const startedAt = Date.now()
+  const nonce = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const stableSetKey = setKeyFor(kind)
+  const tmpSetKey = tmpKeyFor(kind, nonce)
+
+  try {
+    if (kind === 'lesson') {
+      const rows = (await sanityClient.fetch<{slug?: string}[]>(
+        lessonAllowlistQuery,
+      )) as {slug?: string}[]
+      const slugs = rows
+        .map((r) => (r?.slug || '').trim())
+        .filter(Boolean) as string[]
+      const unique = Array.from(new Set(slugs))
+
+      await redis.del(tmpSetKey)
+      for (const part of chunk(unique, 1000)) {
+        await redis.sadd(tmpSetKey, ...part)
+      }
+
+      await redis.rename(tmpSetKey, stableSetKey)
+
+      const meta: AllowlistMeta = {
+        version: 1,
+        kind,
+        refreshed_at: new Date().toISOString(),
+        count: unique.length,
+      }
+      await redis.set(metaKeyFor(kind), meta)
+      metaMemoryCache.set(kind, {
+        value: meta,
+        expiresAt: Date.now() + META_MEMORY_TTL_MS,
+      })
+
+      return {
+        ok: true,
+        kind,
+        refreshed: true,
+        count: unique.length,
+        duration_ms: Date.now() - startedAt,
+      }
+    }
+
+    // course
+    const rows = (await sanityClient.fetch<
+      {slug?: string; railsCourseId?: number; externalId?: number}[]
+    >(courseAllowlistQuery)) as {
+      slug?: string
+      railsCourseId?: number
+      externalId?: number
+    }[]
+
+    const keys: string[] = []
+    for (const r of rows) {
+      const slug = (r?.slug || '').trim()
+      if (slug) keys.push(`slug:${slug}`)
+      if (Number.isFinite(r?.railsCourseId))
+        keys.push(`id:${Number(r?.railsCourseId)}`)
+      if (Number.isFinite(r?.externalId))
+        keys.push(`id:${Number(r?.externalId)}`)
+    }
+    const unique = Array.from(new Set(keys))
+
+    await redis.del(tmpSetKey)
+    for (const part of chunk(unique, 1000)) {
+      await redis.sadd(tmpSetKey, ...part)
+    }
+
+    await redis.rename(tmpSetKey, stableSetKey)
+
+    const meta: AllowlistMeta = {
+      version: 1,
+      kind,
+      refreshed_at: new Date().toISOString(),
+      count: unique.length,
+    }
+    await redis.set(metaKeyFor(kind), meta)
+    metaMemoryCache.set(kind, {
+      value: meta,
+      expiresAt: Date.now() + META_MEMORY_TTL_MS,
+    })
+
+    return {
+      ok: true,
+      kind,
+      refreshed: true,
+      count: unique.length,
+      duration_ms: Date.now() - startedAt,
+    }
+  } catch (e: any) {
+    return {
+      ok: false,
+      kind,
+      refreshed: false,
+      duration_ms: Date.now() - startedAt,
+      error_message: e?.message ?? String(e),
+    }
+  }
+}
+
+export async function refreshAllowlistIfStale(
+  kind: AllowlistKind,
+  logContext: LogContext = {},
+  maxAgeSeconds: number = Number(
+    process.env.SANITY_ALLOWLIST_MAX_AGE_SECONDS ?? DEFAULT_MAX_AGE_SECONDS,
+  ),
+): Promise<RefreshResult> {
+  const meta = await getMeta(kind)
+  if (meta && isMetaFresh(meta, maxAgeSeconds)) {
+    return {ok: true, kind, refreshed: false, count: meta.count}
+  }
+
+  const res = await refreshAllowlist(kind, logContext)
+  if (res.ok && res.refreshed) {
+    logEvent(
+      'info',
+      'sanity.allowlist.refresh',
+      {
+        kind,
+        count: res.count ?? 0,
+        duration_ms: res.duration_ms ?? 0,
+        ok: true,
+      },
+      logContext,
+    )
+  } else if (!res.ok) {
+    logEvent(
+      'warn',
+      'sanity.allowlist.refresh_error',
+      {
+        kind,
+        duration_ms: res.duration_ms ?? 0,
+        ok: false,
+        error_message: res.error_message,
+      },
+      logContext,
+    )
+  }
+
+  return res
+}
+
+export async function sanityAllowlistAllowsLesson(
+  slug: string,
+  logContext: LogContext = {},
+): Promise<AllowlistStatus> {
+  const redis = getRedis()
+  if (!redis) {
+    return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+  }
+
+  const meta = await getMeta('lesson')
+  if (!meta) return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+
+  try {
+    const allowed = Boolean(await redis.sismember(LESSON_SET_KEY, slug))
+    return {
+      ready: true,
+      allowed,
+      reason: allowed ? 'allowlist_hit' : 'allowlist_miss',
+    }
+  } catch {
+    return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+  }
+}
+
+export async function sanityAllowlistAllowsCourse(
+  params: {slug?: string; courseId?: number},
+  logContext: LogContext = {},
+): Promise<AllowlistStatus> {
+  const redis = getRedis()
+  if (!redis) {
+    return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+  }
+
+  const meta = await getMeta('course')
+  if (!meta) return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+
+  const slugKey = params.slug ? `slug:${params.slug}` : null
+  const idKey =
+    params.courseId != null && Number.isFinite(params.courseId)
+      ? `id:${Number(params.courseId)}`
+      : null
+
+  // If we can't build a key, we can't safely check membership. Fail open.
+  if (!slugKey && !idKey) {
+    return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+  }
+
+  try {
+    // We check both potential match keys because the Sanity doc might only have
+    // railsCourseId/externalId populated (or the slug could drift).
+    const p = redis.pipeline()
+    if (slugKey) p.sismember(COURSE_SET_KEY, slugKey)
+    if (idKey) p.sismember(COURSE_SET_KEY, idKey)
+    const results = await p.exec<number[]>()
+    const allowed = results.some((r) => Boolean(r))
+    return {
+      ready: true,
+      allowed,
+      reason: allowed ? 'allowlist_hit' : 'allowlist_miss',
+    }
+  } catch {
+    return {ready: false, allowed: true, reason: 'allowlist_not_ready'}
+  }
+}

--- a/src/lib/upstash-redis.ts
+++ b/src/lib/upstash-redis.ts
@@ -1,0 +1,36 @@
+import {Redis} from '@upstash/redis'
+
+/**
+ * Agent note:
+ * - We prefer Upstash directly over `@vercel/kv`.
+ * - `Redis.fromEnv()` supports both Upstash env vars and Vercel KV fallbacks:
+ *   - UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN
+ *   - KV_REST_API_URL / KV_REST_API_TOKEN
+ *
+ * This module is intentionally lazy so local dev/tests don't crash when Redis
+ * env vars aren't present.
+ */
+
+let _redis: Redis | null | undefined
+
+function hasRedisEnv(): boolean {
+  const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN
+  return Boolean(url && token)
+}
+
+export function getRedis(): Redis | null {
+  if (_redis !== undefined) return _redis
+  if (!hasRedisEnv()) {
+    _redis = null
+    return _redis
+  }
+
+  try {
+    _redis = Redis.fromEnv()
+  } catch {
+    _redis = null
+  }
+  return _redis
+}


### PR DESCRIPTION
Fixes: skillrecordings/egghead-next#1560

## What changed
- Add Upstash Redis wrapper (`Redis.fromEnv()`; Vercel KV env var fallback supported) for agent-first Redis usage.
- Add Sanity allowlists (lesson slugs + course keys) stored in Redis sets.
- Refresh allowlists from Sanity on the existing `/api/cron` endpoint (staleness-gated, default 6h).
- Gate Sanity calls:
  - `loadLessonMetadataFromSanity` skips GROQ entirely if allowlist is ready and slug is not allowlisted.
  - `loadPlaylist` skips `loadCourseMetadata` when course is not allowlisted.

## Why
Structured logs show `lesson.loadLessonMetadataFromSanity.groq` is getting hit way more than `has_sanity` because traffic touches many unique lesson slugs. Miss-caching alone won't save us.

Allowlist = 1 Redis `SISMEMBER` instead of 1 Sanity GROQ per unique slug.

## Safety
- Fail-open: if Redis/allowlist isn't ready, we fall back to current behavior (still call Sanity).
- Allowlist for courses matches both `slug` and numeric `railsCourseId/externalId` via prefixed keys.

## Observability
- New events:
  - `sanity.allowlist.refresh`
  - `sanity.allowlist.refresh_error`
- Existing graphs should show a sharp drop in `lesson.loadLessonMetadataFromSanity.groq` volume relative to `lesson.loadLesson.summary`.

## Tests
- Adds an integration assertion that Sanity fetch is not invoked when allowlist miss is forced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added content allowlist system for lessons and courses with automatic background refresh via cron job.

* **Infrastructure**
  * Upgraded caching infrastructure from Vercel KV to Redis for improved performance and reliability.

* **Tests**
  * Added integration test for allowlist gating behavior to prevent unnecessary external API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->