### PR TITLE
server-hydrate header banners

### DIFF
--- a/src/app/(content)/courses/layout.tsx
+++ b/src/app/(content)/courses/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {FunctionComponent} from 'react'
-import Header from '@/components/app/header'
+import ServerHeaderShell from '@/components/app/header/server-header-shell'
 import Main from '@/components/app/app-main'
 import Footer from '@/components/app/app-footer'
 import '@/styles/index.css'
@@ -14,7 +14,7 @@ const Layout: FunctionComponent<React.PropsWithChildren<unknown>> = ({
       <body>
         <div className="flex flex-col min-h-screen">
           <Providers>
-            <Header />
+            <ServerHeaderShell route="/courses" />
             <Main>{children}</Main>
             <Footer />
           </Providers>

--- a/src/app/(content)/tips/layout.tsx
+++ b/src/app/(content)/tips/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {FunctionComponent} from 'react'
-import Header from '@/components/app/header'
+import ServerHeaderShell from '@/components/app/header/server-header-shell'
 import Main from '@/components/app/app-main'
 import Footer from '@/components/app/app-footer'
 import '@/styles/index.css'
@@ -14,7 +14,7 @@ const Layout: FunctionComponent<React.PropsWithChildren<unknown>> = ({
       <body>
         <div className="flex flex-col min-h-screen">
           <Providers>
-            <Header />
+            <ServerHeaderShell route="/tips" />
             <Main>{children}</Main>
             <Footer />
           </Providers>

--- a/src/app/blocked/layout.tsx
+++ b/src/app/blocked/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {FunctionComponent} from 'react'
-import Header from '@/components/app/header'
+import ServerHeaderShell from '@/components/app/header/server-header-shell'
 import Main from '@/components/app/app-main'
 import Footer from '@/components/app/app-footer'
 import '@/styles/index.css'
@@ -14,7 +14,7 @@ const Layout: FunctionComponent<React.PropsWithChildren<unknown>> = ({
       <body>
         <div className="flex flex-col min-h-screen">
           <Providers>
-            <Header />
+            <ServerHeaderShell route="/blocked" />
             <Main>{children}</Main>
             <Footer />
           </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import WorkshopCTA from '@/components/workshop/workshop-cta'
 import CompactFeed from './_components/compact-feed'
 import CompactFeedSkeleton from './_components/compact-feed-skeleton'
 import LatestCoursesFeed from '@/components/courses/latest-courses-feed'
-import Header from '@/components/app/header'
+import ServerHeaderShell from '@/components/app/header/server-header-shell'
 import Search from '@/components/pages/home/search'
 import Topics from '@/components/pages/home/topics'
 import Footer from '@/components/app/footer'
@@ -112,7 +112,7 @@ export default async function HomePage() {
   return (
     <Providers>
       <div className="min-h-screen dark:bg-gray-900 bg-gray-50">
-        <Header />
+        <ServerHeaderShell route="/" />
 
         <Search />
 

--- a/src/app/user/layout.tsx
+++ b/src/app/user/layout.tsx
@@ -3,7 +3,7 @@ import {ACCESS_TOKEN_KEY} from '@/utils/auth'
 import {cookies} from 'next/headers'
 import fetchEggheadUser from '@/api/egghead/users/from-token'
 import {Providers} from '../providers'
-import Header from '@/components/app/header'
+import ServerHeaderShell from '@/components/app/header/server-header-shell'
 import Main from '@/components/app/app-main'
 import Footer from '@/components/app/app-footer'
 import '@/styles/index.css'
@@ -32,7 +32,7 @@ export default async function UserPageLayout({
       <body>
         <div className="flex flex-col min-h-screen">
           <Providers>
-            <Header />
+            <ServerHeaderShell route="/user" />
             <Main>
               <UserLayout
                 isTeamAccountOwner={isTeamAccountOwner}

--- a/src/components/app/header/banner-context.tsx
+++ b/src/components/app/header/banner-context.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import * as React from 'react'
+import type {HeaderBannerData} from './banner-data'
+
+const HeaderBannerContext = React.createContext<HeaderBannerData | undefined>(
+  undefined,
+)
+
+export function HeaderBannerProvider({
+  children,
+  initialData,
+}: {
+  children: React.ReactNode
+  initialData?: HeaderBannerData
+}) {
+  const value = React.useMemo(() => initialData, [initialData])
+
+  return (
+    <HeaderBannerContext.Provider value={value}>
+      {children}
+    </HeaderBannerContext.Provider>
+  )
+}
+
+export function useHeaderBannerData() {
+  return React.useContext(HeaderBannerContext)
+}

--- a/src/components/app/header/banner-data.ts
+++ b/src/components/app/header/banner-data.ts
@@ -1,0 +1,10 @@
+import type {LiveWorkshop} from '@/types'
+
+export type HeaderBannerData = {
+  lifetimeSaleEnabled: boolean
+  cursorWorkshopSaleEnabled: boolean
+  claudeCodeWorkshopSaleEnabled: boolean
+  cursorWorkshopEarlyBirdEnabled: boolean
+  cursorWorkshop: LiveWorkshop | null
+  claudeCodeWorkshop: LiveWorkshop | null
+}

--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -37,7 +37,8 @@ import LifetimeSaleHeaderBanner from '@/components/cta/sale/lifetime-header-bann
 import WorkshopSaleHeaderBanner from '@/components/cta/sale/workshop-header-banner'
 import WorkshopEarlyBirdHeaderBanner from '@/components/cta/sale/workshop-early-bird-header-banner'
 import {trpc} from '@/app/_trpc/client'
-import type {LiveWorkshop} from '@/types'
+import {useHeaderBannerData} from './banner-context'
+import type {HeaderBannerData} from './banner-data'
 
 type NavLinkProps = {
   name: string
@@ -46,15 +47,6 @@ type NavLinkProps = {
   items?: NavLinkProps[]
   onClick?: () => void
   className?: string
-}
-
-type HeaderBannerData = {
-  lifetimeSaleEnabled: boolean
-  cursorWorkshopSaleEnabled: boolean
-  claudeCodeWorkshopSaleEnabled: boolean
-  cursorWorkshopEarlyBirdEnabled: boolean
-  cursorWorkshop: LiveWorkshop | null
-  claudeCodeWorkshop: LiveWorkshop | null
 }
 
 type HeaderBannerCacheEntry = {
@@ -358,6 +350,7 @@ const NavDropdown: React.FC<
 
 const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
   const {viewer, loading} = useViewer()
+  const providerBannerData = useHeaderBannerData()
 
   const pathname = usePathname() || ''
 
@@ -376,11 +369,15 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
     bannerCache &&
       Date.now() - bannerCache.cachedAt < HEADER_BANNER_CACHE_TTL_MS,
   )
+  const shouldUseFallbackBannerFetch =
+    bannerCache !== undefined &&
+    shouldLoadBanners &&
+    !providerBannerData &&
+    !hasFreshBannerCache
   const {data: fetchedBannerData} = trpc.featureFlag.headerBanners.useQuery(
     undefined,
     {
-      enabled:
-        bannerCache !== undefined && shouldLoadBanners && !hasFreshBannerCache,
+      enabled: shouldUseFallbackBannerFetch,
       staleTime: HEADER_BANNER_CACHE_TTL_MS,
       cacheTime: HEADER_BANNER_CACHE_TTL_MS,
       refetchOnWindowFocus: false,
@@ -388,6 +385,16 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
       refetchOnMount: false,
     },
   )
+
+  React.useEffect(() => {
+    if (providerBannerData) {
+      writeHeaderBannerCache(providerBannerData)
+      setBannerCache({
+        data: providerBannerData,
+        cachedAt: Date.now(),
+      })
+    }
+  }, [providerBannerData])
 
   React.useEffect(() => {
     if (fetchedBannerData) {
@@ -400,7 +407,8 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
   }, [fetchedBannerData])
 
   const bannerData = shouldLoadBanners
-    ? (fetchedBannerData as HeaderBannerData | undefined) ??
+    ? providerBannerData ??
+      (fetchedBannerData as HeaderBannerData | undefined) ??
       bannerCache?.data ??
       undefined
     : undefined

--- a/src/components/app/header/server-header-shell.tsx
+++ b/src/components/app/header/server-header-shell.tsx
@@ -3,7 +3,33 @@ import {HeaderBannerProvider} from './banner-context'
 import {getHeaderBannerData} from '@/server/header-banners'
 
 export default async function ServerHeaderShell({route}: {route: string}) {
-  const headerBannerData = await getHeaderBannerData({route})
+  let headerBannerData
+
+  console.log(
+    JSON.stringify({
+      event: 'header.server_shell.load.start',
+      route,
+    }),
+  )
+
+  try {
+    headerBannerData = await getHeaderBannerData({route})
+    console.log(
+      JSON.stringify({
+        event: 'header.server_shell.load.success',
+        route,
+      }),
+    )
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: 'header.server_shell.load.error',
+        route,
+        error_message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    headerBannerData = undefined
+  }
 
   return (
     <HeaderBannerProvider initialData={headerBannerData}>

--- a/src/components/app/header/server-header-shell.tsx
+++ b/src/components/app/header/server-header-shell.tsx
@@ -1,0 +1,13 @@
+import Header from './index'
+import {HeaderBannerProvider} from './banner-context'
+import {getHeaderBannerData} from '@/server/header-banners'
+
+export default async function ServerHeaderShell({route}: {route: string}) {
+  const headerBannerData = await getHeaderBannerData({route})
+
+  return (
+    <HeaderBannerProvider initialData={headerBannerData}>
+      <Header />
+    </HeaderBannerProvider>
+  )
+}

--- a/src/components/search/instructors/kent-c-dodds/index.tsx
+++ b/src/components/search/instructors/kent-c-dodds/index.tsx
@@ -19,18 +19,22 @@ const SearchKentCDodds = ({instructor}: any) => {
     epicReactCaseStudy,
   } = instructor
 
-  const [primaryCourse, secondCourse] = courses.resources
+  const courseResources = courses?.resources ?? []
+  const collectionResources = collection?.resources ?? []
+  const [primaryCourse] = courseResources
 
   return (
     <div className="max-w-screen-xl mx-auto">
       <SearchInstructorEssential
         instructor={instructor}
         CTAComponent={
-          <CtaCard
-            resource={primaryCourse}
-            trackTitle="clicked instructor landing page CTA resource"
-            location="Kent C. Dodds instructor page"
-          />
+          primaryCourse ? (
+            <CtaCard
+              resource={primaryCourse}
+              trackTitle="clicked instructor landing page CTA resource"
+              location="Kent C. Dodds instructor page"
+            />
+          ) : undefined
         }
       />
       <section className="mt-4 mb-10 flex sm:flex-nowrap flex-wrap flex-shrink justify-between gap-4 xl:px-0 px-5">
@@ -69,11 +73,11 @@ const SearchKentCDodds = ({instructor}: any) => {
 
       <section className="xl:px-0 px-5">
         <h2 className="text-xl sm:font-semibold font-bold mb-3 dark:text-white">
-          {collection.title}
+          {collection?.title ?? 'Featured Collection'}
         </h2>
-        <p className="max-w-md">{collection.description}</p>
+        <p className="max-w-md">{collection?.description ?? ''}</p>
         <div className="flex sm:flex-nowrap flex-wrap gap-4 my-12">
-          {collection.resources.map((resource: any) => {
+          {collectionResources.map((resource: any) => {
             return (
               <VerticalResourceCard
                 resource={resource}

--- a/src/lib/posts/get-post.ts
+++ b/src/lib/posts/get-post.ts
@@ -8,6 +8,11 @@ import {getCourseForPost} from './get-course'
 import {getPool} from '../db'
 
 export async function getPost(slug: string) {
+  if (!process.env.COURSE_BUILDER_DATABASE_URL) {
+    console.warn('COURSE_BUILDER_DATABASE_URL not configured, skipping getPost')
+    return null
+  }
+
   const {hashFromSlug} = parseSlugForHash(slug)
   const pool = getPool()
   const conn = await pool.getConnection()
@@ -104,6 +109,13 @@ export async function getPost(slug: string) {
 }
 
 export async function getAllPostSlugs() {
+  if (!process.env.COURSE_BUILDER_DATABASE_URL) {
+    console.warn(
+      'COURSE_BUILDER_DATABASE_URL not configured, skipping getAllPostSlugs',
+    )
+    return []
+  }
+
   const pool = getPool()
   const conn = await pool.getConnection()
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,6 +26,7 @@ import '@/utils/axios-request-id'
 
 import {PostHogProvider} from 'posthog-js/react'
 import PosthogClient from '@/lib/posthog-client'
+import {HeaderBannerProvider} from '@/components/app/header/banner-context'
 
 declare global {
   interface Window {
@@ -139,14 +140,18 @@ const App: React.FC<React.PropsWithChildren<AppProps>> = ({
             <CioProvider>
               <QueryClientProvider client={queryClient}>
                 <TrpcProvider>
-                  <PostHogProvider client={posthog}>
-                    <MDXProvider components={mdxComponents as any}>
-                      {getLayout(Component, pageProps)}
-                    </MDXProvider>
-                    <div className="print:hidden">
-                      <ReactQueryDevtools />
-                    </div>
-                  </PostHogProvider>
+                  <HeaderBannerProvider
+                    initialData={pageProps.headerBannerData}
+                  >
+                    <PostHogProvider client={posthog}>
+                      <MDXProvider components={mdxComponents as any}>
+                        {getLayout(Component, pageProps)}
+                      </MDXProvider>
+                      <div className="print:hidden">
+                        <ReactQueryDevtools />
+                      </div>
+                    </PostHogProvider>
+                  </HeaderBannerProvider>
                 </TrpcProvider>
               </QueryClientProvider>
             </CioProvider>

--- a/src/pages/courses/[course]/index.tsx
+++ b/src/pages/courses/[course]/index.tsx
@@ -18,6 +18,7 @@ import {loadResourcesForCourse} from '@/lib/course-resources'
 import type {CourseLessonShell} from '@/types'
 import {logEvent} from '@/utils/structured-log'
 import {canonicalizeInternalQueryParams} from '@/server/nxtp-query'
+import {withHeaderBannerServerSideProps} from '@/server/with-header-banner-props'
 const tracer = getTracer('course-page')
 
 type CourseProps = {
@@ -180,105 +181,108 @@ const getSlugFromPath = (path: string) => {
 }
 
 export const getServerSideProps: GetServerSideProps = withSSRLogging(
-  async ({res, req, params, query}) => {
-    setupHttpTracing({name: getServerSideProps.name, tracer, req, res})
-    const requestId = crypto.randomUUID()
-    res.setHeader('x-egghead-request-id', requestId)
-    const logContext = {
-      request_id: requestId,
-      route: '/courses/[course]',
-      page: 'course',
-      course_slug: params?.course as string,
-    }
-
-    try {
-      const courseSlugParam = params?.course as string
-
-      const canonicalRedirect = canonicalizeInternalQueryParams({
-        pathname: `/courses/${courseSlugParam}`,
-        query,
-        omitKeys: ['course'],
-      })
-
-      if (canonicalRedirect) {
-        setCourseCacheHeaders(res, 'internal_query_params')
-        return {
-          redirect: {
-            destination: canonicalRedirect.destination,
-            permanent: false,
-          },
-        }
+  withHeaderBannerServerSideProps(
+    '/courses/[course]',
+    async ({res, req, params, query}) => {
+      setupHttpTracing({name: getServerSideProps.name, tracer, req, res})
+      const requestId = crypto.randomUUID()
+      res.setHeader('x-egghead-request-id', requestId)
+      const logContext = {
+        request_id: requestId,
+        route: '/courses/[course]',
+        page: 'course',
+        course_slug: params?.course as string,
       }
 
-      const course = await loadPublicCourseShell(courseSlugParam, logContext)
+      try {
+        const courseSlugParam = params?.course as string
 
-      if (!course) {
-        throw new Error(
-          `Unable to load public course shell for ${courseSlugParam}`,
-        )
-      }
+        const canonicalRedirect = canonicalizeInternalQueryParams({
+          pathname: `/courses/${courseSlugParam}`,
+          query,
+          omitKeys: ['course'],
+        })
 
-      const fullLessons = await loadResourcesForCourse(
-        {
-          slug: courseSlugParam,
-        },
-        logContext,
-      )
-
-      const resolvedCourse = course
-      const cachePolicy = 'public-swr'
-      const cacheBlocker: string | null = null
-
-      const courseSlug = getSlugFromPath(resolvedCourse?.path)
-      if (resolvedCourse && courseSlug !== params?.course) {
-        return {
-          redirect: {
-            destination: resolvedCourse.path,
-            permanent: true,
-          },
+        if (canonicalRedirect) {
+          setCourseCacheHeaders(res, 'internal_query_params')
+          return {
+            redirect: {
+              destination: canonicalRedirect.destination,
+              permanent: false,
+            },
+          }
         }
-      } else {
-        setCourseCacheHeaders(res, cacheBlocker)
-        logEvent(
-          'info',
-          'page.cache.policy',
+
+        const course = await loadPublicCourseShell(courseSlugParam, logContext)
+
+        if (!course) {
+          throw new Error(
+            `Unable to load public course shell for ${courseSlugParam}`,
+          )
+        }
+
+        const fullLessons = await loadResourcesForCourse(
           {
-            route: '/courses/[course]',
-            course_slug: courseSlugParam,
-            policy: cachePolicy,
-            cache_blocker: cacheBlocker,
+            slug: courseSlugParam,
+          },
+          logContext,
+        )
+
+        const resolvedCourse = course
+        const cachePolicy = 'public-swr'
+        const cacheBlocker: string | null = null
+
+        const courseSlug = getSlugFromPath(resolvedCourse?.path)
+        if (resolvedCourse && courseSlug !== params?.course) {
+          return {
+            redirect: {
+              destination: resolvedCourse.path,
+              permanent: true,
+            },
+          }
+        } else {
+          setCourseCacheHeaders(res, cacheBlocker)
+          logEvent(
+            'info',
+            'page.cache.policy',
+            {
+              route: '/courses/[course]',
+              course_slug: courseSlugParam,
+              policy: cachePolicy,
+              cache_blocker: cacheBlocker,
+            },
+            logContext,
+          )
+
+          return {
+            props: {
+              course: {
+                ...resolvedCourse,
+                sections: resolvedCourse?.sections ?? null,
+              },
+              fullLessons,
+            },
+          }
+        }
+      } catch (e) {
+        logEvent(
+          'warn',
+          'course.ssr.catch',
+          {
+            course_slug: params?.course as string,
+            has_token: Boolean(req.cookies[ACCESS_TOKEN_KEY]),
+            error_message: sanitizeErrorMessage(e),
           },
           logContext,
         )
 
         return {
-          props: {
-            course: {
-              ...resolvedCourse,
-              sections: resolvedCourse?.sections ?? null,
-            },
-            fullLessons,
+          redirect: {
+            destination: '/',
+            permanent: false,
           },
         }
       }
-    } catch (e) {
-      logEvent(
-        'warn',
-        'course.ssr.catch',
-        {
-          course_slug: params?.course as string,
-          has_token: Boolean(req.cookies[ACCESS_TOKEN_KEY]),
-          error_message: sanitizeErrorMessage(e),
-        },
-        logContext,
-      )
-
-      return {
-        redirect: {
-          destination: '/',
-          permanent: false,
-        },
-      }
-    }
-  },
+    },
+  ),
 )

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -17,6 +17,7 @@ import {GenericErrorBoundary} from '@/components/generic-error-boundary'
 import Lesson from '@/components/pages/lessons/lesson'
 import {trpc} from '@/app/_trpc/client'
 import {HOT_LESSON_SLUGS} from '@/lib/hot-content-slugs'
+import {withHeaderBannerStaticProps} from '@/server/with-header-banner-props'
 
 import {VideoProvider} from '@/player'
 
@@ -32,8 +33,15 @@ const isLessonNotFoundError = (error: unknown) => {
 async function getCanonicalStaticLessonSlugs() {
   const canonicalSlugs: string[] = []
 
-  for (let index = 0; index < HOT_LESSON_SLUGS.length; index += STATIC_PATHS_ALIAS_BATCH_SIZE) {
-    const batch = HOT_LESSON_SLUGS.slice(index, index + STATIC_PATHS_ALIAS_BATCH_SIZE)
+  for (
+    let index = 0;
+    index < HOT_LESSON_SLUGS.length;
+    index += STATIC_PATHS_ALIAS_BATCH_SIZE
+  ) {
+    const batch = HOT_LESSON_SLUGS.slice(
+      index,
+      index + STATIC_PATHS_ALIAS_BATCH_SIZE,
+    )
     const batchResults = await Promise.all(
       batch.map(async (slug) => {
         const metadata = await loadLessonMetadataFromGraphQL(slug, undefined, {
@@ -92,7 +100,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 export const getStaticProps: GetStaticProps = withStaticPropsLogging(
-  async function ({params}) {
+  withHeaderBannerStaticProps('/lessons/[slug]', async function ({params}) {
     const lessonSlug = params?.slug as string | undefined
 
     if (!lessonSlug) {
@@ -179,7 +187,7 @@ export const getStaticProps: GetStaticProps = withStaticPropsLogging(
 
       throw error
     }
-  },
+  }),
 )
 
 const LessonPage: React.FC<

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -31,6 +31,7 @@ import {
   getSearchStateFromUrlParts,
   isLowCardinalitySearchPath,
 } from '@/lib/search-url-state'
+import {withHeaderBannerStaticProps} from '@/server/with-header-banner-props'
 
 const createURL = (state: any) => `?${qs.stringify(state)}`
 
@@ -276,7 +277,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 export const getStaticProps: GetStaticProps = withStaticPropsLogging(
-  async function ({params}) {
+  withHeaderBannerStaticProps('/q/[[...all]]', async function ({params}) {
     const rawAll = params?.all
     const all = Array.isArray(rawAll) ? rawAll.filter(Boolean) : []
 
@@ -427,5 +428,5 @@ export const getStaticProps: GetStaticProps = withStaticPropsLogging(
         revalidate: 60,
       }
     }
-  },
+  }),
 )

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -35,9 +35,34 @@ import {withHeaderBannerStaticProps} from '@/server/with-header-banner-props'
 
 const createURL = (state: any) => `?${qs.stringify(state)}`
 
-export const typesenseAdapter = typesenseInstantsearchAdapter()
+const typesenseAdapterInit = (() => {
+  try {
+    return typesenseInstantsearchAdapter()
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: 'search.typesense.init.error',
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return null
+  }
+})()
+
+export const typesenseAdapter =
+  typesenseAdapterInit ??
+  ({
+    typesenseClient: null,
+    clearCache: () => undefined,
+    updateConfiguration: () => undefined,
+    searchClient: {
+      search: async () => ({results: []}),
+      searchForFacetValues: async () => ({facetHits: []}),
+    },
+  } as unknown as ReturnType<typeof typesenseInstantsearchAdapter>)
 
 const searchClient = typesenseAdapter.searchClient
+const typesenseConfigured = typesenseAdapterInit !== null
 
 const defaultProps = {
   searchClient,
@@ -253,7 +278,10 @@ SearchIndex.getLayout = (Page: any, pageProps: any) => {
 export default SearchIndex
 
 const getStaticPathParamsForSearchPath = (path: string) => {
-  const all = path.replace(/^\/q\/?/, '').split('/').filter(Boolean)
+  const all = path
+    .replace(/^\/q\/?/, '')
+    .split('/')
+    .filter(Boolean)
 
   return {
     params: {
@@ -295,12 +323,28 @@ export const getStaticProps: GetStaticProps = withStaticPropsLogging(
     const selectedTopics = topicExtractor(initialSearchState)
     const pageTitle = titleFromPath(all)
     const isHotStaticPath = HOT_SEARCH_PATHS_SET.has(path)
-    const isLowCardinalityBrowse = isLowCardinalitySearchPath(
-      initialSearchState,
-    )
+    const isLowCardinalityBrowse =
+      isLowCardinalitySearchPath(initialSearchState)
     const shouldGenerateServerState = isHotStaticPath || isLowCardinalityBrowse
 
     try {
+      if (!typesenseConfigured) {
+        return {
+          props: {
+            error: 'Search service unavailable',
+            initialSearchState,
+            path,
+            serverState: null,
+            pageTitle,
+            noIndexInitial: true,
+            initialInstructor: null,
+            initialTopicGraphqlData: null,
+            initialTopicSanityData: null,
+          },
+          revalidate: 60,
+        }
+      }
+
       if (!shouldGenerateServerState) {
         console.log(
           JSON.stringify({

--- a/src/server/__tests__/with-header-banner-props.test.ts
+++ b/src/server/__tests__/with-header-banner-props.test.ts
@@ -1,0 +1,127 @@
+import {
+  withHeaderBannerServerSideProps,
+  withHeaderBannerStaticProps,
+} from '../with-header-banner-props'
+import {getHeaderBannerData} from '../header-banners'
+
+jest.mock('../header-banners', () => ({
+  getHeaderBannerData: jest.fn(async () => ({
+    lifetimeSaleEnabled: true,
+    cursorWorkshopSaleEnabled: false,
+    claudeCodeWorkshopSaleEnabled: false,
+    cursorWorkshopEarlyBirdEnabled: false,
+    cursorWorkshop: null,
+    claudeCodeWorkshop: null,
+  })),
+}))
+
+describe('with-header-banner-props', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('merges header banner data into server-side props', async () => {
+    const wrapped = withHeaderBannerServerSideProps(
+      '/q/[[...all]]',
+      async () => {
+        return {
+          props: {
+            hello: 'world',
+          },
+        }
+      },
+    )
+
+    const result = await wrapped({
+      req: {
+        headers: {
+          'x-egghead-request-id': 'req_123',
+        },
+      },
+      res: {
+        getHeader: jest.fn(() => undefined),
+      },
+    } as any)
+
+    expect(result).toEqual({
+      props: {
+        hello: 'world',
+        headerBannerData: {
+          lifetimeSaleEnabled: true,
+          cursorWorkshopSaleEnabled: false,
+          claudeCodeWorkshopSaleEnabled: false,
+          cursorWorkshopEarlyBirdEnabled: false,
+          cursorWorkshop: null,
+          claudeCodeWorkshop: null,
+        },
+      },
+    })
+
+    expect(getHeaderBannerData).toHaveBeenCalledWith({
+      route: '/q/[[...all]]',
+      request_id: 'req_123',
+    })
+  })
+
+  test('preserves redirects for server-side props', async () => {
+    const wrapped = withHeaderBannerServerSideProps(
+      '/courses/[course]',
+      async () => {
+        return {
+          redirect: {
+            destination: '/',
+            permanent: false,
+          },
+        }
+      },
+    )
+
+    const result = await wrapped({
+      req: {headers: {}},
+      res: {
+        getHeader: jest.fn(() => undefined),
+      },
+    } as any)
+
+    expect(result).toEqual({
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    })
+    expect(getHeaderBannerData).not.toHaveBeenCalled()
+  })
+
+  test('merges header banner data into static props and preserves revalidate', async () => {
+    const wrapped = withHeaderBannerStaticProps('/lessons/[slug]', async () => {
+      return {
+        props: {
+          lesson: 'value',
+        },
+        revalidate: 60,
+      }
+    })
+
+    const result = await wrapped({} as any)
+
+    expect(result).toEqual({
+      props: {
+        lesson: 'value',
+        headerBannerData: {
+          lifetimeSaleEnabled: true,
+          cursorWorkshopSaleEnabled: false,
+          claudeCodeWorkshopSaleEnabled: false,
+          cursorWorkshopEarlyBirdEnabled: false,
+          cursorWorkshop: null,
+          claudeCodeWorkshop: null,
+        },
+      },
+      revalidate: 60,
+    })
+
+    expect(getHeaderBannerData).toHaveBeenCalledWith({
+      route: '/lessons/[slug]',
+      request_id: undefined,
+    })
+  })
+})

--- a/src/server/header-banners.ts
+++ b/src/server/header-banners.ts
@@ -1,0 +1,69 @@
+import {getFeatureFlag, getSaleBannerFeatureFlag} from '@/lib/feature-flags'
+import {type LogContext} from '@/utils/structured-log'
+import {LiveWorkshopSchema} from '@/types'
+import type {HeaderBannerData} from '@/components/app/header/banner-data'
+
+export async function getHeaderBannerData(
+  logContext: LogContext = {},
+): Promise<HeaderBannerData> {
+  const [
+    lifetimeSaleEnabled,
+    cursorWorkshopSaleEnabled,
+    claudeCodeWorkshopSaleEnabled,
+    cursorWorkshopEarlyBirdEnabled,
+  ] = await Promise.all([
+    getSaleBannerFeatureFlag(
+      'featureFlagLifetimeSale',
+      'saleBanner',
+      logContext,
+    ),
+    getSaleBannerFeatureFlag(
+      'featureFlagCursorWorkshopSale',
+      'saleBanner',
+      logContext,
+    ),
+    getSaleBannerFeatureFlag(
+      'featureFlagClaudeCodeWorkshopSale',
+      'saleBanner',
+      logContext,
+    ),
+    getSaleBannerFeatureFlag(
+      'featureFlagCursorWorkshopSale',
+      'earlyBirdBanner',
+      logContext,
+    ),
+  ])
+
+  const [cursorWorkshopRaw, claudeCodeWorkshopRaw] = await Promise.all([
+    cursorWorkshopSaleEnabled || cursorWorkshopEarlyBirdEnabled
+      ? getFeatureFlag('featureFlagCursorWorkshopSale', 'workshop', logContext)
+      : Promise.resolve(undefined),
+    claudeCodeWorkshopSaleEnabled
+      ? getFeatureFlag(
+          'featureFlagClaudeCodeWorkshopSale',
+          'workshop',
+          logContext,
+        )
+      : Promise.resolve(undefined),
+  ])
+
+  const parsedCursorWorkshop = cursorWorkshopRaw
+    ? LiveWorkshopSchema.safeParse(cursorWorkshopRaw)
+    : {success: true as const, data: undefined}
+  const parsedClaudeWorkshop = claudeCodeWorkshopRaw
+    ? LiveWorkshopSchema.safeParse(claudeCodeWorkshopRaw)
+    : {success: true as const, data: undefined}
+
+  return {
+    lifetimeSaleEnabled: Boolean(lifetimeSaleEnabled),
+    cursorWorkshopSaleEnabled: Boolean(cursorWorkshopSaleEnabled),
+    claudeCodeWorkshopSaleEnabled: Boolean(claudeCodeWorkshopSaleEnabled),
+    cursorWorkshopEarlyBirdEnabled: Boolean(cursorWorkshopEarlyBirdEnabled),
+    cursorWorkshop: parsedCursorWorkshop.success
+      ? parsedCursorWorkshop.data ?? null
+      : null,
+    claudeCodeWorkshop: parsedClaudeWorkshop.success
+      ? parsedClaudeWorkshop.data ?? null
+      : null,
+  }
+}

--- a/src/server/routers/feature-flag.ts
+++ b/src/server/routers/feature-flag.ts
@@ -2,6 +2,7 @@ import {router, baseProcedure} from '../trpc'
 import {z} from 'zod'
 import {getFeatureFlag, getSaleBannerFeatureFlag} from '@/lib/feature-flags'
 import {LiveWorkshopSchema} from '@/types'
+import {getHeaderBannerData} from '@/server/header-banners'
 
 export const featureFlagRouter = router({
   headerBanners: baseProcedure.query(async ({ctx}) => {
@@ -15,68 +16,7 @@ export const featureFlagRouter = router({
       route: 'trpc.featureFlag.headerBanners',
     }
 
-    const [
-      lifetimeSaleEnabled,
-      cursorWorkshopSaleEnabled,
-      claudeCodeWorkshopSaleEnabled,
-      cursorWorkshopEarlyBirdEnabled,
-    ] = await Promise.all([
-      getSaleBannerFeatureFlag(
-        'featureFlagLifetimeSale',
-        'saleBanner',
-        logContext,
-      ),
-      getSaleBannerFeatureFlag(
-        'featureFlagCursorWorkshopSale',
-        'saleBanner',
-        logContext,
-      ),
-      getSaleBannerFeatureFlag(
-        'featureFlagClaudeCodeWorkshopSale',
-        'saleBanner',
-        logContext,
-      ),
-      getSaleBannerFeatureFlag(
-        'featureFlagCursorWorkshopSale',
-        'earlyBirdBanner',
-        logContext,
-      ),
-    ])
-
-    const [cursorWorkshopRaw, claudeCodeWorkshopRaw] = await Promise.all([
-      cursorWorkshopSaleEnabled || cursorWorkshopEarlyBirdEnabled
-        ? getFeatureFlag(
-            'featureFlagCursorWorkshopSale',
-            'workshop',
-            logContext,
-          )
-        : Promise.resolve(null),
-      claudeCodeWorkshopSaleEnabled
-        ? getFeatureFlag(
-            'featureFlagClaudeCodeWorkshopSale',
-            'workshop',
-            logContext,
-          )
-        : Promise.resolve(null),
-    ])
-
-    const parsedCursorWorkshop = LiveWorkshopSchema.safeParse(cursorWorkshopRaw)
-    const parsedClaudeWorkshop = LiveWorkshopSchema.safeParse(
-      claudeCodeWorkshopRaw,
-    )
-
-    return {
-      lifetimeSaleEnabled: Boolean(lifetimeSaleEnabled),
-      cursorWorkshopSaleEnabled: Boolean(cursorWorkshopSaleEnabled),
-      claudeCodeWorkshopSaleEnabled: Boolean(claudeCodeWorkshopSaleEnabled),
-      cursorWorkshopEarlyBirdEnabled: Boolean(cursorWorkshopEarlyBirdEnabled),
-      cursorWorkshop: parsedCursorWorkshop.success
-        ? parsedCursorWorkshop.data ?? null
-        : null,
-      claudeCodeWorkshop: parsedClaudeWorkshop.success
-        ? parsedClaudeWorkshop.data ?? null
-        : null,
-    }
+    return getHeaderBannerData(logContext)
   }),
   isLiveWorkshopSale: baseProcedure
     .input(

--- a/src/server/with-header-banner-props.ts
+++ b/src/server/with-header-banner-props.ts
@@ -5,7 +5,7 @@ import type {
   GetStaticProps,
   GetStaticPropsResult,
 } from 'next'
-import {getHeaderBannerData} from './header-banners'
+import {getHeaderBannerData} from '@/server/header-banners'
 import type {HeaderBannerData} from '@/components/app/header/banner-data'
 
 type HeaderBannerPageProps = {

--- a/src/server/with-header-banner-props.ts
+++ b/src/server/with-header-banner-props.ts
@@ -1,0 +1,96 @@
+import type {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+  GetStaticProps,
+  GetStaticPropsResult,
+} from 'next'
+import {getHeaderBannerData} from './header-banners'
+import type {HeaderBannerData} from '@/components/app/header/banner-data'
+
+type HeaderBannerPageProps = {
+  headerBannerData: HeaderBannerData
+}
+
+function readRequestId(context: GetServerSidePropsContext) {
+  const responseHeader = context.res.getHeader('x-egghead-request-id')
+  if (typeof responseHeader === 'string') return responseHeader
+  if (Array.isArray(responseHeader)) return responseHeader[0]
+
+  const header =
+    context.req.headers['x-egghead-request-id'] ??
+    context.req.headers['x-vercel-id']
+
+  return Array.isArray(header) ? header[0] : header
+}
+
+async function mergeHeaderBannerServerSideProps<P extends Record<string, any>>(
+  route: string,
+  result: GetServerSidePropsResult<P>,
+  requestId?: string,
+): Promise<GetServerSidePropsResult<P & HeaderBannerPageProps>> {
+  if (!('props' in result)) {
+    return result as GetServerSidePropsResult<P & HeaderBannerPageProps>
+  }
+
+  const headerBannerData = await getHeaderBannerData({
+    route,
+    request_id: requestId,
+  })
+  const props = await Promise.resolve(result.props)
+
+  return {
+    ...result,
+    props: {
+      ...(props as P),
+      headerBannerData,
+    },
+  }
+}
+
+async function mergeHeaderBannerStaticProps<P extends Record<string, any>>(
+  route: string,
+  result: GetStaticPropsResult<P>,
+): Promise<GetStaticPropsResult<P & HeaderBannerPageProps>> {
+  if (!('props' in result)) {
+    return result as GetStaticPropsResult<P & HeaderBannerPageProps>
+  }
+
+  const headerBannerData = await getHeaderBannerData({
+    route,
+    request_id: undefined,
+  })
+  const props = result.props as P
+
+  return {
+    ...result,
+    props: {
+      ...props,
+      headerBannerData,
+    },
+  }
+}
+
+export function withHeaderBannerServerSideProps<P extends Record<string, any>>(
+  route: string,
+  gssp: GetServerSideProps<P>,
+): GetServerSideProps<P & HeaderBannerPageProps> {
+  return async (context) => {
+    const result = await gssp(context)
+    return mergeHeaderBannerServerSideProps(
+      route,
+      result,
+      readRequestId(context),
+    )
+  }
+}
+
+export function withHeaderBannerStaticProps<P extends Record<string, any>>(
+  route: string,
+  gsp: GetStaticProps<P>,
+): GetStaticProps<P & HeaderBannerPageProps> {
+  return async (context) => {
+    const result = await gsp(context)
+    return mergeHeaderBannerStaticProps(route, result)
+  }
+}


### PR DESCRIPTION
## Summary
- server-hydrate Header banner data through shared loaders/providers instead of bootstrapping via client tRPC on covered routes
- wire Pages Router hot paths and App Router header shells to pass banner data at render time
- keep a rollout-safe client fallback in Header for routes that are not yet provider-backed

## Verification
- `pnpm jest --runInBand src/server/__tests__/with-header-banner-props.test.ts src/lib/__tests__/get-post.test.ts src/lib/__tests__/load-lesson.integration.test.ts`
- `pnpm exec tsc --noEmit --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic, route-aware header banners now load server-side and are provided app-wide so header content adapts per page.
  * Pages now use a server header shell to deliver banner data at render time, reducing redundant client fetches.

* **Bug Fixes / Reliability**
  * Search now gracefully falls back when the search service is unavailable.
  * Instructor/profile pages handle missing course/collection data to avoid broken displays.

* **Tests**
  * Added tests covering header-banner data injection for server and static props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->