### PR TITLE
fix: graceful 403 fallbacks for tRPC routes (~15K errors/week)

### DIFF
--- a/src/server/routers/course.ts
+++ b/src/server/routers/course.ts
@@ -4,6 +4,11 @@ import {loadRatings} from '@/lib/ratings'
 import {loadCourse} from '@/lib/courses'
 import {RowDataPacket} from 'mysql2/promise'
 import {getPool} from '@/lib/db'
+import {logEvent} from '@/utils/structured-log'
+
+function isGraphQL403(e: unknown): boolean {
+  return e instanceof Error && e.message.includes('Code: 403')
+}
 
 export const courseRouter = router({
   getRatings: baseProcedure
@@ -14,7 +19,19 @@ export const courseRouter = router({
   getCourse: baseProcedure
     .input(z.object({slug: z.string()}))
     .query(async ({input, ctx}) => {
-      return loadCourse(input.slug, ctx.userToken)
+      try {
+        return await loadCourse(input.slug, ctx.userToken)
+      } catch (e) {
+        if (isGraphQL403(e) && ctx.userToken) {
+          logEvent('warn', 'course.getCourse.403_fallback', {
+            slug: input.slug,
+            user_id: ctx.userId ?? null,
+          })
+          // Stale token — retry without auth for public course data
+          return await loadCourse(input.slug, undefined)
+        }
+        throw e
+      }
     }),
   getCourseByResourceId: baseProcedure
     .input(z.object({resourceId: z.string()}))

--- a/src/server/routers/lesson.ts
+++ b/src/server/routers/lesson.ts
@@ -3,6 +3,10 @@ import {z} from 'zod'
 import {loadAssociatedLessonsByTag, loadLesson} from '@/lib/lessons'
 import {logEvent} from '@/utils/structured-log'
 
+function isGraphQL403(e: unknown): boolean {
+  return e instanceof Error && e.message.includes('Code: 403')
+}
+
 export const lessonRouter = router({
   getAssociatedLessonsByTag: baseProcedure
     .input(
@@ -14,31 +18,68 @@ export const lessonRouter = router({
     .query(async ({input, ctx}) => {
       const {tag, currentLessonSlug} = input
 
-      let data = await loadAssociatedLessonsByTag(tag)
-      const filteredData = currentLessonSlug
-        ? data.filter(
-            (lesson: {slug: string}) => lesson.slug !== currentLessonSlug,
-          )
-        : data
+      try {
+        let data = await loadAssociatedLessonsByTag(tag)
+        const filteredData = currentLessonSlug
+          ? data.filter(
+              (lesson: {slug: string}) => lesson.slug !== currentLessonSlug,
+            )
+          : data
 
-      return filteredData
+        return filteredData
+      } catch (e) {
+        if (isGraphQL403(e)) {
+          logEvent('warn', 'lesson.getAssociatedLessonsByTag.403_fallback', {
+            tag,
+          })
+          return []
+        }
+        throw e
+      }
     }),
   getLessonbySlug: baseProcedure
     .input(z.object({slug: z.string()}))
     .query(async ({input, ctx}) => {
       const {slug} = input
-      const lesson = await loadLesson(slug, ctx?.userToken, false, {
-        request_id: ctx?.req?.headers?.get('x-egghead-request-id') ?? undefined,
-        route: '/api/trpc',
-        page: 'lesson',
-        lesson_slug: slug,
-      })
-      logEvent('info', 'lesson.trpc.getLessonbySlug.result', {
-        lesson_slug: slug,
-        has_hls: Boolean((lesson as any)?.hls_url),
-        has_dash: Boolean((lesson as any)?.dash_url),
-        has_token: Boolean(ctx?.userToken),
-      })
-      return lesson
+      try {
+        const lesson = await loadLesson(slug, ctx?.userToken, false, {
+          request_id:
+            ctx?.req?.headers?.get('x-egghead-request-id') ?? undefined,
+          route: '/api/trpc',
+          page: 'lesson',
+          lesson_slug: slug,
+        })
+        logEvent('info', 'lesson.trpc.getLessonbySlug.result', {
+          lesson_slug: slug,
+          has_hls: Boolean((lesson as any)?.hls_url),
+          has_dash: Boolean((lesson as any)?.dash_url),
+          has_token: Boolean(ctx?.userToken),
+        })
+        return lesson
+      } catch (e) {
+        if (isGraphQL403(e) && ctx?.userToken) {
+          logEvent('warn', 'lesson.getLessonbySlug.403_fallback', {
+            slug,
+            user_id: ctx.userId ?? null,
+          })
+          // Retry without auth — lesson data is public
+          const lesson = await loadLesson(slug, undefined, false, {
+            request_id:
+              ctx?.req?.headers?.get('x-egghead-request-id') ?? undefined,
+            route: '/api/trpc',
+            page: 'lesson',
+            lesson_slug: slug,
+          })
+          logEvent('info', 'lesson.trpc.getLessonbySlug.result', {
+            lesson_slug: slug,
+            has_hls: Boolean((lesson as any)?.hls_url),
+            has_dash: Boolean((lesson as any)?.dash_url),
+            has_token: false,
+            retried_without_auth: true,
+          })
+          return lesson
+        }
+        throw e
+      }
     }),
 })

--- a/src/server/routers/progress.ts
+++ b/src/server/routers/progress.ts
@@ -2,7 +2,11 @@ import {baseProcedure, router} from '../trpc'
 import {z} from 'zod'
 import {loadLessonProgress, loadPlaylistProgress} from '../../lib/progress'
 import {loadUserCompletedCourses} from '@/lib/users'
-import {timeEvent} from '@/utils/structured-log'
+import {timeEvent, logEvent} from '@/utils/structured-log'
+
+function isGraphQL403(e: unknown): boolean {
+  return e instanceof Error && e.message.includes('Code: 403')
+}
 
 const createLessonView = async (
   lessonId: String | Number,
@@ -60,12 +64,22 @@ export const progressRouter = router({
     const token = ctx?.userToken
     if (!token) return []
 
-    const {completeCourses} = await timeEvent(
-      'progress.completedCourses.graphql',
-      {has_token: !!token},
-      async () => loadUserCompletedCourses(token),
-    )
-    return completeCourses
+    try {
+      const {completeCourses} = await timeEvent(
+        'progress.completedCourses.graphql',
+        {has_token: !!token},
+        async () => loadUserCompletedCourses(token),
+      )
+      return completeCourses
+    } catch (e) {
+      if (isGraphQL403(e)) {
+        logEvent('warn', 'progress.completedCourses.403_stale_token', {
+          user_id: ctx.userId ?? null,
+        })
+        return []
+      }
+      throw e
+    }
   }),
   forPlaylist: baseProcedure
     .input(
@@ -78,11 +92,22 @@ export const progressRouter = router({
 
       if (!token) return null
 
-      return await timeEvent(
-        'progress.forPlaylist.graphql',
-        {slug: input.slug, has_token: !!token},
-        async () => loadPlaylistProgress({token, slug: input.slug}),
-      )
+      try {
+        return await timeEvent(
+          'progress.forPlaylist.graphql',
+          {slug: input.slug, has_token: !!token},
+          async () => loadPlaylistProgress({token, slug: input.slug}),
+        )
+      } catch (e) {
+        if (isGraphQL403(e)) {
+          logEvent('warn', 'progress.forPlaylist.403_stale_token', {
+            slug: input.slug,
+            user_id: ctx.userId ?? null,
+          })
+          return null
+        }
+        throw e
+      }
     }),
   forLesson: baseProcedure
     .input(
@@ -95,11 +120,22 @@ export const progressRouter = router({
 
       if (!token) return null
 
-      return await timeEvent(
-        'progress.forLesson.graphql',
-        {slug: input.slug, has_token: !!token},
-        async () => loadLessonProgress({token, slug: input.slug}),
-      )
+      try {
+        return await timeEvent(
+          'progress.forLesson.graphql',
+          {slug: input.slug, has_token: !!token},
+          async () => loadLessonProgress({token, slug: input.slug}),
+        )
+      } catch (e) {
+        if (isGraphQL403(e)) {
+          logEvent('warn', 'progress.forLesson.403_stale_token', {
+            slug: input.slug,
+            user_id: ctx.userId ?? null,
+          })
+          return null
+        }
+        throw e
+      }
     }),
   addProgressToLesson: baseProcedure
     .input(

--- a/src/server/routers/topics.ts
+++ b/src/server/routers/topics.ts
@@ -4,8 +4,28 @@ import {
   typesenseInstantsearchAdapter,
   TYPESENSE_COLLECTION_NAME,
 } from '@/utils/typesense'
+import {logEvent} from '@/utils/structured-log'
 
-const searchClient = typesenseInstantsearchAdapter().searchClient
+// Lazy-init: avoid module-level crash when env vars are missing
+let _searchClient: ReturnType<
+  ReturnType<typeof typesenseInstantsearchAdapter>['searchClient'] & any
+> | null = null
+let _searchClientFailed = false
+
+function getSearchClient() {
+  if (_searchClient) return _searchClient
+  if (_searchClientFailed) return null
+  try {
+    _searchClient = typesenseInstantsearchAdapter().searchClient
+    return _searchClient
+  } catch (e) {
+    _searchClientFailed = true
+    logEvent('error', 'topics.searchClient.init_failed', {
+      error: e instanceof Error ? e.message : String(e),
+    })
+    return null
+  }
+}
 
 export const topicRouter = router({
   top: baseProcedure
@@ -17,8 +37,12 @@ export const topicRouter = router({
         .optional(),
     )
     .query(async ({input, ctx}) => {
+      const searchClient = getSearchClient()
       if (!searchClient?.initIndex) {
-        throw new Error('Search client not initialized')
+        logEvent('warn', 'topics.top.search_unavailable', {
+          topic: input?.topic ?? null,
+        })
+        return []
       }
       const index = searchClient.initIndex(TYPESENSE_COLLECTION_NAME)
       // top 10 free playlists for a topic


### PR DESCRIPTION
## Problem

From the weekly health report (Mar 3–10): **16,900 tRPC errors/week** from 3M requests. 91% are GraphQL 403s — Rails rejecting auth tokens. These bubble up as unhandled 500s to the client.

## Root Causes

1. **`course.getCourse` (11,280/wk):** Sends user token to Rails GraphQL. Stale token → 403 → unhandled throw. Course data is public — auth only gates `favorited` field.
2. **`progress.*` (2,367/wk):** Auth-required endpoints throwing 500 on stale tokens. Same UX as being logged out, but throws instead of returning empty.
3. **`lesson.getAssociatedLessonsByTag` (977/wk):** Public data, 403 from stale cookie leaking into GraphQL client.
4. **`lesson.getLessonbySlug` (~1,400/wk):** Public lesson data, same stale-token pattern.
5. **`topics.top` (700/wk):** Entirely separate bug — Typesense search client initialized at module level, fails when env vars missing, throws on every subsequent call for the lambda lifetime.

## Fixes

| Route | Strategy | Fallback |
|-------|----------|----------|
| `course.getCourse` | Catch 403, retry without auth | Public course data (no `favorited`) |
| `progress.forLesson` | Catch 403, return null | Same as logged-out UX |
| `progress.forPlaylist` | Catch 403, return null | Same as logged-out UX |
| `progress.completedCourses` | Catch 403, return [] | Same as logged-out UX |
| `lesson.getAssociatedLessonsByTag` | Catch 403, return [] | Empty related lessons |
| `lesson.getLessonbySlug` | Catch 403, retry without auth | Public lesson data |
| `topics.top` | Lazy-init search client, return [] | Empty topic results |

All fallbacks emit structured `warn` events (`*.403_fallback`, `*.403_stale_token`, `*.search_unavailable`) so we can monitor the rate and eventually fix the token issue upstream.

## Impact

~15,300 of ~16,900 tRPC errors/week eliminated (**90% reduction**). Users with stale tokens see public data instead of errors.

## Risk

Low. All changes are catch-on-error only — happy paths are untouched. Retry-without-auth calls hit the same `loadCourse`/`loadLesson` functions that the SSR pages already use without auth for anonymous users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling and resilience across multiple server endpoints when encountering authentication-related issues.
  * Added graceful fallback mechanisms to ensure data retrieval continues even when certain conditions cannot be met.
  * Improved system observability through structured logging of error events for better monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->