### PR TITLE
feat: structured logging for case-studies/[slug] page

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -14,6 +14,9 @@ import type {
   GetServerSideProps,
   GetServerSidePropsContext,
   GetServerSidePropsResult,
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
 } from 'next'
 import type {NextRequest} from 'next/server'
 import * as serverCookie from 'cookie'
@@ -250,6 +253,78 @@ export function withAppApiLogging(handler: AppRouteHandler): AppRouteHandler {
           user_id: userCtx.user_id,
           has_token: userCtx.has_token,
           error: err instanceof Error ? err.message : String(err),
+        }
+        console.error(JSON.stringify(log))
+      } catch {
+        // swallow
+      }
+
+      throw err
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Static props (getStaticProps) wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap getStaticProps with structured logging.
+ *
+ * Measures build/ISR duration and logs the slug + outcome so we can
+ * query Axiom for failed static regenerations without relying on the
+ * generic Next.js error page (which logs nothing useful).
+ *
+ * On error: logs with ok:false and re-throws so Next.js handles
+ * fallback or error propagation as normal.
+ */
+export function withStaticPropsLogging<
+  P extends Record<string, any> = Record<string, any>,
+>(gsp: GetStaticProps<P>): GetStaticProps<P> {
+  return async (
+    context: GetStaticPropsContext,
+  ): Promise<GetStaticPropsResult<P>> => {
+    const start = performance.now()
+
+    // Build a best-effort path string from params
+    const params = context.params ?? {}
+    const paramStr = Object.entries(params)
+      .map(([k, v]) => `${k}=${Array.isArray(v) ? v.join('/') : v}`)
+      .join('&')
+
+    try {
+      const result = await gsp(context)
+      const durationMs = Math.round(performance.now() - start)
+
+      try {
+        const log = {
+          event: 'static_props.render',
+          params: paramStr,
+          duration_ms: durationMs,
+          ok: true,
+          is_not_found: 'notFound' in result && !!(result as any).notFound,
+          is_redirect: 'redirect' in result,
+        }
+        console.log(JSON.stringify(log))
+      } catch {
+        // logging must never crash
+      }
+
+      return result
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start)
+
+      try {
+        const log = {
+          event: 'static_props.render',
+          params: paramStr,
+          duration_ms: durationMs,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+          stack:
+            err instanceof Error
+              ? err.stack?.split('\n').slice(0, 5).join(' | ')
+              : undefined,
         }
         console.error(JSON.stringify(log))
       } catch {

--- a/src/pages/case-studies/[slug].tsx
+++ b/src/pages/case-studies/[slug].tsx
@@ -12,6 +12,8 @@ import {HIDDEN_CASE_STUDIES} from './index'
 import remarkGfm from 'remark-gfm'
 import rehypeSlug from 'rehype-slug'
 import rehypeHighlight from 'rehype-highlight'
+import {withStaticPropsLogging} from '@/lib/logging'
+import {GenericErrorBoundary} from '@/components/generic-error-boundary'
 
 type AuthorResource = {
   name: string
@@ -131,7 +133,9 @@ const CaseStudy = (props: CaseStudyResource) => {
         </div>
         <article className="max-w-screen-md mx-auto mt-3 mb-16 lg:mt-14 md:mt-8">
           <main className="prose dark:prose-dark sm:prose-lg lg:prose-xl max-w-none dark:prose-a:text-blue-300 prose-a:text-blue-500">
-            <MDXRemote {...source} components={mdxComponents} />
+            <GenericErrorBoundary>
+              <MDXRemote {...source} components={mdxComponents} />
+            </GenericErrorBoundary>
           </main>
         </article>
       </div>
@@ -203,25 +207,84 @@ const query = groq`*[_type == "caseStudy" && slug.current == $slug][0]{
   body
 }`
 
-export async function getStaticProps(context: any) {
-  const {body, ...caseStudy} = await sanityClient.fetch(query, {
-    slug: context.params.slug,
-  })
+export const getStaticProps = withStaticPropsLogging(async (context: any) => {
+  const slug = context.params?.slug as string
 
-  const mdxSource = await serialize(body, {
-    blockJS: false,
-    blockDangerousJS: true,
-    mdxOptions: {
-      useDynamicImport: true,
-      remarkPlugins: [remarkGfm],
-      rehypePlugins: [rehypeSlug, rehypeHighlight],
-    },
-  })
+  const rawData = await sanityClient.fetch(query, {slug})
+
+  // Log null/missing document so we can spot broken slugs in Axiom
+  if (!rawData) {
+    console.error(
+      JSON.stringify({
+        event: 'case_study.not_found',
+        slug,
+        ok: false,
+        error: 'Sanity returned null for caseStudy query',
+      }),
+    )
+    return {notFound: true}
+  }
+
+  const {body, ...caseStudy} = rawData
+
+  // Log when the body field is missing (content not published / field empty)
+  if (!body) {
+    console.error(
+      JSON.stringify({
+        event: 'case_study.missing_body',
+        slug,
+        ok: false,
+        fields: Object.keys(rawData),
+        error: 'caseStudy document found but body field is null or undefined',
+      }),
+    )
+  } else {
+    console.log(
+      JSON.stringify({
+        event: 'case_study.fetched',
+        slug,
+        ok: true,
+        body_length:
+          typeof body === 'string' ? body.length : JSON.stringify(body).length,
+        has_author: !!(caseStudy as any).author,
+        has_cover_image: !!(caseStudy as any).coverImage,
+      }),
+    )
+  }
+
+  let mdxSource: any = null
+  try {
+    mdxSource = await serialize(body ?? '', {
+      blockJS: false,
+      blockDangerousJS: true,
+      mdxOptions: {
+        useDynamicImport: true,
+        remarkPlugins: [remarkGfm],
+        rehypePlugins: [rehypeSlug, rehypeHighlight],
+      },
+    })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'case_study.serialize_error',
+        slug,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        stack:
+          err instanceof Error
+            ? err.stack?.split('\n').slice(0, 5).join(' | ')
+            : undefined,
+      }),
+    )
+    // Return notFound so ISR serves a 404 rather than the error page
+    return {notFound: true}
+  }
+
   return {
     props: {...caseStudy, source: mdxSource},
     revalidate: 1,
   }
-}
+})
 
 const allCaseStudiesQuery = groq`
   *[_type == "caseStudy" && publishedAt < now() && !(slug.current match $hiddenCaseStudies)]{


### PR DESCRIPTION
## What

Adds structured logging to the case-studies `[slug].tsx` page so we can diagnose why `/case-studies/maggie-appleton` (and potentially others) is showing the broken-egg error page despite returning HTTP 200.

## Why

The page is broken in production. Vercel returns 200 so it's not a `getStaticProps` crash — the error is happening at render time (React error boundary → `_error.tsx`). Without logs we have no visibility into **what** is failing: missing Sanity document, null body, MDX serialize failure, or a runtime render crash.

## Changes

### `src/lib/logging.ts`
- Added `withStaticPropsLogging()` — mirrors the existing `withSSRLogging()` pattern but typed for `GetStaticProps`. Emits `event=static_props.render` with `duration_ms`, `params`, `ok`, and `error`/`stack` on failure.

### `src/pages/case-studies/[slug].tsx`
- **Null-guard** the Sanity fetch result: logs `case_study.not_found` and returns `notFound: true` instead of crashing on `const {body} = null`.
- Logs **`case_study.fetched`** on success (`body_length`, `has_author`, `has_cover_image`) so we can confirm what Sanity is returning.
- Logs **`case_study.missing_body`** when the document exists but `body` is absent.
- Wraps `serialize()` in try/catch: logs **`case_study.serialize_error`** with message + stack and returns `notFound: true` so ISR serves a clean 404.
- Wraps `<MDXRemote>` in `<GenericErrorBoundary>` so render-time failures are captured as `error_boundary.catch` in Axiom instead of escalating to the full error page.

## Querying in log-beast / Axiom

```bash
# See what the case study page is logging
log-beast raw '["vercel"] | where ["message"] contains "case_study" | project _time, ["message"] | order by _time desc | limit 20'

# Check for serialize errors specifically  
log-beast raw '["vercel"] | where ["message"] contains "case_study.serialize_error" | order by _time desc | limit 10'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved error handling and resilience for the case studies page with protective error boundaries around content rendering
  * Enhanced monitoring to detect and diagnose issues, preventing unexpected crashes and maintaining content stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->