### PR TITLE
perf: skip middleware on clean lesson/course URLs

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,29 +5,13 @@ import {getCanonicalSearchQueryRedirect} from '@/server/search-query-canonicaliz
 
 const PUBLIC_FILE = /\.(.*)$/
 
-// Keys whose presence on /courses/* or /lessons/* should trigger canonicalization.
-// Must stay in sync with SHARED_STRIP_KEYS / LESSON_CONTEXT_STRIP_KEYS in
-// content-query-canonicalization.ts. Without one of these, the request can
-// be served straight from the static ISR cache without invoking the edge.
-const CONTENT_STRIP_QUERY_KEYS = [
-  'utm_source',
-  'utm_medium',
-  'utm_campaign',
-  'utm_content',
-  'utm_term',
-  'af',
-  'rc',
-  'ref',
-  '_cio_id',
-  'cio_id',
-] as const
-
-const LESSON_ONLY_STRIP_QUERY_KEYS = ['course', 'pl'] as const
-
-const queryHas = (keys: readonly string[]) =>
-  keys.map((key) => ({type: 'query' as const, key}))
-
-// The allow-list of paths where this middleware executes (perf)
+// The allow-list of paths where this middleware executes (perf).
+// `has` clauses on /courses/* and /lessons/* mean middleware only fires when
+// a strip-worthy query key is present, letting clean URLs serve directly
+// from the static ISR cache. Keys must stay in sync with SHARED_STRIP_KEYS /
+// LESSON_CONTEXT_STRIP_KEYS in content-query-canonicalization.ts. Listed
+// inline because Next.js statically analyzes this export — helpers/spreads
+// would fail the build with "Invalid segment configuration export".
 export const config = {
   matcher: [
     '/pricing',
@@ -36,14 +20,35 @@ export const config = {
     '/q/:path*',
     {
       source: '/courses/:path*',
-      has: queryHas(CONTENT_STRIP_QUERY_KEYS),
+      has: [
+        {type: 'query', key: 'utm_source'},
+        {type: 'query', key: 'utm_medium'},
+        {type: 'query', key: 'utm_campaign'},
+        {type: 'query', key: 'utm_content'},
+        {type: 'query', key: 'utm_term'},
+        {type: 'query', key: 'af'},
+        {type: 'query', key: 'rc'},
+        {type: 'query', key: 'ref'},
+        {type: 'query', key: '_cio_id'},
+        {type: 'query', key: 'cio_id'},
+      ],
     },
     {
       source: '/lessons/:path*',
-      has: queryHas([
-        ...CONTENT_STRIP_QUERY_KEYS,
-        ...LESSON_ONLY_STRIP_QUERY_KEYS,
-      ]),
+      has: [
+        {type: 'query', key: 'utm_source'},
+        {type: 'query', key: 'utm_medium'},
+        {type: 'query', key: 'utm_campaign'},
+        {type: 'query', key: 'utm_content'},
+        {type: 'query', key: 'utm_term'},
+        {type: 'query', key: 'af'},
+        {type: 'query', key: 'rc'},
+        {type: 'query', key: 'ref'},
+        {type: 'query', key: '_cio_id'},
+        {type: 'query', key: 'cio_id'},
+        {type: 'query', key: 'course'},
+        {type: 'query', key: 'pl'},
+      ],
     },
   ],
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,28 @@ import {getCanonicalSearchQueryRedirect} from '@/server/search-query-canonicaliz
 
 const PUBLIC_FILE = /\.(.*)$/
 
+// Keys whose presence on /courses/* or /lessons/* should trigger canonicalization.
+// Must stay in sync with SHARED_STRIP_KEYS / LESSON_CONTEXT_STRIP_KEYS in
+// content-query-canonicalization.ts. Without one of these, the request can
+// be served straight from the static ISR cache without invoking the edge.
+const CONTENT_STRIP_QUERY_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'af',
+  'rc',
+  'ref',
+  '_cio_id',
+  'cio_id',
+] as const
+
+const LESSON_ONLY_STRIP_QUERY_KEYS = ['course', 'pl'] as const
+
+const queryHas = (keys: readonly string[]) =>
+  keys.map((key) => ({type: 'query' as const, key}))
+
 // The allow-list of paths where this middleware executes (perf)
 export const config = {
   matcher: [
@@ -12,8 +34,17 @@ export const config = {
     '/pricing/:path*',
     '/q',
     '/q/:path*',
-    '/courses/:path*',
-    '/lessons/:path*',
+    {
+      source: '/courses/:path*',
+      has: queryHas(CONTENT_STRIP_QUERY_KEYS),
+    },
+    {
+      source: '/lessons/:path*',
+      has: queryHas([
+        ...CONTENT_STRIP_QUERY_KEYS,
+        ...LESSON_ONLY_STRIP_QUERY_KEYS,
+      ]),
+    },
   ],
 }
 


### PR DESCRIPTION
## Summary
- Tighten the `src/middleware.ts` matcher so middleware only fires on `/lessons/*` and `/courses/*` when the URL actually has a strip-worthy query key (utm_*, af, rc, ref, _cio_id, cio_id; +course/pl for lessons).
- Other matched routes (`/pricing*`, `/q*`) are unchanged.
- Strip-key list mirrors `SHARED_STRIP_KEYS` / `LESSON_CONTEXT_STRIP_KEYS` in `src/server/content-query-canonicalization.ts` — comment flags the sync requirement.

## Why
Looking at Axiom logs over a 2h window: lesson detail pages had ~5% cache HIT rate (288 HIT / 6,156 events). The dominant pattern was `vercel.source = edge` and `lambda` MISS — middleware was being invoked on every clean URL even though it had nothing to do, blocking the static ISR cache from serving directly. Course detail pages had effectively 0 HIT visible in that window for the same reason.

| source | MISS | STALE | HIT |
|---|---|---|---|
| lambda (SSR) | 2,758 | 289 | 36 |
| edge (middleware) | 1,726 | 0 | 0 |
| static (ISR) | 0 | 196 | 288 |

After this change, requests without canonicalization-relevant params skip middleware entirely and become eligible for direct edge serving from the static cache.

## Caveats
- `nxtP*` keys (matched via regex inside `shouldStripKey`) are not covered by the matcher anymore. These are Next.js internal — shouldn't appear in user URLs.
- Strip-key list is duplicated between `middleware.ts` and `content-query-canonicalization.ts`. Could be unified later by exporting `SHARED_STRIP_KEYS`.
- Requires Next.js ≥ 12.2 for `has` matcher syntax.

## Test plan
- [ ] Deploy to preview, hit `/lessons/<slug>` clean URL — confirm response served (200, content correct)
- [ ] Hit `/lessons/<slug>?utm_source=test` — confirm middleware redirects to clean URL and sets cookies as before
- [ ] Hit `/lessons/<slug>?course=foo` — confirm canonicalization redirect still fires
- [ ] Hit `/courses/<slug>?af=xxx` — confirm affiliate cookie + redirect still work
- [ ] After 1–2h in production, run `bun run src/cli.ts frontend-cache --filter "lessons/"` from log-beast — expect HIT share to climb above ~5% and `vercel.source = static` events to grow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Middleware routing updated so course and lesson pages are processed only when specific query parameters are present, improving request handling and reducing unnecessary processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->