### PR TITLE
fix: harden pricing geo proxy

### DIFF
--- a/src/app/api/pricing/route.ts
+++ b/src/app/api/pricing/route.ts
@@ -71,10 +71,19 @@ function sanitizeCountryNameForHeader(input: unknown): string | null {
   return sanitizeForwardedHeader(ascii)
 }
 
+function fingerprintValue(input: string | null): string | null {
+  return input ? fnv1a32(input) : null
+}
+
 const PRICING_PROXY_CACHE_PREFIX = 'pricing-proxy'
 const PRICING_PROXY_CACHE_TTL_SECONDS = Number(
   process.env.PRICING_PROXY_CACHE_TTL_SECONDS ?? '300',
 )
+const PRICING_PROXY_SHARED_CACHE_TTL_SECONDS =
+  Number.isFinite(PRICING_PROXY_CACHE_TTL_SECONDS) &&
+  PRICING_PROXY_CACHE_TTL_SECONDS > 0
+    ? Math.floor(PRICING_PROXY_CACHE_TTL_SECONDS)
+    : 300
 
 type PricingCacheEntry = {value: unknown; expiresAt: number}
 type PricingCacheStatus = 'memory_hit' | 'redis_hit' | 'miss' | 'skip'
@@ -200,10 +209,11 @@ function createPricingResponse(
   response.headers.set('x-pricing-cache', options.cacheStatus)
 
   if (options.cacheableCandidate) {
-    response.headers.set(
-      'Cache-Control',
-      'public, max-age=60, stale-while-revalidate=300',
-    )
+    const cacheControl = `public, max-age=60, s-maxage=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}, stale-while-revalidate=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`
+    const cdnCacheControl = `public, s-maxage=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}, stale-while-revalidate=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`
+
+    response.headers.set('Cache-Control', cacheControl)
+    response.headers.set('Vercel-CDN-Cache-Control', cdnCacheControl)
   }
 
   return response
@@ -227,8 +237,11 @@ async function _GET(request: NextRequest) {
   const geoHeaders: Record<string, string> = {}
 
   const safeCountry = sanitizeForwardedHeader(geo?.country)
-  const safeCountryName = safeCountry
-    ? sanitizeCountryNameForHeader(countries.getName(safeCountry, 'en'))
+  const rawCountryName = safeCountry
+    ? countries.getName(safeCountry, 'en')
+    : null
+  const safeCountryName = rawCountryName
+    ? sanitizeCountryNameForHeader(rawCountryName)
     : null
   if (safeCountry) {
     geoHeaders['x-vercel-ip-country'] = safeCountry
@@ -302,6 +315,28 @@ async function _GET(request: NextRequest) {
     : null
 
   try {
+    try {
+      console.log(
+        JSON.stringify({
+          event: 'pricing.proxy.geo_forwarded',
+          request_id: requestId,
+          site_client_id: siteClientId,
+          has_site_client: Boolean(siteClientId),
+          country_code: safeCountry,
+          country_name_present: Boolean(rawCountryName),
+          country_name_changed:
+            Boolean(rawCountryName) && rawCountryName !== safeCountryName,
+          country_name_fingerprint: fingerprintValue(safeCountryName),
+          city_present: Boolean(safeCity),
+          region_present: Boolean(safeRegion),
+          has_ip: Boolean(ip),
+          has_token: hasToken,
+          cacheable_candidate: cacheableCandidate,
+        }),
+      )
+    } catch {
+      // logging must never crash
+    }
     const fetchPricingFromRails = async () => {
       railsStartedAt = performance.now()
       const response = await axios.get(
@@ -343,6 +378,7 @@ async function _GET(request: NextRequest) {
           has_token: hasToken,
           has_coupon_param: hasCouponParam,
           geo_country: safeCountry,
+          country_name_fingerprint: fingerprintValue(safeCountryName),
           query_keys: queryKeys,
           query_fingerprint: fnv1a32(normalizedQueryString || '_'),
         }),
@@ -391,6 +427,7 @@ async function _GET(request: NextRequest) {
         has_site_client: Boolean(siteClientId),
         geo_country: safeCountry,
         has_geo_country: Boolean(safeCountry),
+        country_name_fingerprint: fingerprintValue(safeCountryName),
         has_ip: Boolean(ip),
         query_keys: queryKeys,
         has_coupon_param: hasCouponParam,

--- a/src/app/api/pricing/route.ts
+++ b/src/app/api/pricing/route.ts
@@ -6,6 +6,7 @@ import countries from 'i18n-iso-countries'
 import enLocale from 'i18n-iso-countries/langs/en.json'
 import {withAppApiLogging} from '@/lib/logging'
 import {getRedis} from '@/lib/upstash-redis'
+import {logEvent, type LogContext} from '@/utils/structured-log'
 
 // Register English locale for country name lookups
 countries.registerLocale(enLocale)
@@ -79,11 +80,12 @@ const PRICING_PROXY_CACHE_PREFIX = 'pricing-proxy'
 const PRICING_PROXY_CACHE_TTL_SECONDS = Number(
   process.env.PRICING_PROXY_CACHE_TTL_SECONDS ?? '300',
 )
-const PRICING_PROXY_SHARED_CACHE_TTL_SECONDS =
+const PRICING_PROXY_CACHE_ENABLED =
   Number.isFinite(PRICING_PROXY_CACHE_TTL_SECONDS) &&
   PRICING_PROXY_CACHE_TTL_SECONDS > 0
-    ? Math.floor(PRICING_PROXY_CACHE_TTL_SECONDS)
-    : 300
+const PRICING_PROXY_SHARED_CACHE_TTL_SECONDS = PRICING_PROXY_CACHE_ENABLED
+  ? Math.floor(PRICING_PROXY_CACHE_TTL_SECONDS)
+  : undefined
 
 type PricingCacheEntry = {value: unknown; expiresAt: number}
 type PricingCacheStatus = 'memory_hit' | 'redis_hit' | 'miss' | 'skip'
@@ -105,8 +107,7 @@ function pricingMemoryGet<T>(key: string): T | undefined {
 }
 
 function pricingMemorySet(key: string, value: unknown) {
-  if (!Number.isFinite(PRICING_PROXY_CACHE_TTL_SECONDS)) return
-  if (PRICING_PROXY_CACHE_TTL_SECONDS <= 0) return
+  if (!PRICING_PROXY_CACHE_ENABLED) return
 
   pricingMemoryCache.set(key, {
     value,
@@ -180,9 +181,11 @@ async function getCachedPricingValue<T>(
     const fetched = await fetcher()
     pricingMemorySet(key, fetched)
 
-    if (redis && Number.isFinite(PRICING_PROXY_CACHE_TTL_SECONDS)) {
+    if (redis && PRICING_PROXY_CACHE_ENABLED) {
       try {
-        await redis.set(key, fetched, {ex: PRICING_PROXY_CACHE_TTL_SECONDS})
+        await redis.set(key, fetched, {
+          ex: Math.floor(PRICING_PROXY_CACHE_TTL_SECONDS),
+        })
       } catch {
         // fail open if Redis set fails
       }
@@ -200,6 +203,19 @@ async function getCachedPricingValue<T>(
   }
 }
 
+function appendVaryHeader(response: NextResponse, headerName: string) {
+  const existing = response.headers.get('Vary')
+  const values = new Set(
+    (existing ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  )
+
+  values.add(headerName)
+  response.headers.set('Vary', Array.from(values).join(', '))
+}
+
 function createPricingResponse(
   body: unknown,
   options: {cacheStatus: PricingCacheStatus; cacheableCandidate: boolean},
@@ -209,11 +225,21 @@ function createPricingResponse(
   response.headers.set('x-pricing-cache', options.cacheStatus)
 
   if (options.cacheableCandidate) {
-    const cacheControl = `public, max-age=60, s-maxage=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}, stale-while-revalidate=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`
-    const cdnCacheControl = `public, s-maxage=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}, stale-while-revalidate=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`
+    const cacheControlParts = ['public', 'max-age=60']
 
-    response.headers.set('Cache-Control', cacheControl)
-    response.headers.set('Vercel-CDN-Cache-Control', cdnCacheControl)
+    if (PRICING_PROXY_SHARED_CACHE_TTL_SECONDS !== undefined) {
+      cacheControlParts.push(
+        `s-maxage=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`,
+        `stale-while-revalidate=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`,
+      )
+      response.headers.set(
+        'Vercel-CDN-Cache-Control',
+        `public, s-maxage=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}, stale-while-revalidate=${PRICING_PROXY_SHARED_CACHE_TTL_SECONDS}`,
+      )
+    }
+
+    response.headers.set('Cache-Control', cacheControlParts.join(', '))
+    appendVaryHeader(response, 'x-vercel-ip-country')
   }
 
   return response
@@ -306,7 +332,11 @@ async function _GET(request: NextRequest) {
     !hasToken && !hasCouponParam && !hasDiscountCodeParam && !hasEncodedParams
 
   const siteClientId = process.env.NEXT_PUBLIC_CLIENT_ID ?? null
-  const cacheKey = cacheableCandidate
+  const logContext: LogContext = {
+    request_id: requestId ?? undefined,
+    route: '/api/pricing',
+  }
+  const cacheKey = cacheableCandidate && PRICING_PROXY_CACHE_ENABLED
     ? buildPricingCacheKey({
         siteClientId,
         country: safeCountry,
@@ -316,10 +346,10 @@ async function _GET(request: NextRequest) {
 
   try {
     try {
-      console.log(
-        JSON.stringify({
-          event: 'pricing.proxy.geo_forwarded',
-          request_id: requestId,
+      logEvent(
+        'info',
+        'pricing.proxy.geo_forwarded',
+        {
           site_client_id: siteClientId,
           has_site_client: Boolean(siteClientId),
           country_code: safeCountry,
@@ -332,7 +362,8 @@ async function _GET(request: NextRequest) {
           has_ip: Boolean(ip),
           has_token: hasToken,
           cacheable_candidate: cacheableCandidate,
-        }),
+        },
+        logContext,
       )
     } catch {
       // logging must never crash
@@ -369,10 +400,10 @@ async function _GET(request: NextRequest) {
     }
 
     try {
-      console.log(
-        JSON.stringify({
-          event: 'pricing.proxy.cache',
-          request_id: requestId,
+      logEvent(
+        'info',
+        'pricing.proxy.cache',
+        {
           status: cacheStatus,
           cacheable_candidate: cacheableCandidate,
           has_token: hasToken,
@@ -381,7 +412,8 @@ async function _GET(request: NextRequest) {
           country_name_fingerprint: fingerprintValue(safeCountryName),
           query_keys: queryKeys,
           query_fingerprint: fnv1a32(normalizedQueryString || '_'),
-        }),
+        },
+        logContext,
       )
     } catch {
       // logging must never crash
@@ -411,29 +443,30 @@ async function _GET(request: NextRequest) {
           ? error.response.status
           : null
 
-      const log = {
-        event: 'pricing.proxy.error',
-        ok: false,
-        duration_ms,
-        rails_duration_ms,
-        request_id: requestId,
-        rails_status: railsStatus,
-        axios_code: error?.code ?? null,
-        error_message,
-        error_fingerprint,
-        has_token: hasToken,
-        cacheable_candidate: cacheableCandidate,
-        site_client_id: siteClientId,
-        has_site_client: Boolean(siteClientId),
-        geo_country: safeCountry,
-        has_geo_country: Boolean(safeCountry),
-        country_name_fingerprint: fingerprintValue(safeCountryName),
-        has_ip: Boolean(ip),
-        query_keys: queryKeys,
-        has_coupon_param: hasCouponParam,
-      }
-
-      console.error(JSON.stringify(log))
+      logEvent(
+        'error',
+        'pricing.proxy.error',
+        {
+          ok: false,
+          duration_ms,
+          rails_duration_ms,
+          rails_status: railsStatus,
+          axios_code: error?.code ?? null,
+          error_message,
+          error_fingerprint,
+          has_token: hasToken,
+          cacheable_candidate: cacheableCandidate,
+          site_client_id: siteClientId,
+          has_site_client: Boolean(siteClientId),
+          geo_country: safeCountry,
+          has_geo_country: Boolean(safeCountry),
+          country_name_fingerprint: fingerprintValue(safeCountryName),
+          has_ip: Boolean(ip),
+          query_keys: queryKeys,
+          has_coupon_param: hasCouponParam,
+        },
+        logContext,
+      )
     } catch {
       // Never crash the handler due to logging failures.
     }

--- a/src/components/search/instructors/kent-c-dodds/index.tsx
+++ b/src/components/search/instructors/kent-c-dodds/index.tsx
@@ -5,9 +5,7 @@ import ExternalTrackedLink from '@/components/external-tracked-link'
 
 import SearchInstructorEssential from '../instructor-essential'
 import CtaCard from '@/components/search/components/cta-card'
-import {VerticalResourceCollectionCard} from '@/components/card/vertical-resource-collection-card'
 import {VerticalResourceCard} from '@/components/card/verticle-resource-card'
-import {HorizontalResourceCard} from '@/components/card/horizontal-resource-card'
 
 const SearchKentCDodds = ({instructor}: any) => {
   const {
@@ -21,6 +19,8 @@ const SearchKentCDodds = ({instructor}: any) => {
 
   const courseResources = courses?.resources ?? []
   const collectionResources = collection?.resources ?? []
+  const testingJavascriptProduct = products?.testingJavascript
+  const epicReactProduct = products?.epicReact
   const [primaryCourse] = courseResources
 
   return (
@@ -38,37 +38,41 @@ const SearchKentCDodds = ({instructor}: any) => {
         }
       />
       <section className="mt-4 mb-10 flex sm:flex-nowrap flex-wrap flex-shrink justify-between gap-4 xl:px-0 px-5">
-        <ExternalTrackedLink
-          eventName="clicked testing javascript banner"
-          location="Kent C. Dodds instructor page"
-          href={get(products.testingJavascript, 'url')}
-        >
-          <Image
-            quality={100}
-            src={get(products.testingJavascript, 'image')}
-            width={620}
-            height={350}
-            layout="intrinsic"
-            alt={get(
-              products.testingJavascript,
-              'alt',
-              `illustration for testingJavascript`,
-            )}
-          />
-        </ExternalTrackedLink>
-        <ExternalTrackedLink
-          eventName="clicked epic react banner"
-          location="Kent C. Dodds instructor page"
-          href={get(products.epicReact, 'url')}
-        >
-          <Image
-            quality={100}
-            src={get(products.epicReact, 'image')}
-            width={620}
-            height={350}
-            alt={get(products.epicReact, 'alt', `illustration for epicreact`)}
-          />
-        </ExternalTrackedLink>
+        {testingJavascriptProduct ? (
+          <ExternalTrackedLink
+            eventName="clicked testing javascript banner"
+            location="Kent C. Dodds instructor page"
+            href={get(testingJavascriptProduct, 'url')}
+          >
+            <Image
+              quality={100}
+              src={get(testingJavascriptProduct, 'image')}
+              width={620}
+              height={350}
+              layout="intrinsic"
+              alt={get(
+                testingJavascriptProduct,
+                'alt',
+                `illustration for testingJavascript`,
+              )}
+            />
+          </ExternalTrackedLink>
+        ) : null}
+        {epicReactProduct ? (
+          <ExternalTrackedLink
+            eventName="clicked epic react banner"
+            location="Kent C. Dodds instructor page"
+            href={get(epicReactProduct, 'url')}
+          >
+            <Image
+              quality={100}
+              src={get(epicReactProduct, 'image')}
+              width={620}
+              height={350}
+              alt={get(epicReactProduct, 'alt', `illustration for epicreact`)}
+            />
+          </ExternalTrackedLink>
+        ) : null}
       </section>
 
       <section className="xl:px-0 px-5">
@@ -94,23 +98,29 @@ const SearchKentCDodds = ({instructor}: any) => {
           More From Kent
         </h2>
         <div className="flex sm:flex-nowrap flex-wrap gap-4 mt-4">
-          <VerticalResourceCard
-            className="mt-0 sm:w-1/2 w-full flex flex-col items-center justify-center text-center sm:py-8 py-6"
-            resource={podcast}
-            describe
-            location="Kent C. Dodds instructor Landing page"
-          />
-          <VerticalResourceCard
-            resource={epicReactCaseStudy}
-            className="sm:w-1/2 w-full border-none flex flex-col items-center justify-center text-center sm:py-8 py-6"
-            location="Kent C. Dodds instructor Landing page"
-          />
-          <VerticalResourceCard
-            className="sm:w-1/2 w-full border-none flex flex-col items-center justify-center text-center sm:py-8 py-6"
-            resource={caseStudy}
-            describe
-            location="Kent C. Dodds instructor Landing page"
-          />
+          {podcast ? (
+            <VerticalResourceCard
+              className="mt-0 sm:w-1/2 w-full flex flex-col items-center justify-center text-center sm:py-8 py-6"
+              resource={podcast}
+              describe
+              location="Kent C. Dodds instructor Landing page"
+            />
+          ) : null}
+          {epicReactCaseStudy ? (
+            <VerticalResourceCard
+              resource={epicReactCaseStudy}
+              className="sm:w-1/2 w-full border-none flex flex-col items-center justify-center text-center sm:py-8 py-6"
+              location="Kent C. Dodds instructor Landing page"
+            />
+          ) : null}
+          {caseStudy ? (
+            <VerticalResourceCard
+              className="sm:w-1/2 w-full border-none flex flex-col items-center justify-center text-center sm:py-8 py-6"
+              resource={caseStudy}
+              describe
+              location="Kent C. Dodds instructor Landing page"
+            />
+          ) : null}
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- sanitize derived country names before forwarding them to Rails
- add structured pricing geo forwarding logs for Axiom
- make anonymous pricing responses friendlier to Vercel shared caching
- remove country name from the proxy cache key

## Validation
- bun x tsc -p tsconfig.json --noEmit
- pre-commit lint hook passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer country-name handling to prevent null-related errors.
  * Conditional rendering for instructor banners and resource cards to avoid empty/broken UI elements.

* **Improvements**
  * Dynamic cache-control headers to better leverage shared CDN caching and reduce staleness.
  * Enhanced structured logging with a country-name fingerprint and logging that tolerates failures so telemetry won’t impact requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->