### PR TITLE
obs(trpc): include sanitized error_message in trpc.call logs

### DIFF
--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -2,6 +2,36 @@ import {initTRPC} from '@trpc/server'
 import {TrpcContext} from '@/app/api/trpc/[trpc]/route'
 import {transformer} from './transformer'
 
+function fnv1a32(input: string): string {
+  // Small, stable fingerprint for grouping high-cardinality strings in logs.
+  // Output: 8-char hex (uint32).
+  let hash = 2166136261
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function sanitizeErrorMessage(input: unknown): string | null {
+  if (input == null) return null
+  const raw = typeof input === 'string' ? input : String(input)
+
+  // Avoid leaking secrets/PII in logs.
+  const redacted = raw
+    .replace(/Bearer\\s+[A-Za-z0-9._\\-]+/g, 'Bearer [redacted]')
+    .replace(/(sk|rk|pk)_(live|test)_[A-Za-z0-9]+/g, '[redacted_key]')
+    .replace(
+      /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}/g,
+      '[redacted_email]',
+    )
+
+  const oneLine = redacted.replace(/\\s+/g, ' ').trim()
+  if (!oneLine) return null
+  const max = 300
+  return oneLine.length > max ? `${oneLine.slice(0, max)}...` : oneLine
+}
+
 const t = initTRPC.context<TrpcContext>().create({
   transformer,
   errorFormatter({shape}) {
@@ -16,6 +46,16 @@ const logMiddleware = t.middleware(
     const duration_ms = Math.round(performance.now() - start)
     const trpcCtx = ctx as TrpcContext
 
+    const trpcError =
+      !result.ok && 'error' in result ? (result as any).error : null
+    const error_message = sanitizeErrorMessage(trpcError?.message)
+    const error_code = trpcError?.code ?? null
+    const error_name = trpcError?.name ?? null
+    const error_fingerprint =
+      error_message || error_code
+        ? fnv1a32(`${String(error_code ?? '')}:${String(error_message ?? '')}`)
+        : null
+
     const log = {
       event: 'trpc.call',
       path,
@@ -28,8 +68,13 @@ const logMiddleware = t.middleware(
       ...(rawInput && typeof rawInput === 'object'
         ? {input_keys: Object.keys(rawInput as Record<string, unknown>)}
         : {}),
-      ...(!result.ok && 'error' in result
-        ? {error_code: (result as any).error?.code}
+      ...(!result.ok
+        ? {
+            error_code,
+            error_name,
+            error_message,
+            error_fingerprint,
+          }
         : {}),
     }
 


### PR DESCRIPTION
Fixes egghead-next#1572.

Adds sanitized error fields to structured `trpc.call` logs so agents can debug failing procedures in Axiom:

- `error_message` (single-line, redacted, truncated)
- `error_name`
- `error_fingerprint` (stable hash for grouping)

After deploy:

```bash
bun tools/me.ts logs trpc-errors --since-deploy latest-prod --json | jq .
```

You should start seeing `has_error_message > 0` and `topMessages` fill in for hot paths like `course.getCourse`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened error logging infrastructure with fingerprinting capabilities to better identify, track, and diagnose system failures.
  * Implemented automatic sanitization of error messages to redact sensitive data and prevent inadvertent information exposure.
  * Extended error logging for failed server operations to capture comprehensive diagnostic information for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->