### PR TITLE
Wire workshop receipt flags

### DIFF
--- a/src/inngest/utils/specific-product-helpers.ts
+++ b/src/inngest/utils/specific-product-helpers.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe'
 import {stripe} from '@/utils/stripe'
 import {getFeatureFlag} from '@/lib/feature-flags'
 import {LiveWorkshopSchema} from '@/types'
+import {LIVE_WORKSHOP_SALE_FLAGS} from '@/lib/live-workshop-flags'
 
 /**
  * Checks if a checkout session contains our specific product.
@@ -21,26 +22,15 @@ export async function containsSpecificProduct(
   checkoutSession: Stripe.Checkout.Session,
 ): Promise<boolean> {
   try {
-    const cursorWorkshop = await getFeatureFlag(
-      'featureFlagCursorWorkshopSale',
-      'workshop',
+    const workshops = await Promise.all(
+      LIVE_WORKSHOP_SALE_FLAGS.map((flag) => getFeatureFlag(flag, 'workshop')),
     )
-    const claudeWorkshop = await getFeatureFlag(
-      'featureFlagClaudeCodeWorkshopSale',
-      'workshop',
-    )
-
-    const parsedCursorWorkshop = LiveWorkshopSchema.safeParse(cursorWorkshop)
-    const parsedClaudeWorkshop = LiveWorkshopSchema.safeParse(claudeWorkshop)
-
-    const possibleProductIds: string[] = []
-
-    if (parsedCursorWorkshop.success && parsedCursorWorkshop.data) {
-      possibleProductIds.push(parsedCursorWorkshop.data.productId)
-    }
-    if (parsedClaudeWorkshop.success && parsedClaudeWorkshop.data) {
-      possibleProductIds.push(parsedClaudeWorkshop.data.productId)
-    }
+    const possibleProductIds = workshops.flatMap((workshop) => {
+      const parsedWorkshop = LiveWorkshopSchema.safeParse(workshop)
+      return parsedWorkshop.success && parsedWorkshop.data
+        ? [parsedWorkshop.data.productId]
+        : []
+    })
 
     if (possibleProductIds.length === 0) {
       console.warn('No workshop found')
@@ -120,18 +110,19 @@ export async function containsSpecificProduct(
  */
 export async function getSpecificProductName(): Promise<string> {
   try {
-    const workshop = await getFeatureFlag(
-      'featureFlagCursorWorkshopSale',
-      'workshop',
+    const workshops = await Promise.all(
+      LIVE_WORKSHOP_SALE_FLAGS.map((flag) => getFeatureFlag(flag, 'workshop')),
     )
-    const parsedWorkshop = LiveWorkshopSchema.parse(workshop)
+    const workshop = workshops
+      .map((workshop) => LiveWorkshopSchema.safeParse(workshop))
+      .find((parsedWorkshop) => parsedWorkshop.success)?.data
 
-    if (!parsedWorkshop) {
+    if (!workshop) {
       console.warn('No workshop found')
       return ''
     }
 
-    const product = await stripe.products.retrieve(parsedWorkshop.productId)
+    const product = await stripe.products.retrieve(workshop.productId)
     return product.name || ''
   } catch (error) {
     console.error(`Error retrieving specific product name: ${error}`)

--- a/src/inngest/utils/stripe-webhook-utils.ts
+++ b/src/inngest/utils/stripe-webhook-utils.ts
@@ -6,14 +6,12 @@ import {
   shouldProcessCheckoutSession,
   isLifetimePurchase,
 } from '@/inngest/utils/lifetime-helpers'
-import {
-  containsSpecificProduct,
-  getSpecificProductName,
-} from '@/inngest/utils/specific-product-helpers'
+import {containsSpecificProduct} from '@/inngest/utils/specific-product-helpers'
 import {LIFETIME_PURCHASE_EVENT} from '@/inngest/events/lifetime-purchase'
 import {SPECIFIC_PRODUCT_PURCHASE_EVENT} from '@/inngest/events/specific-product-purchase'
 import {getFeatureFlag} from '@/lib/feature-flags'
 import {LiveWorkshopSchema} from '@/types'
+import {LIVE_WORKSHOP_SALE_FLAGS} from '@/lib/live-workshop-flags'
 import {z} from 'zod'
 const LIFETIME_PRICE_ID = process.env.STRIPE_LIFETIME_MEMBERSHIP_PRICE_ID
 
@@ -40,13 +38,6 @@ export const handleSpecificProductPurchase = async (
   const customerId = getCustomerId(checkoutSession.customer, checkoutSession)
   const priceId = checkoutSession.line_items?.data[0]?.price?.id || ''
 
-  // 1. Define all workshop flag keys in an array for scalability.
-  const workshopFlagKeys = [
-    'featureFlagCursorWorkshopSale',
-    'featureFlagClaudeCodeWorkshopSale',
-    // ✨ To add another workshop, just add its feature flag key here!
-  ]
-
   // Get the purchased product ID from the checkout session.
   const purchasedProduct = checkoutSession.line_items?.data[0]?.price?.product
   let purchasedProductId: string | undefined
@@ -61,14 +52,14 @@ export const handleSpecificProductPurchase = async (
     return
   }
 
-  // 2. Fetch all feature flags concurrently.
+  // Fetch all configured workshop flags concurrently.
   const workshopFlags = await Promise.all(
-    workshopFlagKeys.map((key) => getFeatureFlag(key, 'workshop')),
+    LIVE_WORKSHOP_SALE_FLAGS.map((flag) => getFeatureFlag(flag, 'workshop')),
   )
 
   let selectedWorkshop: z.infer<typeof LiveWorkshopSchema> | null = null
 
-  // 3. Iterate to find the first valid and matching workshop.
+  // Find the first valid workshop whose product matches the purchase.
   for (const flagData of workshopFlags) {
     const parsedWorkshop = LiveWorkshopSchema.safeParse(flagData)
     // Check if the workshop data is valid AND its product ID matches the purchased one.

--- a/src/lib/__tests__/live-workshop-flags.test.ts
+++ b/src/lib/__tests__/live-workshop-flags.test.ts
@@ -1,0 +1,12 @@
+import {LIVE_WORKSHOP_SALE_FLAGS} from '@/lib/live-workshop-flags'
+
+describe('LIVE_WORKSHOP_SALE_FLAGS', () => {
+  it('includes every workshop sale flag eligible for purchase emails', () => {
+    expect(LIVE_WORKSHOP_SALE_FLAGS).toEqual([
+      'featureFlagCursorWorkshopSale',
+      'featureFlagClaudeCodeWorkshopSale',
+      'featureFlagCodexWorkshopSale',
+      'featureFlagSoftwareFactoryWorkshopSale',
+    ])
+  })
+})

--- a/src/lib/live-workshop-flags.ts
+++ b/src/lib/live-workshop-flags.ts
@@ -1,0 +1,12 @@
+/**
+ * Feature flags whose Stripe products receive the live-workshop purchase email.
+ *
+ * Add a workshop sale flag here when its Edge Config `workshop` value should be
+ * recognized by the post-checkout receipt flow.
+ */
+export const LIVE_WORKSHOP_SALE_FLAGS = [
+  'featureFlagCursorWorkshopSale',
+  'featureFlagClaudeCodeWorkshopSale',
+  'featureFlagCodexWorkshopSale',
+  'featureFlagSoftwareFactoryWorkshopSale',
+] as const


### PR DESCRIPTION
## Summary

Centralizes the live-workshop sale flags that participate in the post-checkout receipt email flow.

- Adds Codex and Software Factory workshop sale flags to the registry.
- Uses the registry for purchase eligibility, product matching, and the legacy product-name helper.
- Removes the duplicated flag lists that caused new workshops to be skipped.

## Why

The receipt pipeline recognized only Cursor and Claude Code workshop products. Products configured through the new Codex and Software Factory Edge Config flags never emitted the purchase-email event.

## Validation

- `node_modules/.bin/eslint` on the changed files
- `node_modules/.bin/jest --runInBand src/lib/__tests__/live-workshop-flags.test.ts`
- `git diff --check`

`tsc --noEmit` is blocked in this checkout by missing `@sanity/client` dependencies outside this change.