### PR TITLE
fix(redis): prefer KV env vars over broken UPSTASH_*

### DIFF
--- a/src/lib/upstash-redis.ts
+++ b/src/lib/upstash-redis.ts
@@ -3,9 +3,17 @@ import {Redis} from '@upstash/redis'
 /**
  * Agent note:
  * - We prefer Upstash directly over `@vercel/kv`.
- * - `Redis.fromEnv()` supports both Upstash env vars and Vercel KV fallbacks:
- *   - UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN
- *   - KV_REST_API_URL / KV_REST_API_TOKEN
+ * - Vercel-managed KV is still Upstash under the hood. In practice we often have
+ *   BOTH env var sets present:
+ *   - `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`
+ *   - `KV_REST_API_URL` / `KV_REST_API_TOKEN`
+ *
+ *   Unfortunately, `Redis.fromEnv()` prefers `UPSTASH_*` when set, even if those
+ *   values are stale/broken. That can take down caching and any feature that
+ *   relies on Redis.
+ *
+ *   So we explicitly choose the connection details instead of relying on
+ *   `fromEnv()`'s preference order.
  *
  * This module is intentionally lazy so local dev/tests don't crash when Redis
  * env vars aren't present.
@@ -13,22 +21,33 @@ import {Redis} from '@upstash/redis'
 
 let _redis: Redis | null | undefined
 
-function hasRedisEnv(): boolean {
-  const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL
-  const token =
-    process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN
-  return Boolean(url && token)
+function resolveRedisEnv(): {
+  source: 'kv' | 'upstash'
+  url: string
+  token: string
+} | null {
+  const kvUrl = process.env.KV_REST_API_URL
+  const kvToken = process.env.KV_REST_API_TOKEN
+  if (kvUrl && kvToken) return {source: 'kv', url: kvUrl, token: kvToken}
+
+  const upstashUrl = process.env.UPSTASH_REDIS_REST_URL
+  const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN
+  if (upstashUrl && upstashToken)
+    return {source: 'upstash', url: upstashUrl, token: upstashToken}
+
+  return null
 }
 
 export function getRedis(): Redis | null {
   if (_redis !== undefined) return _redis
-  if (!hasRedisEnv()) {
+  const cfg = resolveRedisEnv()
+  if (!cfg) {
     _redis = null
     return _redis
   }
 
   try {
-    _redis = Redis.fromEnv()
+    _redis = new Redis({url: cfg.url, token: cfg.token})
   } catch {
     _redis = null
   }


### PR DESCRIPTION
Prod regression after switching search SSR cache to @upstash/redis: `search_ssr_cache.status=error` spiked because `UPSTASH_REDIS_REST_URL` is NXDOMAIN (stale), and `Redis.fromEnv()` always prefers UPSTASH_* when present.

This changes `getRedis()` to explicitly pick `KV_REST_API_URL/KV_REST_API_TOKEN` first (still Upstash under the hood), then fallback to UPSTASH_* only if KV vars are missing.

Expected impact:
- search SSR cache errors drop to ~0
- redis-backed features (sanity allowlist, lesson caching) stop failing open

No user-facing behavior change besides Redis actually working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Redis credential resolution with explicit prioritization across multiple configuration sources and cascading fallback mechanisms. Direct credential construction now replaces environment-based detection, enhancing flexibility and transparency of connection setup across diverse deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->